### PR TITLE
일기 상세 페이지 API 연동

### DIFF
--- a/src/api/diaries.ts
+++ b/src/api/diaries.ts
@@ -1,4 +1,4 @@
-import type { DiaryRequest, DiaryResponse } from 'types/Diary';
+import type { DiaryRequest, DiaryResponse, DiaryDetail } from 'types/Diary';
 import type { SuccessResponse } from 'types/Response';
 import { API_PATH } from 'constants/api/path';
 import axios from 'lib/axios';
@@ -19,4 +19,13 @@ export const writeDiary = async ({
     },
   );
   return diaryData;
+};
+
+export const getDiaryDetail = async (id: string) => {
+  const {
+    data: { data },
+  } = await axios.get<SuccessResponse<DiaryDetail>>(
+    `${API_PATH.diaries.index}/${id}`,
+  );
+  return data;
 };

--- a/src/components/diary/DiaryDetail.tsx
+++ b/src/components/diary/DiaryDetail.tsx
@@ -1,5 +1,8 @@
 import styled from '@emotion/styled';
+import { useQuery } from '@tanstack/react-query';
 import Image from 'next/image';
+import { useRouter } from 'next/router';
+import * as api from 'api';
 import {
   BookmarkOffIcon,
   BookmarkOnIcon,
@@ -10,55 +13,51 @@ import {
 import ResponsiveImage from 'components/common/ResponsiveImage';
 import { dateFormat, timeFormat } from 'utils';
 
-interface DiaryDetailProps {
-  id: number;
-  title: string;
-  content: string;
-  imgUrl: string | null;
-  commentCount: number;
-  favoriteCount: number;
-  isFavorite: boolean;
-  isBookmark: boolean;
-  createdAt: string;
-  modifiedAt: string;
-  authorUsername: string;
-  authorThumbnailUrl: string;
-}
+const DiaryDetail = () => {
+  const router = useRouter();
+  const { id } = router.query;
+  const { data, isLoading } = useQuery(
+    ['diary-detail', id],
+    async () => await api.getDiaryDetail(id as string),
+  );
 
-const DiaryDetail = ({
-  title,
-  content,
-  imgUrl,
-  commentCount,
-  favoriteCount,
-  isFavorite,
-  isBookmark,
-  createdAt,
-  authorUsername,
-  authorThumbnailUrl,
-}: DiaryDetailProps) => {
+  if (data === undefined) return <div />;
+  if (isLoading) return <div>Loading</div>;
+
+  const {
+    title,
+    content,
+    imgUrl,
+    favoriteCount,
+    commentCount,
+    createdAt,
+    author,
+    isBookmark,
+    isFavorite,
+  } = data;
   return (
     <Container>
       <ContentContainer>
         <AuthorContainer>
-          {authorThumbnailUrl !== null && (
+          {author.imgUrl !== null && (
             // TODO
             // 1. 유저 프로필 이미지 클릭 시 해당 프로필로 이동
             // 2. 프로필 이미지 컴포넌트 분리
             <AuthorImageContainer>
               <Image
-                src={authorThumbnailUrl}
-                alt={authorUsername}
+                src={author.imgUrl}
+                alt={author.username}
                 width={28}
                 height={28}
               />
             </AuthorImageContainer>
           )}
-          <UsernameText>{authorUsername.slice(0, 20)}</UsernameText>
+          <UsernameText>{author.username}</UsernameText>
           <CreatedAtText>{dateFormat(createdAt)}</CreatedAtText>
         </AuthorContainer>
         <Title>{title}</Title>
-        {imgUrl !== null && (
+        {/* NOTE: 잘못된 이미지 데이터로 인해 문제 해결 후 주석 해제 */}
+        {/* {imgUrl !== null && (
           <ImageContainer>
             <ResponsiveImage
               src={imgUrl}
@@ -68,7 +67,7 @@ const DiaryDetail = ({
               aspectRatio={'auto'}
             />
           </ImageContainer>
-        )}
+        )} */}
         <Content>{content}</Content>
         {timeFormat(createdAt) !== null && (
           <TimeContainer>{timeFormat(createdAt)}</TimeContainer>

--- a/src/containers/diary/DiaryContainer.tsx
+++ b/src/containers/diary/DiaryContainer.tsx
@@ -13,7 +13,7 @@ import {
 import ResponsiveImage from 'components/common/ResponsiveImage';
 import { dateFormat, timeFormat } from 'utils';
 
-const DiaryDetail = () => {
+const DiaryContainer = () => {
   const router = useRouter();
   const { id } = router.query;
   const { data, isLoading } = useQuery(
@@ -35,26 +35,27 @@ const DiaryDetail = () => {
     isBookmark,
     isFavorite,
   } = data;
+
   return (
     <Container>
+      <AuthorContainer>
+        {author.imgUrl !== null && (
+          // TODO
+          // 1. 유저 프로필 이미지 클릭 시 해당 프로필로 이동
+          // 2. 프로필 이미지 컴포넌트 분리
+          <AuthorImageContainer>
+            <Image
+              src={author.imgUrl}
+              alt={author.username}
+              width={28}
+              height={28}
+            />
+          </AuthorImageContainer>
+        )}
+        <UsernameText>{author.username}</UsernameText>
+        <CreatedAtText>{dateFormat(createdAt)}</CreatedAtText>
+      </AuthorContainer>
       <ContentContainer>
-        <AuthorContainer>
-          {author.imgUrl !== null && (
-            // TODO
-            // 1. 유저 프로필 이미지 클릭 시 해당 프로필로 이동
-            // 2. 프로필 이미지 컴포넌트 분리
-            <AuthorImageContainer>
-              <Image
-                src={author.imgUrl}
-                alt={author.username}
-                width={28}
-                height={28}
-              />
-            </AuthorImageContainer>
-          )}
-          <UsernameText>{author.username}</UsernameText>
-          <CreatedAtText>{dateFormat(createdAt)}</CreatedAtText>
-        </AuthorContainer>
         <Title>{title}</Title>
         {/* NOTE: 잘못된 이미지 데이터로 인해 문제 해결 후 주석 해제 */}
         {/* {imgUrl !== null && (
@@ -92,14 +93,14 @@ const DiaryDetail = () => {
   );
 };
 
-export default DiaryDetail;
+export default DiaryContainer;
 
 const Container = styled.div`
   background-color: ${({ theme }) => theme.colors.white};
 `;
 
 const ContentContainer = styled.div`
-  padding: 18px 20px 20px;
+  padding: 6px 20px 20px;
 `;
 
 const AuthorContainer = styled.div`
@@ -107,7 +108,7 @@ const AuthorContainer = styled.div`
   grid-template-columns: 28px auto auto;
   gap: 8px;
   align-items: center;
-  margin-bottom: 24px;
+  padding: 18px 20px;
 `;
 
 const AuthorImageContainer = styled.div`

--- a/src/pages/diary/[id].tsx
+++ b/src/pages/diary/[id].tsx
@@ -1,12 +1,10 @@
-import DiaryDetail from 'components/diary/DiaryDetail';
 import DiaryCommentsContainer from 'containers/diary/DiaryCommentsContainer';
+import DiaryContainer from 'containers/diary/DiaryContainer';
 
 const DiaryDetailPage = () => {
   return (
     <>
-      <section>
-        <DiaryDetail />
-      </section>
+      <DiaryContainer />
       <DiaryCommentsContainer />
     </>
   );

--- a/src/pages/diary/[id].tsx
+++ b/src/pages/diary/[id].tsx
@@ -1,20 +1,12 @@
-import { useRouter } from 'next/router';
 import DiaryDetail from 'components/diary/DiaryDetail';
 import DiaryCommentsContainer from 'containers/diary/DiaryCommentsContainer';
-import { DIARY_LIST_MOCK_DATA } from 'mocks/DiaryList';
 
 const DiaryDetailPage = () => {
-  const router = useRouter();
-  const { id } = router.query;
-
-  // TODO: API 연동하기
-  const data = DIARY_LIST_MOCK_DATA[Number(id)];
-
-  if (data === undefined) return <div>Loading...</div>;
-
   return (
     <>
-      <section>{data !== undefined && <DiaryDetail {...data} />}</section>
+      <section>
+        <DiaryDetail />
+      </section>
       <DiaryCommentsContainer />
     </>
   );

--- a/src/types/Diary.ts
+++ b/src/types/Diary.ts
@@ -33,8 +33,10 @@ export interface DiaryDetail {
   id: string;
   title: string;
   content: string;
-  imgUrl?: string;
+  imgUrl: string | null;
   isPublic: boolean;
+  isBookmark: boolean;
+  isFavorite: boolean;
   favoriteCount: number;
   commentCount: number;
   createdAt: string;


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #113

<br />

## 🗒 작업 목록

- [x] DiaryDetail 누락된 타입 추가
- [x] 일기 상세 정보 조회 api 구현
- [x] getDiaryDetail 연동
- getDiaryDetail 연동하면서 불필요해진 코드 삭제
- 잘못된 이미지 데이터로 인해 이미지 주석처리
- [x] DiaryDetail > DiaryContainer 파일명 변경 및 이동

<br />

## 🧐 PR Point

- 일기 상세 정보 조회 api를 연동하면서 DiaryDetail 타입 중 누락된 타입을 추가하고, CSR로 해당 일기 데이터를 가져와서 보여주는 작업을 진행했습니다.

#### TODO
- 잘못된 이미지 데이터로 인해 주석처리 된 코드 수정하기
- DiaryContainer 컴포넌트 내 하위 컴포넌트 추상화(?)

<br />

## 💥 Trouble Shooting
#### 로그인 인증 문제
- 일기 상세 정보 조회 api 호출 시 로그인 된 토큰 값을 확인합니다. 하지만 쿠키에 저장된 토큰 값이 백엔드에서 넘겨준 토큰 값이 아닌 next-auth에서 새로 생성한 토큰값을 저장하여 로그인 상태를 확인하지 못하는 문제가 발생했습니다.
- 서버 사이드 렌더링의 경우 해당 에러 메시지가 출력되지만, 클라이언트 사이드 렌더링일 경우 에러가 발생하지 않는 것으로 확인되었습니다.
- Suspense를 적용할 경우에도 해당 에러가 발생하므로 빠르게 해결 방법을 찾아 적용하겠습니다.
⇒ 현재는 문제가 해결된 상태가 아닙니다.
<img width="310" alt="image" src="https://github.com/a-daily-diary/ADD.FE/assets/85009583/0b0d3e8a-a1d7-4f12-8d78-f293f3fef06e">

<br />

## 📸 스크린샷 / 피그마 링크

#### CSR
<img width="897" alt="image" src="https://github.com/a-daily-diary/ADD.FE/assets/85009583/9fb7bd7d-51fa-4bb1-a042-410760475dd1">

#### SSR
<img width="897" alt="image" src="https://github.com/a-daily-diary/ADD.FE/assets/85009583/fb23e1bd-adc3-43b7-9463-b668a23390ee">



<br />

## 📚 참고

- 참고한 내용 또는 링크를 입력해주세요.

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다. 
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
