### PR TITLE
회원가입 약관 동의 변경된 데이터 구조 적용

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,2 +1,3 @@
 export * from './image';
 export * from './users';
+export * from './termsAgreements';

--- a/src/api/termsAgreements.ts
+++ b/src/api/termsAgreements.ts
@@ -1,0 +1,11 @@
+import type { SuccessResponse } from 'types/Response';
+import type { TermsAgreementResponse } from 'types/TermsAgreement';
+import { API_PATH } from 'constants/api/path';
+import axios from 'lib/axios';
+
+export const getTermsAgreement = async () => {
+  const { data } = await axios.get<SuccessResponse<TermsAgreementResponse>>(
+    API_PATH.terms.index,
+  );
+  return data.data;
+};

--- a/src/api/users.ts
+++ b/src/api/users.ts
@@ -13,7 +13,7 @@ export const register = async ({
   username,
   password,
   imgUrl,
-  isAgree,
+  termsAgreementIdList,
 }: RegisterRequest) => {
   return await axios.post<SuccessResponse<RegisterResponse>>(
     API_PATH.users.register,
@@ -22,7 +22,7 @@ export const register = async ({
       username,
       password,
       imgUrl,
-      isAgree: true, // TODO: API에서 데이터 구조 수정 필요
+      termsAgreementIdList,
     },
   );
 };

--- a/src/components/account/CompleteRegister.tsx
+++ b/src/components/account/CompleteRegister.tsx
@@ -23,16 +23,15 @@ const CompleteRegister = () => {
           랜덤 매칭을 통해 영어 실력을 키워보세요.
         </WelcomeText>
       </WelcomeContainer>
-      {/* TODO: 페이지 이동 논의 필요(로그인 or 홈) */}
       <ButtonContainer>
         <Button
           type="button"
           pattern="box"
           size="lg"
           fullWidth
-          onClick={async () => await router.replace('/')}
+          onClick={async () => await router.replace('/account/login')}
         >
-          홈으로 이동
+          로그인하기
         </Button>
       </ButtonContainer>
     </Section>

--- a/src/components/account/RegisterTerms.tsx
+++ b/src/components/account/RegisterTerms.tsx
@@ -1,26 +1,19 @@
 import styled from '@emotion/styled';
+import { useQuery } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 import type { ChangeEventHandler } from 'react';
 import type { RegisterForm } from 'types/Register';
+import * as api from 'api';
 import CheckedOffIcon from 'assets/icons/checkbox_off.svg';
 import CheckedOnIcon from 'assets/icons/checkbox_on.svg';
 import { FadeInAnimationStyle } from 'styles';
 
-// 이용 약관 동의 목록
-// 소셜 로그인/회원가입 적용 시 제 3자 개인정보 활용 동의 필요
-const TERMS_AND_CONDITIONS = [
-  { id: 'service', title: '서비스 이용약관', required: true },
-  { id: 'privacy', title: '개인정보 수집 및 이용 동의', required: true },
-  { id: 'marketing', title: '마케팅 활용 동의', required: false },
-];
-
-interface TermsAgreement {
+interface TermsAgreementState {
   all: boolean;
   service: boolean;
   privacy: boolean;
   marketing: boolean;
-  [key: string]: boolean;
 }
 
 type TermsAgreementField =
@@ -29,13 +22,18 @@ type TermsAgreementField =
   | 'termsAgreement.marketing';
 
 const RegisterTerms = () => {
+  const { data: termsAgreement } = useQuery(
+    ['terms-agreement'],
+    api.getTermsAgreement,
+  );
+
   const { register, setValue } = useFormContext<RegisterForm>();
 
-  const [agreedToTerms, setAgreedToTerms] = useState<TermsAgreement>({
-    all: false,
-    service: false,
-    privacy: false,
-    marketing: false,
+  const [agreedToTerms, setAgreedToTerms] = useState<TermsAgreementState>({
+    all: true,
+    service: true,
+    privacy: true,
+    marketing: true,
   });
 
   useEffect(() => {
@@ -122,8 +120,8 @@ const RegisterTerms = () => {
         약관 전체 동의하기
       </CheckboxLabel>
       <CheckboxList>
-        {TERMS_AND_CONDITIONS.map((term) => {
-          const { id, title, required } = term;
+        {termsAgreement?.map((term) => {
+          const { id, title, isRequired } = term;
           const fieldName = `termsAgreement.${id}` as TermsAgreementField;
           return (
             <li key={`terms-and-conditions-${id}`}>
@@ -132,13 +130,13 @@ const RegisterTerms = () => {
                 type="checkbox"
                 checked={agreedToTerms[id]}
                 {...register(fieldName, {
-                  required: !!required,
+                  required: !!isRequired,
                   onChange: handleOnToggleCheckbox,
                 })}
               />
               <CheckboxLabel htmlFor={id}>
                 {agreedToTerms[id] ? <CheckedOnIcon /> : <CheckedOffIcon />}
-                {title} {required ? '(필수)' : '(선택)'}
+                {title}
               </CheckboxLabel>
               {/* TODO: 각 이용 약관 모달 형식으로 보여주기 */}
             </li>

--- a/src/constants/api/path.ts
+++ b/src/constants/api/path.ts
@@ -11,4 +11,7 @@ export const API_PATH = {
     index: '/diaries',
     image: '/diaries/upload-image',
   },
+  terms: {
+    index: '/terms-agreements',
+  },
 } as const;

--- a/src/types/Register.ts
+++ b/src/types/Register.ts
@@ -1,3 +1,5 @@
+import type { TermsAgreementId } from './TermsAgreement';
+
 export interface RegisterForm {
   email: string;
   username: string;
@@ -27,7 +29,7 @@ export interface RegisterRequest {
   username: string;
   password: string;
   imgUrl: string;
-  isAgree: boolean;
+  termsAgreementIdList: TermsAgreementId[];
 }
 
 /*

--- a/src/types/TermsAgreement.ts
+++ b/src/types/TermsAgreement.ts
@@ -1,0 +1,15 @@
+export interface TermsAgreement {
+  id: TermsAgreementId;
+  title: string;
+  content: string;
+  isRequired: boolean;
+}
+
+export type TermsAgreementId = 'service' | 'privacy' | 'marketing';
+
+/*
+ * Response Data Types
+ */
+
+// 회원가입 약관
+export type TermsAgreementResponse = TermsAgreement[];


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #107 

<br />

## 🗒 작업 목록

- [x] 회원가입 약관 타입 생성 및 회원가입 타입 수정
- [x] 회원가입 약관 조회 api 구현 
- [x] pre-render를 사용하기 위한 react-query 기본 설정
- [x] 회원가입 약관 조회 api 연결
- [x] 회원가입 완료 후 로그인 페이지로 이동처리

<br />

## 🧐 PR Point

- 어떤 이유로 코드를 변경했나요?
- 리뷰어가 집중해야하는 포인트가 어디인가요?
- 해당 작업에서 주의 해야할 부분이 있나요?

<br />

## 💥 Trouble Shooting
#### Error serializing
- getServerSideProps/getStaticProps를 통해 서버에서 클라이언트로 데이터를 props로 넘겨줄 때, props로 전달되는 값(dehydrate(queryClient))에 JSON으로 변환이 불가능한 것들이 포함되어 있을 경우 해당 에러가 발생합니다.
- props로 넘겨주는 것은 AxiosResponse 타입(Promise 객체)이 아니라 여기서 data를 추출한 형태여야 합니다.
⇒ AxiosResponse의 데이터 값만 반환하여 해결

#### `Access-Control-Allow-Origin: *` 사용 시 에러 발생
- CORS 에러 해결 후 cors 크롬 익스텐션을 끄고 개발 진행 시 발생한 에러입니다.
![image](https://github.com/a-daily-diary/ADD.FE/assets/85009583/5872cdc9-ebb6-4a51-93da-c4c93e8fd81b)
- CORS 사용 시 Access-Control-Allow-Origin 헤더에 wildcard(*)로 명시하는 경우 쿠키를 사용하지 못하도록 제제하면서 해당 에러가 발생합니다.
- 따라서 `withCredentials: true` 코드를 제거하면 에러가 발생하지 않습니다.
⇒ 추후에 실제 배포 시점에 다시 확인

#### git stash pop
- 해당 브랜치에서 필요없는 git stash pop 명령어를 사용
- 아래 내용을 참고하여 `git reset --merge`을 사용해서 해결

> Merge --abort only when you merge other branch code and it has conflict.
> ```
> git merge --abort
>```
> If stash pop has conflict, you can use:
> ```
> git reset --merge
>```

<br />

## 📸 스크린샷 / 피그마 링크

- 내용을 입력해주세요.

<br />

## 📚 참고

- [SSR](https://tanstack.com/query/v4/docs/react/guides/ssr)
- [[Next.js] SSR + react-query Hydration에서의 serializing 에러](https://velog.io/@pikadev1771/Next.js-SSR-react-query-Hydration%EC%97%90%EC%84%9C%EC%9D%98-serializing-%EC%97%90%EB%9F%AC)
- [Access-Control-Allow-Origin가 wildcard(*)일 때 왜 인증 정보를 포함한 요청은 실패하는가](https://www.hahwul.com/2019/04/10/why-failed-get-data-with-this-cors-policy/)
- [How to abort a stash pop?](https://stackoverflow.com/questions/8515729/how-to-abort-a-stash-pop)

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다. 
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
