### PR TITLE
ESLint rule 수정

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -29,7 +29,7 @@
   "plugins": ["import", "prettier", "react", "@typescript-eslint"],
   "rules": {
     "@typescript-eslint/explicit-module-boundary-types": "off",
-    "@typescript-eslint/explicit-function-return-type": "warn",
+    "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/consistent-type-imports": [
       "warn",
       {
@@ -46,7 +46,7 @@
     "import/no-extraneous-dependencies": "off",
     "import/no-unresolved": "off",
     "import/prefer-default-export": "off",
-    "react/jsx-props-no-spreading": ["warn"],
+    "react/jsx-props-no-spreading": "off",
     "react/react-in-jsx-scope": "off",
     "react/prop-types": "off",
     "react/jsx-filename-extension": [


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #28 

<br />

## 🗒 작업 목록

- [x] ESLint rule 수정
  - "@typescript-eslint/explicit-function-return-type" : off 로 변경
  - "react/jsx-props-no-spreading" : off 로 변경

<br />

## 🧐 PR Point

- 스프레드 문법은 자주 사용하는 방식이므로 ESLint 설정을 off로 변경
- 함수 리턴값의 타입을 지정하는 레퍼런스를 찾아보았으나 대부분 ESLint 설정을 off로 두고 개발하는 경우가 많은 것으로 파악하여 off로 변경
  - 잘못된 타입 지정으로 에러가 발생할 확률이 더 높을 것 같다는 개인적인 우려
  - 조금 더 내용을 찾아보고 지정하는 것이 프로덕트의 안정성을 훨씬 높인다면 추후에 적용할 예정

<br />

## 💥 Trouble Shooting
- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크

- 내용을 입력해주세요.

<br />

## 📚 참고

- [explicit-function-return-type](https://typescript-eslint.io/rules/explicit-function-return-type/)
- [Disallow JSX prop spreading (react/jsx-props-no-spreading)](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-props-no-spreading.md)

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다. 
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
