### PR TITLE
next/image 컴포넌트 생성

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,11 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  images: {
+    domains: [
+      "127.0.0.1",
+      "dummyimage.com", // 목데이터의 이미지 URL 도메인, 추후 삭제
+    ]
+  },
   reactStrictMode: true,
   experimental: {
     fontLoaders: [

--- a/src/components/common/NextImage.tsx
+++ b/src/components/common/NextImage.tsx
@@ -1,0 +1,52 @@
+import styled from '@emotion/styled';
+import Image from 'next/image';
+
+interface NextImageStyleProps {
+  aspectRatio: number;
+}
+
+interface NextImageProps extends NextImageStyleProps {
+  src: string;
+  alt: string;
+  width: number;
+  height: number;
+  quality?: number;
+}
+
+const NextImage = ({
+  src,
+  alt,
+  width,
+  height,
+  quality,
+  aspectRatio,
+}: NextImageProps) => {
+  return (
+    <ImageContainer aspectRatio={aspectRatio}>
+      <StyledImage
+        src={src}
+        alt={alt}
+        width={width}
+        height={height}
+        quality={quality ?? 100}
+        priority
+      />
+    </ImageContainer>
+  );
+};
+
+export default NextImage;
+
+const ImageContainer = styled.div<NextImageStyleProps>`
+  overflow: hidden;
+  display: flex;
+  place-content: center;
+  width: 100%;
+  aspect-ratio: ${({ aspectRatio }) => aspectRatio};
+`;
+
+const StyledImage = styled(Image)`
+  width: 100%;
+  height: auto;
+  object-fit: cover;
+`;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 import Head from 'next/head';
 import type { NextPage } from 'next';
+import NextImage from 'components/common/NextImage';
 import { DIARY_LIST_MOCK_DATA } from 'mocks/DiaryList';
 
 const Home: NextPage = () => {
@@ -30,6 +31,15 @@ const Home: NextPage = () => {
               <li key={`diary-list-${id}`}>
                 <h2>{title}</h2>
                 <p>{content}</p>
+                {imgUrl?.length > 0 && (
+                  <NextImage
+                    src={imgUrl}
+                    alt={title}
+                    width={320}
+                    height={160}
+                    aspectRatio={2 / 1}
+                  />
+                )}
               </li>
             );
           })}


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #25 

<br />

## 🗒 작업 목록

- [x] images domain 설정
- [x] NextImage 컴포넌트 생성 및 적용

<br />

## 🧐 PR Point

- next/image Image 컴포넌트 사용시 설정해야하는 기본 속성들과 스타일을 쉽게 설정하기 위해 NextImage 컴포넌트 생성

<br />

## 💥 Trouble Shooting
- 일기 이미지 업로드 API를 이용하여 생성된 이미지 URL의 도메인을 설정해도 에러 발생
  ![image](https://user-images.githubusercontent.com/85009583/220684578-a2085c9e-44de-425c-909e-d96cf585e01b.png)
- images 설정을 최상단에 하지 않으면 인식을 제대로 못하는 문제가 존재
⇒ 도메인 설정을 최상단에 작성하여 문제 해결

```
const nextConfig = {
  images: {
    domains: [
      "127.0.0.1",
      "dummyimage.com", // 목데이터의 이미지 URL 도메인
    ]
  },
// 다른 설정들...
};
```

<br />

## 📸 스크린샷 / 피그마 링크

- 내용을 입력해주세요.

<br />

## 📚 참고

- [next/image](https://nextjs.org/docs/api-reference/next/image)
- [Image Component and Image Optimization](https://nextjs.org/docs/basic-features/image-optimization)
- [Next.js에서 Next/image에서 외부 이미지를 못가져오는 문제(도메인 설정하기, loader 적용하기)](https://velog.io/@hhhminme/Next.js%EC%97%90%EC%84%9C-Nextimage%EC%97%90%EC%84%9C-%EC%99%B8%EB%B6%80-%EC%9D%B4%EB%AF%B8%EC%A7%80%EB%A5%BC-%EB%AA%BB%EA%B0%80%EC%A0%B8%EC%98%A4%EB%8A%94-%EB%AC%B8%EC%A0%9C%EB%8F%84%EB%A9%94%EC%9D%B8-%EC%84%A4%EC%A0%95%ED%95%98%EA%B8%B0-loader-%EC%A0%81%EC%9A%A9%ED%95%98%EA%B8%B0)
- [next/image Un-configured Host](https://nextjs.org/docs/messages/next-image-unconfigured-host)

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다. 
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
