### PR TITLE
ESLint parserOptions tsconfigRootDir 삭제

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,8 +23,7 @@
     },
     "ecmaVersion": "latest",
     "sourceType": "module",
-    "project": "./tsconfig.json",
-    "tsconfigRootDir": "ADD.FE"
+    "project": "./tsconfig.json"
   },
   "plugins": ["import", "prettier", "react", "@typescript-eslint"],
   "rules": {


### PR DESCRIPTION
## 🔗 연관된 이슈

- #21 

<br />

## 🗒 작업 목록

- [x] ESLint parserOptions - tsconfigRootDir 삭제

<br />

## 🧐 PR Point

- ADD.FE가 root일 때, Parsing error 발생
- root가 ADD.FE가 아닐 경우, tsconfigRootDir 추가시켜야 할 것으로 보임!

<br />

## 💥 Trouble Shooting
- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크

- 내용을 입력해주세요.

<br />

## 📚 참고

- 참고한 내용 또는 링크를 입력해주세요.

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다. 
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
