### PR TITLE
ESLint parserOptions에서 tsconfigRootDir 추가

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,7 +23,8 @@
     },
     "ecmaVersion": "latest",
     "sourceType": "module",
-    "project": "./tsconfig.json"
+    "project": "./tsconfig.json",
+    "tsconfigRootDir": "ADD.FE"
   },
   "plugins": ["import", "prettier", "react", "@typescript-eslint"],
   "rules": {


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #21 

<br />

## 🗒 작업 목록

- [x] ESLint parserOptions - tsconfigRootDir 추가

<br />

## 🧐 PR Point

- root가 ADD.FE가 아닐 경우, Parsing error 발생
- parserOptions 내에 tsconfigRootDir를 추가해 절대 경로를 찾도록 해 줌으로써 문제 해결

<br />

## 💥 Trouble Shooting
- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크

- 내용을 입력해주세요.

<br />

## 📚 참고

- https://velog.io/@wanzekim/Nest.js-Parsing-error-Cannot-read-file-...tsconfig.json

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다. 
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
