### PR TITLE
프로필 페이지 > 활동 탭 UI 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,12 +25,15 @@
     "next": "13.1.1",
     "next-auth": "^4.22.1",
     "react": "18.2.0",
+    "react-calendar-heatmap": "^1.9.0",
     "react-dom": "18.2.0",
     "react-hook-form": "^7.43.7",
+    "react-tooltip": "^5.11.1",
     "typescript": "4.9.4"
   },
   "devDependencies": {
     "@next/eslint-plugin-next": "^13.1.1",
+    "@types/react-calendar-heatmap": "^1.6.3",
     "@typescript-eslint/eslint-plugin": "^5.47.1",
     "@typescript-eslint/parser": "^5.47.1",
     "eslint-config-prettier": "^8.5.0",

--- a/src/components/profile/HeatmapCalendar.tsx
+++ b/src/components/profile/HeatmapCalendar.tsx
@@ -1,0 +1,165 @@
+import styled from '@emotion/styled';
+import { useEffect, useRef } from 'react';
+import CalendarHeatmap from 'react-calendar-heatmap';
+import { Tooltip } from 'react-tooltip';
+import 'react-tooltip/dist/react-tooltip.css';
+
+const data = [
+  {
+    date: '2022-04-25',
+    count: 1,
+  },
+  {
+    date: '2023-01-01',
+    count: 1,
+  },
+  {
+    date: '2023-01-11',
+    count: 2,
+  },
+  {
+    date: '2023-02-01',
+    count: 3,
+  },
+  {
+    date: '2023-04-24',
+    count: 3,
+  },
+];
+
+const WEEKDAY = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'];
+
+const HeatmapCalendar = () => {
+  const today = new Date();
+  const oneYearAgo = new Date(today.setFullYear(today.getFullYear() - 1));
+  const boxRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (boxRef !== null) {
+      boxRef.current?.scrollTo({ left: 1600 });
+    }
+  }, []);
+
+  return (
+    <>
+      <HeatMapContainer ref={boxRef}>
+        <WeekdayContainer>
+          {WEEKDAY.map((day) => (
+            <li key={day}>{day}</li>
+          ))}
+        </WeekdayContainer>
+        <Box>
+          <CalendarHeatmap
+            startDate={oneYearAgo}
+            endDate={new Date()}
+            values={data}
+            classForValue={(value: { date: string; count: number }) => {
+              if (value === null) {
+                return 'color-empty';
+              }
+              return `color-github-${value.count}`;
+            }}
+            tooltipDataAttrs={(value: { date: string; count: number }) => {
+              if (value.date === null) return false;
+              return {
+                'data-tooltip-id': 'my-tooltip',
+                'data-tooltip-content': `${value.date} has count: ${value.count}`,
+              };
+            }}
+            onClick={(value: { date: string; count: number }) => {
+              alert(`Clicked on value with count: ${value.count}`);
+            }}
+            gutterSize={1}
+          />
+        </Box>
+      </HeatMapContainer>
+      <Tooltip id="my-tooltip" />
+    </>
+  );
+};
+
+export default HeatmapCalendar;
+
+const HeatMapContainer = styled.div`
+  overflow-x: auto;
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+  display: grid;
+  grid-template-columns: 30px auto;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+`;
+
+const WeekdayContainer = styled.ul`
+  display: grid;
+  grid-template-rows: repeat(7, 27.5px);
+  row-gap: 3px;
+  align-content: end;
+  position: sticky;
+  left: 0;
+  bottom: 0;
+  background-color: #fff;
+
+  & li {
+    font-size: 1.1rem;
+    font-weight: 400;
+    letter-spacing: -0.04em;
+    line-height: 27.5px;
+  }
+`;
+
+const Box = styled.div`
+  width: 1600px;
+
+  & .react-calendar-heatmap text {
+    font-family: pretendard;
+    font-size: 5px;
+  }
+
+  & .react-calendar-heatmap .react-calendar-heatmap-small-text {
+    font-size: 5px;
+  }
+
+  & .react-calendar-heatmap rect {
+    rx: 1px;
+  }
+
+  & .react-calendar-heatmap rect:hover {
+    stroke: #555;
+    stroke-width: 1px;
+  }
+
+  /*
+ * Default color scale
+ */
+
+  & .react-calendar-heatmap .color-empty {
+    fill: #eeeeee;
+  }
+
+  & .react-calendar-heatmap .color-filled {
+    fill: #8cc665;
+  }
+
+  /*
+ * Github color scale
+ */
+
+  & .react-calendar-heatmap .color-github-0 {
+    fill: #eeeeee;
+  }
+  & .react-calendar-heatmap .color-github-1 {
+    fill: #d6e685;
+  }
+  & .react-calendar-heatmap .color-github-2 {
+    fill: #8cc665;
+  }
+  & .react-calendar-heatmap .color-github-3 {
+    fill: #44a340;
+  }
+  & .react-calendar-heatmap .color-github-4 {
+    fill: #1e6823;
+  }
+`;

--- a/src/components/profile/HeatmapCalendar.tsx
+++ b/src/components/profile/HeatmapCalendar.tsx
@@ -47,9 +47,9 @@ export const HeatmapCalendar = () => {
   const boxRef = useRef<HTMLDivElement | null>(null);
 
   const getClassForValue = (value: Value) => {
-    const { count } = value;
-
     if (value === null) return 'color-step-0';
+
+    const { count } = value;
 
     if (count > 0) return 'color-step-1';
     if (count > 2) return 'color-step-2';

--- a/src/components/profile/HeatmapCalendar.tsx
+++ b/src/components/profile/HeatmapCalendar.tsx
@@ -3,6 +3,8 @@ import { useEffect, useRef } from 'react';
 import CalendarHeatmap from 'react-calendar-heatmap';
 import { Tooltip } from 'react-tooltip';
 import 'react-tooltip/dist/react-tooltip.css';
+import { WEEKDAY } from 'constants/common';
+import { HEATMAP_WIDTH } from 'constants/styles';
 import { getLastYearDate } from 'utils';
 
 // TODO: Mock data 제거
@@ -32,9 +34,6 @@ const data = [
     count: 6,
   },
 ];
-
-// TODO: constants/common으로 이동
-const WEEKDAY = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'];
 
 interface Value {
   date: string;
@@ -78,7 +77,7 @@ export const HeatmapCalendar = () => {
 
   useEffect(() => {
     if (boxRef?.current !== null) {
-      boxRef.current.scrollTo({ left: 1520 });
+      boxRef.current.scrollTo({ left: HEATMAP_WIDTH });
     }
   }, []);
 
@@ -147,7 +146,7 @@ const WeekdayList = styled.ul`
 `;
 
 const CalendarContainer = styled.div`
-  width: 1520px;
+  width: ${HEATMAP_WIDTH}px;
   height: 240px;
 
   & .react-calendar-heatmap .react-calendar-heatmap-all-weeks {

--- a/src/components/profile/index.ts
+++ b/src/components/profile/index.ts
@@ -1,3 +1,4 @@
 export * from './ProfileContainer';
 export * from './SelectProfileImage';
 export * from './ProfileImage';
+export * from './HeatmapCalendar';

--- a/src/constants/common/date.ts
+++ b/src/constants/common/date.ts
@@ -1,0 +1,1 @@
+export const WEEKDAY = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'];

--- a/src/constants/common/index.ts
+++ b/src/constants/common/index.ts
@@ -1,1 +1,2 @@
 export * from './page';
+export * from './date';

--- a/src/constants/styles/heatmap.ts
+++ b/src/constants/styles/heatmap.ts
@@ -1,0 +1,1 @@
+export const HEATMAP_WIDTH = 1520;

--- a/src/constants/styles/index.ts
+++ b/src/constants/styles/index.ts
@@ -1,2 +1,3 @@
 export * from './colors';
 export * from './zIndex';
+export * from './heatmap';

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -7,7 +7,7 @@ import * as api from 'api';
 import { FullPageLoading, ObserverTarget, Seo, Tab } from 'components/common';
 import { DiariesContainer } from 'components/diary';
 import EmptyDiary from 'components/diary/EmptyDiary';
-import { ProfileContainer } from 'components/profile';
+import { ProfileContainer, HeatmapCalendar } from 'components/profile';
 import { queryKeys } from 'constants/services';
 import { useIntersectionObserver, useTabIndicator } from 'hooks/common';
 import { useBookmarkedDiaries, useUserDiaries } from 'hooks/services';
@@ -73,6 +73,7 @@ const MyProfile: NextPage = () => {
           );
         })}
       </Tab>
+      {PROFILE_TAB_LIST[activeIndex].id === 'activities' && <HeatmapCalendar />}
       {PROFILE_TAB_LIST[activeIndex].id === 'diaries' && (
         <>
           <DiariesContainer

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,4 +1,4 @@
-export const getLastYearDate = (date: Date) => {
+export const getLastYearDate = (date: Date): Date => {
   const lastYear = date.getFullYear() - 1;
   const monthInLastYear = date.getMonth();
   const dayInLastYear = date.getDate() + 1;

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,0 +1,7 @@
+export const getLastYearDate = (date: Date) => {
+  const lastYear = date.getFullYear() - 1;
+  const monthInLastYear = date.getMonth();
+  const dayInLastYear = date.getDate() + 1;
+
+  return new Date(lastYear, monthInLastYear, dayInLastYear);
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
+export * from './date';
 export * from './ErrorResponseMessage';
 export * from './Formatter';
 export { default as textareaAutosize } from './TextareaAutosize';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1123,6 +1123,18 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
+"@floating-ui/core@^1.2.6":
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.2.6.tgz#d21ace437cc919cdd8f1640302fa8851e65e75c0"
+  integrity sha512-EvYTiXet5XqweYGClEmpu3BoxmsQ4hkj3QaYA6qEnigCWffTP3vNRwBReTdrwDwo7OoJ3wM8Uoe9Uk4n+d4hfg==
+
+"@floating-ui/dom@^1.0.0":
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.2.6.tgz#bcf0c7bada97c20d9d1255b889f35bac838c63fe"
+  integrity sha512-02vxFDuvuVPs22iJICacezYJyf7zwwOCWkPNkWNBr1U0Qt1cKFYzWvxts0AmqcOQGwt/3KJWcWIgtbUU38keyw==
+  dependencies:
+    "@floating-ui/core" "^1.2.6"
+
 "@humanwhocodes/config-array@^0.11.8":
   version "0.11.8"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.11.8.tgz#03595ac2075a4dc0f191cc2131de14fbd7d410b9"
@@ -1469,6 +1481,13 @@
   version "15.7.5"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.5.tgz#5f19d2b85a98e9558036f6a3cacc8819420f05cf"
   integrity sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==
+
+"@types/react-calendar-heatmap@^1.6.3":
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/@types/react-calendar-heatmap/-/react-calendar-heatmap-1.6.3.tgz#9d2ac8f67a5c5d6c7ec2fb215ee372eacdd0508c"
+  integrity sha512-C6hN9Nl0NBqeJEkivwwf/bvWNoPwpwGSNABwYl0yHD20rClSJqRgYoGPKDIn8QqoYHGJsTFJdFbBAZRPlJ/+qg==
+  dependencies:
+    "@types/react" "*"
 
 "@types/react-dom@18.0.10":
   version "18.0.10"
@@ -1842,6 +1861,11 @@ chalk@^4.0.0:
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
+
+classnames@^2.3.0:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.2.tgz#351d813bf0137fcc6a76a16b88208d2560a0d924"
+  integrity sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==
 
 client-only@0.0.1:
   version "0.0.1"
@@ -3178,6 +3202,11 @@ mdn-data@2.0.14:
   resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.14.tgz#7113fc4281917d63ce29b43446f701e68c25ba50"
   integrity sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==
 
+memoize-one@^5.0.0:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.2.1.tgz#8337aa3c4335581839ec01c3d594090cebe8f00e"
+  integrity sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==
+
 merge2@^1.3.0, merge2@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
@@ -3522,7 +3551,7 @@ pretty-format@^3.8.0:
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-3.8.0.tgz#bfbed56d5e9a776645f4b1ff7aa1a3ac4fa3c385"
   integrity sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew==
 
-prop-types@^15.8.1:
+prop-types@^15.6.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -3546,6 +3575,14 @@ queue-microtask@^1.2.2:
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
+react-calendar-heatmap@^1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/react-calendar-heatmap/-/react-calendar-heatmap-1.9.0.tgz#b691310a150d9c52e4ede21ebaa79734fc170d18"
+  integrity sha512-mGed9any6QLOVckxwxC/eeP9s9wE8mTUW/FCE0V27xF9WOaCGuOftGSRH8DSDoSwgzMSVF6uuH7M1xvc+aZ8sg==
+  dependencies:
+    memoize-one "^5.0.0"
+    prop-types "^15.6.2"
+
 react-dom@18.2.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.2.0.tgz#22aaf38708db2674ed9ada224ca4aa708d821e3d"
@@ -3563,6 +3600,14 @@ react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
+react-tooltip@^5.11.1:
+  version "5.11.1"
+  resolved "https://registry.yarnpkg.com/react-tooltip/-/react-tooltip-5.11.1.tgz#75857ffaed1d13e3e35189934e8a373751fc78c0"
+  integrity sha512-+2a/DvmOlPQd5e1f3s32E/+vv4Tv4UmPxZfCyeVr4BeY3SRCEKGHiE36jH+UtqxSuRP9TKviwmhow4gNDRXCMQ==
+  dependencies:
+    "@floating-ui/dom" "^1.0.0"
+    classnames "^2.3.0"
 
 react@18.2.0:
   version "18.2.0"


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #59
- 후속 작업: #203 

<br />

## 🗒 작업 목록

- [x] react-calendar-heatmap, react-tooltip 설치
- [x] 사용자 활동 잔디 UI 구현
  - 현재 날짜 기준 1년의 활동을 나타냄
  - 해당 라이브러리 컬러셋 적용하여 추후 수정 필요
  - Mock data를 적용하여 API 연동 후 제거

<br />

## 🧐 PR Point

- react-calendar-heatmap 라이브러리를 이용하요 활동 탭 UI를 구현합니다.
- react-calendar-heatmap  사용 시 피그마와 차이점 

| 피그마 | 라이브러리 |
|:------:|:-----:|
| ![](https://github.com/a-daily-diary/ADD.FE/assets/85009583/b063b547-eb3b-4c24-b6fe-e2e358cf4563) | ![](https://github.com/a-daily-diary/ADD.FE/assets/85009583/9a21063b-4aca-4424-ba37-676df072eb0a) |
  
- 요일 순서
  - 라이브러리는 일요일부터 시작: 순서 바꿀 수 있으나 텍스트의 순서만 변경되어 날짜와 상이하게 됨
  - 피그마는 월요일부터 시작
- month 텍스트
  - 라이브러리는 텍스트 마지막에 마침표 없음(붙이려고 시도했으나 안 붙음..)
  - 피그마는 텍스트 마지막에 마침표가 있음 

- tooltip은 테스트 겸 설치하여 UI 확인해봄
<img width="347" alt="image" src="https://github.com/a-daily-diary/ADD.FE/assets/85009583/249ec464-99fe-40ee-baef-567c33e52301">

<br />

## 💥 Trouble Shooting
- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크

- 내용을 입력해주세요.

<br />

## 📚 참고

- [react-calendar-heatmap](https://www.npmjs.com/package/react-calendar-heatmap)
- [reaviz](https://www.npmjs.com/package/reaviz) : mui같이 UI를 지원하여 라이브러리 크기가 큼, install 시 여러 라이브러리 설치로 인해 시간이 꽤 많이 걸리는 것을 확인하고 사용하지 않음
- [react-grid-heatmap](https://www.npmjs.com/package/react-grid-heatmap): UI를 커스텀하기 용이하나, 날짜에 맞춰 월을 표기하기 위해서 직접 구현해야함. 따라서, 추가적인 기능 구현이 필요 없는 react-calendar-heatmap 를 사용

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다. 
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
