### PR TITLE
Emotion 컴포넌트를 일반 CSS 선택자로 사용하기 위한 next.config 설정

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,18 +1,21 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  images: {
+  images: { // NOTE: images domains 설정이 최상위에 있어야 합니다.
     domains: [
       "add.bucket.s3.amazonaws.com",
       "dummyimage.com", // 목데이터의 이미지 URL 도메인, 추후 삭제
       "robohash.org" // 목데이터의 이미지 URL 도메인, 추후 삭제
     ]
   },
-  reactStrictMode: true,
+  compiler: {
+    emotion: true
+  },
   experimental: {
     fontLoaders: [
       { loader: '@next/font/google', options: { subsets: ['latin'] } },
     ],
   },
+  reactStrictMode: true,
   webpack: config => {
     config.module.rules.push({
       test: /\.svg$/,


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #103 

<br />

## 🗒 작업 목록

- [x] Emotion 컴포넌트를 일반 CSS 선택자로 사용하기 위한 next.config 설정

<br />

## 🧐 PR Point

- Emotion 컴포넌트를 일반 CSS 선택자로 사용하기 위해서는 설정이 필요합니다.
- Emotion 공식 문서에서는 [@emotion/babel-plugin](https://emotion.sh/docs/@emotion/babel-plugin)를 설치하여 사용할 수 있다고 했지만 next.js의 경우 config만 추가 설정하면 됩니다.
- 보다 쉽게 CSS를 적용하기 위해 해당 설정을 추가하였습니다.
⇒ 블로그에 해당 내용 정리 [블로그 바로가기](https://velog.io/@qhflrnfl4324/Emotion-%EC%BB%B4%ED%8F%AC%EB%84%8C%ED%8A%B8%EB%A5%BC-%EC%9D%BC%EB%B0%98-CSS-%EC%84%A0%ED%83%9D%EC%9E%90%EB%A1%9C-%EC%82%AC%EC%9A%A9%ED%95%98%EA%B8%B0-Next.js)
<br />

## 💥 Trouble Shooting
- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크

- 내용을 입력해주세요.

<br />

## 📚 참고

- [Component selectors can only be used in conjunction with babel-plugin-emotion](https://github.com/emotion-js/emotion/issues/1305#issuecomment-1369727249)
- [Targeting another emotion component](https://emotion.sh/docs/styled#targeting-another-emotion-component)

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다. 
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
