### PR TITLE
로그인 인증 구현

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server';
+import { getToken } from 'next-auth/jwt';
+import type { NextRequest } from 'next/server';
+
+const secret = process.env.NEXTAUTH_SECRET;
+
+export async function middleware(request: NextRequest) {
+  const session = await getToken({ req: request, secret, raw: true });
+  const { pathname } = request.nextUrl;
+
+  // 로그인 상태에서 로그인, 회원가입 페이지 접근 시 메인 페이지로 리다이렉트
+  if (session != null) {
+    if (pathname.startsWith('/account')) {
+      return NextResponse.redirect(new URL('/', request.url));
+    }
+  }
+}
+
+// matcher에 포함된 특정 경로에서만 middleware 실행
+export const config = {
+  matcher: ['/account/:path*'],
+};

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,23 +1,31 @@
 import { Global, ThemeProvider } from '@emotion/react';
 import Head from 'next/head';
+import { SessionProvider } from 'next-auth/react';
 import type { NextPage } from 'next';
 import type { AppProps } from 'next/app';
+import type { Session } from 'next-auth';
 import type { ReactElement, ReactNode } from 'react';
 import { theme, GlobalStyle } from 'styles';
 
-export type NextPageWithLayout = NextPage & {
+export type NextPageWithLayout<P = Record<string, unknown>> = NextPage<P> & {
   getLayout?: (page: ReactElement) => ReactNode;
 };
 
-type AppPropsWithLayout = AppProps & {
+type AppPropsWithLayout<P> = AppProps<P> & {
   Component: NextPageWithLayout;
+  pageProps: P & {
+    session?: Session;
+  };
 };
 
-export default function App({ Component, pageProps }: AppPropsWithLayout) {
+export default function App({
+  Component,
+  pageProps,
+}: AppPropsWithLayout<{ session: Session }>) {
   const getLayout = Component.getLayout ?? ((page) => page);
 
   return (
-    <>
+    <SessionProvider session={pageProps.session}>
       <Head>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
       </Head>
@@ -25,6 +33,6 @@ export default function App({ Component, pageProps }: AppPropsWithLayout) {
         <Global styles={GlobalStyle} />
         {getLayout(<Component {...pageProps} />)}
       </ThemeProvider>
-    </>
+    </SessionProvider>
   );
 }

--- a/src/pages/account/login.tsx
+++ b/src/pages/account/login.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import { useRouter } from 'next/router';
-import { signIn } from 'next-auth/react';
+import { signIn, useSession } from 'next-auth/react';
 import { useForm } from 'react-hook-form';
 import type { NextPage } from 'next';
 import type { SubmitHandler } from 'react-hook-form';
@@ -15,6 +15,7 @@ import {
 
 const Login: NextPage = () => {
   const router = useRouter();
+  const { status } = useSession();
   const {
     register,
     handleSubmit,
@@ -28,7 +29,7 @@ const Login: NextPage = () => {
       const response = await signIn('credentials', {
         email,
         password,
-        callbackUrl: 'http://localhost:3000', // TODO: 이전 pathname 확인하여 로그인 성공 후 이 전 페이지로 라우팅 처리하기
+        redirect: false,
       });
 
       if (response?.ok === false && response?.error !== null) {
@@ -45,6 +46,9 @@ const Login: NextPage = () => {
       alert('로그인에 실패하였습니다. 관리자에게 문의해주세요.');
     }
   };
+
+  // TODO: 로그인 완료 후 라우팅 되면서 로딩 UI 보여주기 및 라우팅 처리 고도화
+  if (status === 'authenticated') void router.replace('/');
 
   return (
     <Section>

--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -1,0 +1,69 @@
+import NextAuth from 'next-auth/next';
+import CredentialsProvider from 'next-auth/providers/credentials';
+import type { NextAuthOptions } from 'next-auth';
+import type { LoginResponse } from 'types/Login';
+import type { SuccessResponse } from 'types/Response';
+
+export const authOption: NextAuthOptions = {
+  session: {
+    strategy: 'jwt',
+    maxAge: 30 * 24 * 60 * 60, // 30 days
+  },
+  providers: [
+    // email, password를 이용한 인증 방식
+    CredentialsProvider({
+      name: 'Credentials',
+      credentials: {
+        email: { type: 'text' },
+        password: { type: 'password' },
+      },
+      // 로그인 인증
+      async authorize(credentials, _req) {
+        const res = await fetch('http://34.168.182.31:5000/users/login', {
+          method: 'POST',
+          body: JSON.stringify(credentials),
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        });
+
+        const { data } = (await res.json()) as SuccessResponse<LoginResponse>;
+
+        if (res.ok && data.user !== null) {
+          return data.user;
+        }
+        return null;
+      },
+    }),
+  ],
+  callbacks: {
+    async jwt({ token, account, user }) {
+      // Oauth로 로그인할 경우 account 객체가 인수로 전달됨, 추후 수정 필요
+      if (account != null) {
+        // !== 연산자 사용시 사용자 정보가 제대로 넘어오지 않음
+        token.accessToken = account.access_token;
+        // token.id = profile.id; // profile 필요할 경우 추가
+      }
+
+      return await Promise.resolve({ ...token, ...user });
+    },
+    async session({ session, token }) {
+      // jwt의 반환값 token으로 받음
+      const { email, id, imgUrl, isAdmin, username } = token;
+      // session.user에 token의 로그인 한 사용자 정보 전달
+      session.user = { email, id, username, imgUrl, isAdmin };
+
+      return await Promise.resolve(session);
+    },
+    async signIn({ user }) {
+      return await Promise.resolve(true);
+    },
+  },
+  pages: {
+    // 커스텀 로그인 페이지로 라우팅 처리
+    signIn: '/account/login',
+  },
+  secret: process.env.NEXTAUTH_SECRET,
+};
+
+export default NextAuth(authOption);

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -1,0 +1,25 @@
+import { Session } from 'next-auth';
+import { JWT } from 'next-auth/jwt';
+
+declare module 'next-auth' {
+  interface User {
+    id: string;
+    email: string;
+    username: string;
+    imgUrl: string;
+    isAdmin: boolean;
+  }
+  interface Session {
+    user: User;
+  }
+}
+
+declare module 'next-auth/jwt' {
+  interface JWT {
+    id: string;
+    email: string;
+    username: string;
+    imgUrl: string;
+    isAdmin: boolean;
+  }
+}


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #96 

<br />

## 🗒 작업 목록

- [x] next-auth 구성 옵션 정의
  - 이메일, 비밀번호로 로그인 설정
  - 로그인 인증 기능 구현
  - next-auth 기본 로그인 페이지로 접근 시 생성해둔 로그인 페이지로 라우팅 처리
- [x] User, Session, JWT 타입 재정의
- [x] userSession을 사용하기 위한 SessionProvider 적용
- [x] authorize axios 적용 및 에러 핸들링
- [x] 로그인 코드 next-auth signIn 적용
- [x] 로그인 상태에서 로그인, 회원가입 페이지 접근 제한
  - 로그인 후 메인 페이지로 라우팅 처리 
 
<br />

## 🧐 PR Point

- next-auth를 이용하여 로그인 인증을 위한 기본 셋팅 및 로그인 기능을 구현했습니다.
- authOption의 callbacks의 메서드가 실행되며 각 매개변수를 이용하여 token, session의 값을 설정하는 흐름을 이해하는데 오래걸렸습니다.
  - 로그인 시 필요한 사용자 정보를 반환
  - jwt 메서드의 user를 통해 로그인한 사용자 정보를 token과 함께 반환 
  ⇒ session 메서드의 token으로 전달 받음
  - sesstion 메서드에서 전달받은 사용자 정보를 session.user에 저장하여 session 반환
  ⇒ useSession의 data를 이용하여 사용자 정보를 얻을 수 있다.
- `.env.local`에 환경변수 추가하였습니다.
  - `NEXTAUTH_URL`
  - `NEXTAUTH_SECRET` 
- Next.js에서 제공하는 middleware를 이용하여 사용자가 로그인 상태인 경우, 로그인/회원가입 페이지에 접근을 제한하였습니다.
  - 로그인 여부에 따라 접근 가능한 페이지가 꽤 많아질 예정이라 해당 기능은 추후 고도화 하겠습니다.
  - 현재 브랜치에서는 이정도로 작업 마무리 하겠습니다. 
  ⇒ 블로그에 해당 내용 정리 [블로그 바로가기](https://velog.io/@qhflrnfl4324/Middleware-with-Next.js)

<br />

## 💥 Trouble Shooting
- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크

- 내용을 입력해주세요.

<br />

## 📚 참고

- [next-auth-example](https://github.com/nextauthjs/next-auth-example)

#### NextAuth 기본 사용 방법
- [NextAuth.js로 NextJS앱에 로그인 로직 만들기](https://cpro95.tistory.com/611)
- [[ Next.js ] - next-auth 사용법 (credentials)](https://mihee0703.tistory.com/73)
- [인증 로직 구현 ( next-auth )](https://velog.io/@1-blue/%EC%9D%B8%EC%A6%9D-%EB%A1%9C%EC%A7%81-%EA%B5%AC%ED%98%84-next-auth)
- [Next-auth 를 이용한 로그인 구현](https://velog.io/@dosomething/Next-auth-%EB%A5%BC-%EC%9D%B4%EC%9A%A9%ED%95%9C-%EB%A1%9C%EA%B7%B8%EC%9D%B8-%EA%B5%AC%ED%98%84#2%EF%B8%8F%E2%83%A3-trouble-shooting)
- [Next.js 에서 소셜 로그인 구현하기 (next-auth.js 사용)](https://11001.tistory.com/m/230)
- [Next-Auth를 사용하여 손쉽게 OAuth기반 권한관리하기 + RefreshToken + Private Route](https://jeongyunlog.netlify.app/develop/nextjs/next-auth/)
- [NextAuth.js JWT session with credentials provider for beginners](https://remaster.com/blog/next-auth-jwt-session)

#### next-auth 타입 재정의
- [Can't extend JWT interface?](https://github.com/nextauthjs/next-auth/discussions/4920)
- [(NextAuth) Type error: Property 'session' does not exist on type '{}'](https://stackoverflow.com/questions/73668032/nextauth-type-error-property-session-does-not-exist-on-type)
- [How to use next-auth with per page layouts in Next.js with TypeScript?](https://stackoverflow.com/questions/73942758/how-to-use-next-auth-with-per-page-layouts-in-next-js-with-typescript)

#### next.js middleware
- [Middleware](https://nextjs.org/docs/pages/building-your-application/routing/middleware)
- [[Next.js] middleware](https://velog.io/@real-bird/Next.js-middleware)
- [Middleware Upgrade Guide](https://nextjs.org/docs/messages/middleware-upgrade-guide)
- [Nested Middleware](https://nextjs.org/docs/messages/nested-middleware)

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다. 
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
