### PR TITLE
getLayout을 통해 페이지 별 Navbar 적용

### DIFF
--- a/src/components/layouts/Navbar.tsx
+++ b/src/components/layouts/Navbar.tsx
@@ -62,6 +62,7 @@ const Navigation = styled.nav`
   bottom: 0;
   left: 0;
   border-top: 1px solid ${({ theme }) => theme.colors.gray_eee};
+  background-color: ${({ theme }) => theme.colors.white};
 `;
 
 const NavigationList = styled.ul`

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,16 +1,25 @@
 import { Global, ThemeProvider } from '@emotion/react';
+import type { NextPage } from 'next';
 import type { AppProps } from 'next/app';
-import Layout from 'components/layouts/Layout';
+import type { ReactElement, ReactNode } from 'react';
 import GlobalStyle from 'styles/GlobalStyle';
 import theme from 'styles/theme';
 
-export default function App({ Component, pageProps }: AppProps) {
+export type NextPageWithLayout = NextPage & {
+  getLayout?: (page: ReactElement) => ReactNode;
+};
+
+type AppPropsWithLayout = AppProps & {
+  Component: NextPageWithLayout;
+};
+
+export default function App({ Component, pageProps }: AppPropsWithLayout) {
+  const getLayout = Component.getLayout ?? ((page) => page);
+
   return (
     <ThemeProvider theme={theme}>
       <Global styles={GlobalStyle} />
-      <Layout>
-        <Component {...pageProps} />
-      </Layout>
+      {getLayout(<Component {...pageProps} />)}
     </ThemeProvider>
   );
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,11 +1,13 @@
 import styled from '@emotion/styled';
 import Head from 'next/head';
 import Link from 'next/link';
-import type { NextPage } from 'next';
 import NextImage from 'components/common/NextImage';
+import type { NextPageWithLayout } from './_app';
+import type { ReactElement } from 'react';
 import DiaryList from 'components/diary/DiaryList';
+import Layout from 'components/layouts/Layout';
 
-const Home: NextPage = () => {
+const Home: NextPageWithLayout = () => {
   return (
     <>
       <Head>
@@ -26,6 +28,10 @@ const Home: NextPage = () => {
       <DiaryList />
     </>
   );
+};
+
+Home.getLayout = function getLayout(page: ReactElement) {
+  return <Layout>{page}</Layout>;
 };
 
 export default Home;


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #38 

<br />

## 🗒 작업 목록

- [x] getLayout 설정 및 적용
- [x] 누락된 Navbar 배경색 적용

<br />

## 🧐 PR Point

- getLayout을 적용하여 페이지 별 다른 레이아웃을 보여준다.
- Navbar가 필요한 페이지가 있고, 그렇지 않은 페이지가 존재
- Navbar 컴포넌트를 필요한 페이지에 바로 적용할 수 있으나, getLayout을 이용하면 레이아웃 관련 코드와 다른 코드들이 분리되어, 페이지 별 레아이웃 이 어떻게 다른지 확인하기 쉽다는 장점이 생긴다.

<br />

## 💥 Trouble Shooting
- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크

- #37 이 머지 전인 상태의 스크린 샷입니다.

![image](https://user-images.githubusercontent.com/85009583/223418979-28b6db99-d383-45ff-aa44-337fce8636d9.png)


<br />

## 📚 참고

- [Layouts](https://nextjs.org/docs/basic-features/layouts)
- [Unable to use persisted layouts following the official Next documentation](https://github.com/auth0/nextjs-auth0/issues/597)
- [[NextJs] getLayout 적용하기](https://velog.io/@sssssssssy/getLayout)

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다. 
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
