### PR TITLE
Font style 추가

### DIFF
--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -49,25 +49,25 @@ const patternStyles = ({ pattern }: ButtonProps) => css`
 const sizeStyles = ({ size, theme }: ButtonProps) => css`
   ${size === 'sm' &&
   css`
-    ${theme?.fonts.button}
+    ${theme?.fonts.button_01}
     padding: 8px 10px;
   `}
 
   ${size === 'md' &&
   css`
-    ${theme?.fonts.button}
+    ${theme?.fonts.button_01}
     padding: 12px 20px;
   `}
 
   ${size === 'lg' &&
   css`
-    ${theme?.fonts.button_lg}
+    ${theme?.fonts.button_02}
     padding: 17px 32px;
   `}
 
   ${size === 'xl' &&
   css`
-    ${theme?.fonts.button_xl}
+    ${theme?.fonts.button_03}
     padding: 20px 48px;
   `}
 `;

--- a/src/components/diary/Diary.tsx
+++ b/src/components/diary/Diary.tsx
@@ -98,12 +98,12 @@ const ContentContainer = styled.div`
 `;
 
 const Title = styled.h3`
-  ${({ theme }) => theme.fonts.diary_title}
+  ${({ theme }) => theme.fonts.headline_03}
 `;
 
 const ContentLink = styled(Link)`
   ${EllipsisStyle}
-  ${({ theme }) => theme.fonts.diary_content}
+  ${({ theme }) => theme.fonts.body_06}
   margin: 4px 0 6px;
   cursor: default;
 `;
@@ -112,7 +112,7 @@ const DateContainer = styled.div`
   display: flex;
   justify-content: space-between;
   margin-top: 12px;
-  ${({ theme }) => theme.fonts.diary_info}
+  ${({ theme }) => theme.fonts.caption_02}
   color: ${({ theme }) => theme.colors.gray_999};
 `;
 
@@ -122,7 +122,7 @@ const IconContainer = styled.div`
   justify-content: space-between;
   padding: 10px 20px;
   border-top: 1px solid ${({ theme }) => theme.colors.gray_eee};
-  ${({ theme }) => theme.fonts.diary_icon};
+  ${({ theme }) => theme.fonts.caption_01};
 `;
 
 const IconInnerContainer = styled.div`

--- a/src/components/diary/DiaryComment.tsx
+++ b/src/components/diary/DiaryComment.tsx
@@ -89,17 +89,12 @@ const ProfileImageBox = styled.div`
 const UsernameSpan = styled.span`
   margin: 0 6px 0 8px;
   color: ${({ theme }) => theme.colors.black};
-  font-size: 14px;
-  font-weight: 400;
-  line-height: 100%;
+  ${({ theme }) => theme.fonts.body_08};
 `;
 
 const CreatedAtSpan = styled.span`
   color: ${({ theme }) => theme.colors.gray_999};
-  font-size: 12px;
-  font-weight: 400;
-  line-height: 100%;
-  letter-spacing: -0.02em;
+  ${({ theme }) => theme.fonts.caption_02};
   text-align: right;
 `;
 
@@ -115,10 +110,7 @@ const StyledMoreIcon = styled(MoreIcon)`
 
 const CommentContent = styled.p`
   color: ${({ theme }) => theme.colors.black};
-  font-weight: 400;
-  font-size: 12px;
-  line-height: 140%;
-  letter-spacing: -0.02em;
+  ${({ theme }) => theme.fonts.body_09};
   word-break: keep-all;
   white-space: pre-wrap;
 `;

--- a/src/components/diary/DiaryCommentInput.tsx
+++ b/src/components/diary/DiaryCommentInput.tsx
@@ -96,18 +96,12 @@ const CommentTextarea = styled.textarea`
   border: 0;
   background-color: transparent;
   color: ${({ theme }) => theme.colors.black};
-  font-size: 14px;
-  font-weight: 400;
-  line-height: 140%;
-  letter-spacing: -0.02em;
+  ${({ theme }) => theme.fonts.body_07};
   resize: none;
 
   &::placeholder {
     color: ${({ theme }) => theme.colors.gray_999};
-    font-size: 14px;
-    font-weight: 400;
-    line-height: 140%;
-    letter-spacing: -0.02em;
+    ${({ theme }) => theme.fonts.body_07};
   }
 
   &:focus {

--- a/src/components/diary/DiaryComments.tsx
+++ b/src/components/diary/DiaryComments.tsx
@@ -55,9 +55,6 @@ const CommentTitle = styled.h3`
 const NoCommentTitle = styled.h3`
   margin: 40px 0 20px;
   color: ${({ theme }) => theme.colors.gray_999};
-  font-size: 12px;
-  font-weight: 400;
-  line-height: 140%;
+  ${({ theme }) => theme.fonts.body_09};
   text-align: center;
-  letter-spacing: -0.02em;
 `;

--- a/src/components/diary/DiaryDetail.tsx
+++ b/src/components/diary/DiaryDetail.tsx
@@ -118,22 +118,17 @@ const AuthorImageContainer = styled.div`
 
 const UsernameText = styled.span`
   color: ${({ theme }) => theme.colors.black};
-  font-size: 16px;
-  font-weight: 400;
-  line-height: 100%;
+  ${({ theme }) => theme.fonts.body_05};
 `;
 
 const CreatedAtText = styled.span`
   color: ${({ theme }) => theme.colors.gray_999};
-  font-size: 14px;
-  font-weight: 400;
-  line-height: 100%;
-  letter-spacing: -0.02em;
+  ${({ theme }) => theme.fonts.body_08};
   text-align: right;
 `;
 
 const Title = styled.h3`
-  ${({ theme }) => theme.fonts.diary_title}
+  ${({ theme }) => theme.fonts.headline_03}
 `;
 
 const ImageContainer = styled.div`
@@ -141,13 +136,13 @@ const ImageContainer = styled.div`
 `;
 
 const Content = styled.p`
-  ${({ theme }) => theme.fonts.diary_content}
+  ${({ theme }) => theme.fonts.body_06}
   margin-top: 4px;
 `;
 
 const TimeContainer = styled.div`
   margin-top: 12px;
-  ${({ theme }) => theme.fonts.diary_info}
+  ${({ theme }) => theme.fonts.caption_02}
   color: ${({ theme }) => theme.colors.gray_999};
 `;
 
@@ -157,7 +152,7 @@ const IconContainer = styled.div`
   justify-content: space-between;
   padding: 10px 20px;
   border-top: 1px solid ${({ theme }) => theme.colors.gray_eee};
-  ${({ theme }) => theme.fonts.diary_icon};
+  ${({ theme }) => theme.fonts.caption_01};
 `;
 
 const IconInnerContainer = styled.div`

--- a/src/components/layouts/header/Header.tsx
+++ b/src/components/layouts/header/Header.tsx
@@ -11,7 +11,7 @@ const Header = ({ children }: HeaderProps) => {
 
 export default Header;
 
-const HeaderLayout = styled.header`
+const HeaderLayout = styled.body_02`
   display: flex;
   align-items: center;
   position: fixed;

--- a/src/components/layouts/header/HeaderRight.tsx
+++ b/src/components/layouts/header/HeaderRight.tsx
@@ -37,7 +37,7 @@ const HeaderRightLayout = styled.div`
 
 const TextButton = styled.button`
   color: ${({ theme }) => theme.colors.gray_ccc};
-  ${({ theme }) => theme.fonts.header_button}
+  ${({ theme }) => theme.fonts.body_05}
 `;
 
 const StyledMoreIcon = styled(MoreIcon)`

--- a/src/components/layouts/header/HeaderTtitle.tsx
+++ b/src/components/layouts/header/HeaderTtitle.tsx
@@ -33,6 +33,6 @@ const Title = styled.strong<HeaderTitleProps>`
           padding: 0 0 0 4px;
         `};
 
-  ${({ theme }) => theme.fonts.header};
+  ${({ theme }) => theme.fonts.body_02};
   font-weight: ${({ isNumber }) => (isNumber ?? false) && 700};
 `;

--- a/src/components/profile/Empty.tsx
+++ b/src/components/profile/Empty.tsx
@@ -29,7 +29,5 @@ const EmptyContainer = styled.div`
 const EmptyParagraph = styled.p`
   margin-top: 12px;
   color: ${({ theme }) => theme.colors.gray_999};
-  font-size: 14px;
-  font-weight: 400;
-  line-height: 1;
+  ${({ theme }) => theme.fonts.body_08};
 `;

--- a/src/containers/diary/DiaryCommentsContainer.tsx
+++ b/src/containers/diary/DiaryCommentsContainer.tsx
@@ -56,7 +56,5 @@ const WriteCommentLabel = styled.label`
 const WriteCommentSpan = styled.span`
   margin-top: 2px;
   color: ${({ theme }) => theme.colors.gray_666};
-  font-size: 12px;
-  font-weight: 500;
-  line-height: 100%;
+  ${({ theme }) => theme.fonts.button_01};
 `;

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -106,20 +106,14 @@ const UserProfileImage = styled.div`
 
 const UserName = styled.h2`
   margin: 8px 0 6px;
-  font-size: 24px;
-  font-weight: 700;
-  letter-spacing: -0.02em;
-  line-height: 1.4;
+  ${({ theme }) => theme.fonts.headline_01};
 `;
 
 const ProfileEditLink = styled(Link)`
   padding: 12px 20px;
   border-radius: 120px;
   background: #f4f4f4;
-  font-size: 12px;
-  font-weight: 500;
-  line-height: 1;
-  letter-spacing: -0.02em;
+  ${({ theme }) => theme.fonts.caption_01};
 `;
 
 const TabButton = styled.button<{ active: boolean }>`

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -117,7 +117,5 @@ const ProfileEditLink = styled(Link)`
 `;
 
 const TabButton = styled.button<{ active: boolean }>`
-  font-size: 16px;
-  font-weight: 700;
-  line-height: 140%;
+  ${({ theme }) => theme.fonts.headline_04};
 `;

--- a/src/styles/GlobalStyle.ts
+++ b/src/styles/GlobalStyle.ts
@@ -12,6 +12,8 @@ const GlobalStyle = css`
   body {
     max-width: 100vw;
     overflow-x: hidden;
+    /* 폰트 사이즈 10px = 1rem 으로 설정*/
+    font-size: 62.5%;
   }
 
   a {

--- a/src/styles/GlobalStyle.ts
+++ b/src/styles/GlobalStyle.ts
@@ -12,8 +12,16 @@ const GlobalStyle = css`
   body {
     max-width: 100vw;
     overflow-x: hidden;
-    /* 폰트 사이즈 10px = 1rem 으로 설정*/
+  }
+
+  html {
+    /* 10px = 1rem */
     font-size: 62.5%;
+  }
+
+  body {
+    /* 기본 폰트 사이즈 설정: 16px */
+    font-size: 1.6rem;
   }
 
   a {

--- a/src/styles/emotion.d.ts
+++ b/src/styles/emotion.d.ts
@@ -27,6 +27,8 @@ declare module '@emotion/react' {
       headline_01: SerializedStyles;
       headline_02: SerializedStyles;
       headline_03: SerializedStyles;
+      headline_04: SerializedStyles;
+      headline_05: SerializedStyles;
       body_01: SerializedStyles;
       body_02: SerializedStyles;
       body_03: SerializedStyles;

--- a/src/styles/emotion.d.ts
+++ b/src/styles/emotion.d.ts
@@ -24,16 +24,24 @@ declare module '@emotion/react' {
       pink: string;
     };
     fonts: {
-      diary_title: SerializedStyles;
-      diary_content: SerializedStyles;
-      diary_info: SerializedStyles;
-      diary_icon: SerializedStyles;
+      headline_01: SerializedStyles;
+      headline_02: SerializedStyles;
+      headline_03: SerializedStyles;
+      body_01: SerializedStyles;
+      body_02: SerializedStyles;
+      body_03: SerializedStyles;
+      body_04: SerializedStyles;
+      body_05: SerializedStyles;
+      body_06: SerializedStyles;
+      body_07: SerializedStyles;
+      body_08: SerializedStyles;
+      body_09: SerializedStyles;
+      caption_01: SerializedStyles;
+      caption_02: SerializedStyles;
       navigation: SerializedStyles;
-      button: SerializedStyles;
-      button_lg: SerializedStyles;
-      button_xl: SerializedStyles;
-      header: SerializedStyles;
-      header_button: SerializedStyles;
+      button_01: SerializedStyles;
+      button_02: SerializedStyles;
+      button_03: SerializedStyles;
     };
   }
 }

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -81,7 +81,7 @@ const fontStyle = ({
     font-family: ${fontFamily};
     font-size: ${size}rem;
     font-weight: ${weight};
-    line-height: ${lineHeight}%;
+    line-height: ${lineHeight};
     letter-spacing: ${letterSpacing}em;
   `;
 };
@@ -93,68 +93,68 @@ const theme: Theme = {
       fontFamily: montserrat.style.fontFamily,
       size: 2,
       weight: 700,
-      lineHeight: 140,
+      lineHeight: 1.4,
     }),
     diary_content: fontStyle({
       fontFamily: pretendard.style.fontFamily,
       size: 1.4,
       weight: 400,
-      lineHeight: 160,
+      lineHeight: 1.6,
     }),
     diary_info: fontStyle({
       fontFamily: pretendard.style.fontFamily,
       size: 1.2,
       weight: 400,
-      lineHeight: 100,
+      lineHeight: 1,
       letterSpacing: -0.02,
     }),
     diary_icon: fontStyle({
       fontFamily: pretendard.style.fontFamily,
       size: 1.2,
       weight: 500,
-      lineHeight: 100,
+      lineHeight: 1,
       letterSpacing: -0.02,
     }),
     navigation: fontStyle({
       fontFamily: pretendard.style.fontFamily,
       size: 1.2,
       weight: 500,
-      lineHeight: 100,
+      lineHeight: 1,
       letterSpacing: -0.04,
     }),
     button: fontStyle({
       fontFamily: pretendard.style.fontFamily,
       size: 1.2,
       weight: 500,
-      lineHeight: 100,
+      lineHeight: 1,
       letterSpacing: -0.02,
     }),
     button_lg: fontStyle({
       fontFamily: pretendard.style.fontFamily,
       size: 1.4,
       weight: 700,
-      lineHeight: 100,
+      lineHeight: 1,
       letterSpacing: -0.02,
     }),
     button_xl: fontStyle({
       fontFamily: pretendard.style.fontFamily,
       size: 1.6,
       weight: 700,
-      lineHeight: 100,
+      lineHeight: 1,
       letterSpacing: -0.02,
     }),
     header: fontStyle({
       fontFamily: pretendard.style.fontFamily,
       size: 18,
       weight: 500,
-      lineHeight: 100,
+      lineHeight: 1,
       letterSpacing: -0.02,
     }),
     header_button: fontStyle({
       fontFamily: pretendard.style.fontFamily,
       size: 16,
       weight: 500,
-      lineHeight: 100,
+      lineHeight: 1,
       letterSpacing: -0.02,
     }),
   },

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -79,7 +79,7 @@ const fontStyle = ({
 }: Font): SerializedStyles => {
   return css`
     font-family: ${fontFamily};
-    font-size: ${size}px;
+    font-size: ${size}rem;
     font-weight: ${weight};
     line-height: ${lineHeight}%;
     letter-spacing: ${letterSpacing}em;
@@ -91,54 +91,54 @@ const theme: Theme = {
   fonts: {
     diary_title: fontStyle({
       fontFamily: montserrat.style.fontFamily,
-      size: 20,
+      size: 2,
       weight: 700,
       lineHeight: 140,
     }),
     diary_content: fontStyle({
       fontFamily: pretendard.style.fontFamily,
-      size: 14,
+      size: 1.4,
       weight: 400,
       lineHeight: 160,
     }),
     diary_info: fontStyle({
       fontFamily: pretendard.style.fontFamily,
-      size: 12,
+      size: 1.2,
       weight: 400,
       lineHeight: 100,
       letterSpacing: -0.02,
     }),
     diary_icon: fontStyle({
       fontFamily: pretendard.style.fontFamily,
-      size: 12,
+      size: 1.2,
       weight: 500,
       lineHeight: 100,
       letterSpacing: -0.02,
     }),
     navigation: fontStyle({
       fontFamily: pretendard.style.fontFamily,
-      size: 12,
+      size: 1.2,
       weight: 500,
       lineHeight: 100,
       letterSpacing: -0.04,
     }),
     button: fontStyle({
       fontFamily: pretendard.style.fontFamily,
-      size: 12,
+      size: 1.2,
       weight: 500,
       lineHeight: 100,
       letterSpacing: -0.02,
     }),
     button_lg: fontStyle({
       fontFamily: pretendard.style.fontFamily,
-      size: 14,
+      size: 1.4,
       weight: 700,
       lineHeight: 100,
       letterSpacing: -0.02,
     }),
     button_xl: fontStyle({
       fontFamily: pretendard.style.fontFamily,
-      size: 16,
+      size: 1.6,
       weight: 700,
       lineHeight: 100,
       letterSpacing: -0.02,

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -89,29 +89,99 @@ const fontStyle = ({
 const theme: Theme = {
   colors,
   fonts: {
-    diary_title: fontStyle({
+    headline_01: fontStyle({
+      fontFamily: pretendard.style.fontFamily,
+      size: 2.4,
+      weight: 700,
+      lineHeight: 1.4,
+      letterSpacing: -0.02,
+    }),
+    headline_02: fontStyle({
+      fontFamily: pretendard.style.fontFamily,
+      size: 2,
+      weight: 700,
+      lineHeight: 1.6,
+      letterSpacing: -0.02,
+    }),
+    headline_03: fontStyle({
       fontFamily: montserrat.style.fontFamily,
       size: 2,
       weight: 700,
       lineHeight: 1.4,
     }),
-    diary_content: fontStyle({
+    body_01: fontStyle({
+      fontFamily: pretendard.style.fontFamily,
+      size: 2,
+      weight: 400,
+      lineHeight: 1,
+      letterSpacing: -0.02,
+    }),
+    body_02: fontStyle({
+      fontFamily: pretendard.style.fontFamily,
+      size: 1.8,
+      weight: 500,
+      lineHeight: 1,
+      letterSpacing: -0.02,
+    }),
+    body_03: fontStyle({
+      fontFamily: pretendard.style.fontFamily,
+      size: 1.6,
+      weight: 500,
+      lineHeight: 1.6,
+      letterSpacing: -0.02,
+    }),
+    body_04: fontStyle({
+      fontFamily: pretendard.style.fontFamily,
+      size: 1.6,
+      weight: 400,
+      lineHeight: 1.4,
+      letterSpacing: -0.02,
+    }),
+    body_05: fontStyle({
+      fontFamily: pretendard.style.fontFamily,
+      size: 16,
+      weight: 500,
+      lineHeight: 1,
+      letterSpacing: -0.02,
+    }),
+    body_06: fontStyle({
       fontFamily: pretendard.style.fontFamily,
       size: 1.4,
       weight: 400,
       lineHeight: 1.6,
     }),
-    diary_info: fontStyle({
+    body_07: fontStyle({
       fontFamily: pretendard.style.fontFamily,
-      size: 1.2,
+      size: 1.4,
+      weight: 400,
+      lineHeight: 1.4,
+      letterSpacing: -0.02,
+    }),
+    body_08: fontStyle({
+      fontFamily: pretendard.style.fontFamily,
+      size: 1.4,
       weight: 400,
       lineHeight: 1,
       letterSpacing: -0.02,
     }),
-    diary_icon: fontStyle({
+    body_09: fontStyle({
+      fontFamily: pretendard.style.fontFamily,
+      size: 1.2,
+      weight: 400,
+      lineHeight: 1.4,
+      letterSpacing: -0.02,
+    }),
+    caption_01: fontStyle({
       fontFamily: pretendard.style.fontFamily,
       size: 1.2,
       weight: 500,
+      lineHeight: 1,
+      letterSpacing: -0.02,
+    }),
+    caption_02: fontStyle({
+      fontFamily: pretendard.style.fontFamily,
+      size: 1.2,
+      weight: 400,
       lineHeight: 1,
       letterSpacing: -0.02,
     }),
@@ -122,38 +192,24 @@ const theme: Theme = {
       lineHeight: 1,
       letterSpacing: -0.04,
     }),
-    button: fontStyle({
+    button_01: fontStyle({
       fontFamily: pretendard.style.fontFamily,
       size: 1.2,
       weight: 500,
       lineHeight: 1,
       letterSpacing: -0.02,
     }),
-    button_lg: fontStyle({
+    button_02: fontStyle({
       fontFamily: pretendard.style.fontFamily,
       size: 1.4,
       weight: 700,
       lineHeight: 1,
       letterSpacing: -0.02,
     }),
-    button_xl: fontStyle({
+    button_03: fontStyle({
       fontFamily: pretendard.style.fontFamily,
       size: 1.6,
       weight: 700,
-      lineHeight: 1,
-      letterSpacing: -0.02,
-    }),
-    header: fontStyle({
-      fontFamily: pretendard.style.fontFamily,
-      size: 18,
-      weight: 500,
-      lineHeight: 1,
-      letterSpacing: -0.02,
-    }),
-    header_button: fontStyle({
-      fontFamily: pretendard.style.fontFamily,
-      size: 16,
-      weight: 500,
       lineHeight: 1,
       letterSpacing: -0.02,
     }),

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -109,6 +109,19 @@ const theme: Theme = {
       weight: 700,
       lineHeight: 1.4,
     }),
+    headline_04: fontStyle({
+      fontFamily: pretendard.style.fontFamily,
+      size: 1.6,
+      weight: 700,
+      lineHeight: 1.4,
+      letterSpacing: -0.02,
+    }),
+    headline_05: fontStyle({
+      fontFamily: montserrat.style.fontFamily,
+      size: 1.6,
+      weight: 700,
+      lineHeight: 1,
+    }),
     body_01: fontStyle({
       fontFamily: pretendard.style.fontFamily,
       size: 2,
@@ -140,7 +153,7 @@ const theme: Theme = {
     body_05: fontStyle({
       fontFamily: pretendard.style.fontFamily,
       size: 16,
-      weight: 500,
+      weight: 400,
       lineHeight: 1,
       letterSpacing: -0.02,
     }),


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #56 

<br />

## 🗒 작업 목록

- [x] GlobalStyle에 font-size: 62.5% 적용
  - 10px = 1rem 으로 사용할 수 있게 적용
  - theme의 px 단위 rem으로 변경
- [x] body에 기본 폰트 사이즈 설정
- [x] lineheight 값을 % 값에서 숫자 값으로 변경
- [x] theme font system 수정, 추가 및 적용

<br />

## 🧐 PR Point

- 피그마에 적용된 type scale을 theme font style에 적용

<br />

## 💥 Trouble Shooting
- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크

- [Type scale 피그마 링크](https://www.figma.com/file/4cAfw9zpq7PMwMgFPDC3hF/ADD?node-id=1713-326&t=w5LAjRRZ4QunOuQy-4)

![image](https://user-images.githubusercontent.com/85009583/232778564-6be6e7b8-1482-4728-b248-16b3a9e409c5.png)

<br />

## 📚 참고

- 참고한 내용 또는 링크를 입력해주세요.

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다. 
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
