### PR TITLE
ESLint rule’s severity(엄격도) 일관성 있게 수정

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -27,7 +27,7 @@
   },
   "plugins": ["import", "prettier", "react", "@typescript-eslint"],
   "rules": {
-    "@typescript-eslint/explicit-module-boundary-types": 0,
+    "@typescript-eslint/explicit-module-boundary-types": "off",
     "@typescript-eslint/explicit-function-return-type": "warn",
     "@typescript-eslint/consistent-type-imports": [
       "warn",
@@ -37,17 +37,17 @@
         "fixStyle": "separate-type-imports"
       }
     ],
-    "jsx-a11y/no-noninteractive-element-interactions": 0,
-    "linebreak-style": 0,
-    "no-shadow": 0,
-    "no-use-before-define": 0,
-    "import/extensions": 0,
-    "import/no-extraneous-dependencies": 0,
-    "import/no-unresolved": 0,
-    "import/prefer-default-export": 0,
+    "jsx-a11y/no-noninteractive-element-interactions": "off",
+    "linebreak-style": "off",
+    "no-shadow": "off",
+    "no-use-before-define": "off",
+    "import/extensions": "off",
+    "import/no-extraneous-dependencies": "off",
+    "import/no-unresolved": "off",
+    "import/prefer-default-export": "off",
     "react/jsx-props-no-spreading": ["warn"],
-    "react/react-in-jsx-scope": 0,
-    "react/prop-types": 0,
+    "react/react-in-jsx-scope": "off",
+    "react/prop-types": "off",
     "react/jsx-filename-extension": [
       2,
       { "extensions": [".js", ".jsx", ".ts", ".tsx"] }


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #9 

<br />

## 🗒 작업 목록

- [x] ESLint rule’s severity의 rule ID를 문자열로 변경

<br />

## 🧐 PR Point

- ESLint rule’s severity에 숫자와 문자열이 혼합된 rule ID 일관성있게 수정하여 적용된 규칙의 엄격도를 확인하기 쉽게 한다.

<br />

## 💥 Trouble Shooting
- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크

- 내용을 입력해주세요.

<br />

## 📚 참고

- [Configure Rules](https://eslint.org/docs/latest/use/configure/rules)
- [ESLint 설정 살펴보기](https://velog.io/@kyusung/eslint-config-2)

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다. 
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
