### PR TITLE
일기 작성 페이지 > 이미지 업로드 API 연동

### DIFF
--- a/src/api/image.ts
+++ b/src/api/image.ts
@@ -1,11 +1,24 @@
-import type { UploadImageRequest, UploadImageResponse } from 'types/Register';
 import type { SuccessResponse } from 'types/Response';
+import type {
+  UploadImageRequest,
+  UploadImageResponse,
+} from 'types/UploadImage';
 import { API_PATH } from 'constants/api/path';
 import axios from 'lib/axios';
 
 export const uploadUserImage = async (imageFormData: UploadImageRequest) => {
   return await axios.post<SuccessResponse<UploadImageResponse>>(
     API_PATH.users.image,
+    imageFormData,
+    {
+      headers: { 'Content-Type': 'multipart/form-data' },
+    },
+  );
+};
+
+export const uploadDiaryImage = async (imageFormData: UploadImageRequest) => {
+  return await axios.post<SuccessResponse<UploadImageResponse>>(
+    API_PATH.diaries.image,
     imageFormData,
     {
       headers: { 'Content-Type': 'multipart/form-data' },

--- a/src/components/common/ResponsiveImage.tsx
+++ b/src/components/common/ResponsiveImage.tsx
@@ -2,51 +2,38 @@ import styled from '@emotion/styled';
 import Image from 'next/image';
 
 interface ResponsiveImageStyleProps {
-  aspectRatio: number | 'auto';
+  aspectRatio?: number | 'auto';
 }
 
 interface ResponsiveImageProps extends ResponsiveImageStyleProps {
   src: string;
   alt: string;
-  width: number;
-  height: number;
   quality?: number;
 }
 
 const ResponsiveImage = ({
   src,
   alt,
-  width,
-  height,
   quality,
-  aspectRatio,
+  aspectRatio = 'auto',
 }: ResponsiveImageProps) => {
   return (
     <ImageContainer aspectRatio={aspectRatio}>
-      <StyledImage
-        src={src}
-        alt={alt}
-        width={width}
-        height={height}
-        quality={quality ?? 100}
-        priority
-      />
+      <StyledImage src={src} alt={alt} quality={quality ?? 100} fill priority />
     </ImageContainer>
   );
 };
 
 export default ResponsiveImage;
 
-const ImageContainer = styled.div<ResponsiveImageStyleProps>`
-  overflow: hidden;
-  display: flex;
-  place-content: center;
-  width: 100%;
-  aspect-ratio: ${({ aspectRatio }) => aspectRatio};
+const StyledImage = styled(Image)`
+  position: relative !important;
+  height: unset !important;
+  object-fit: cover;
 `;
 
-const StyledImage = styled(Image)`
-  width: 100%;
-  height: auto;
-  object-fit: cover;
+const ImageContainer = styled.div<ResponsiveImageStyleProps>`
+  ${StyledImage} {
+    aspect-ratio: ${({ aspectRatio }) => aspectRatio};
+  }
 `;

--- a/src/components/diary/Diary.tsx
+++ b/src/components/diary/Diary.tsx
@@ -49,13 +49,7 @@ const Diary = ({
         {/* TODO: 현재 목데이터 index와 id 값이 달라 임의로 (id - 1)를 적용하여 해결 */}
         <ContentLink href={`/diary/${id - 1}`}>{content}</ContentLink>
         {imgUrl !== null && (
-          <ResponsiveImage
-            src={imgUrl}
-            alt={title}
-            width={320}
-            height={160}
-            aspectRatio={2 / 1}
-          />
+          <ResponsiveImage src={imgUrl} alt={title} aspectRatio={2 / 1} />
         )}
         <DateContainer>
           <span>

--- a/src/containers/diary/DiaryContainer.tsx
+++ b/src/containers/diary/DiaryContainer.tsx
@@ -63,9 +63,6 @@ const DiaryContainer = () => {
             <ResponsiveImage
               src={imgUrl}
               alt={title}
-              width={320}
-              height={160}
-              aspectRatio={'auto'}
             />
           </ImageContainer>
         )} */}

--- a/src/pages/diary/index.tsx
+++ b/src/pages/diary/index.tsx
@@ -175,13 +175,7 @@ const WriteDiary: NextPageWithLayout = () => {
           />
           {isPhotoActive && (
             <PreviewImageContainer>
-              <ResponsiveImage
-                src={previewImage}
-                alt={watchTitle}
-                width={100}
-                height={100}
-                aspectRatio={'auto'}
-              />
+              <ResponsiveImage src={previewImage} alt={watchTitle} />
               <CancelImageButton
                 type="button"
                 aria-label="사진 선택 취소"

--- a/src/pages/diary/index.tsx
+++ b/src/pages/diary/index.tsx
@@ -40,18 +40,12 @@ const WriteDiary: NextPageWithLayout = () => {
     formState: { isValid },
   } = useForm<DiaryForm>({
     mode: 'onChange',
-    defaultValues: { isPublic: true },
+    defaultValues: { imgUrl: null, isPublic: true },
   });
   const { isPublic: watchIsPublic, title: watchTitle } = watch();
 
   const [previewImage, setPreviewImage] = useState<string>('');
   const isPhotoActive = previewImage.length > 0;
-
-  useEffect(() => {
-    return () => {
-      URL.revokeObjectURL(previewImage);
-    };
-  }, [previewImage]);
 
   // TODO: 일기작성 페이지 벗어났을 때 동작하는 코드 수정 필요
   const handleConfirmMessage = () => {
@@ -65,6 +59,37 @@ const WriteDiary: NextPageWithLayout = () => {
       router.beforePopState(() => true);
     };
   }, []);
+
+  const handleOnChangeImageFile: ChangeEventHandler<HTMLInputElement> = async (
+    e,
+  ) => {
+    const { files } = e.target;
+    if (files !== null) {
+      try {
+        const imageFormData = new FormData();
+        imageFormData.append('image', files[0]);
+
+        const {
+          data: {
+            data: { imgUrl },
+          },
+        } = await api.uploadDiaryImage(imageFormData);
+
+        setPreviewImage(imgUrl);
+        setValue('imgUrl', imgUrl);
+      } catch (error) {
+        if (isAxiosError<ErrorResponse>(error)) {
+          // TODO: 이미지 업로드 시 에러 처리
+          console.log(error);
+        }
+      }
+    }
+  };
+
+  const handleCancelImage = () => {
+    setPreviewImage('');
+    setValue('imgUrl', null);
+  };
 
   const onSubmit: SubmitHandler<DiaryForm> = async (data) => {
     try {
@@ -87,23 +112,11 @@ const WriteDiary: NextPageWithLayout = () => {
     }
   };
 
-  const handleOnChangeImageFile: ChangeEventHandler<HTMLInputElement> = (e) => {
-    const { files } = e.target;
-    if (files !== null) {
-      const imageUrl = URL.createObjectURL(files[0]);
-      setPreviewImage(imageUrl);
-    }
-  };
-
-  const handleCancelImage = () => {
-    setPreviewImage('');
-    setValue('imgUrl', undefined);
-  };
-
   return (
     <Section>
       <Title>일기 작성</Title>
       <form onSubmit={handleSubmit(onSubmit)}>
+        {/* NOTE: 등록 버튼을 사용하기 위해 form 요소 내에 Header가 존재함 */}
         <Header>
           <HeaderLeft
             type="닫기"
@@ -128,9 +141,7 @@ const WriteDiary: NextPageWithLayout = () => {
             type="file"
             id="selectImageFile"
             accept="image/*"
-            {...register('imgUrl', {
-              onChange: handleOnChangeImageFile,
-            })}
+            onChange={handleOnChangeImageFile}
           />
           <PublicLabel htmlFor="isPublic" isPublic={watchIsPublic}>
             {watchIsPublic ? (

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -21,8 +21,6 @@ const Home: NextPageWithLayout = () => {
           <ResponsiveImage
             src="/images/main/banner/go_to_write.png"
             alt="오늘 영어 일기 쓰러가기"
-            width={640}
-            height={132}
             aspectRatio={640 / 132}
           />
         </Link>

--- a/src/types/Diary.ts
+++ b/src/types/Diary.ts
@@ -3,7 +3,7 @@ import type { User } from 'next-auth';
 export interface DiaryForm {
   title: string;
   content: string;
-  imgUrl?: string;
+  imgUrl: string | null;
   isPublic: boolean;
 }
 


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #114

<br />

## 🗒 작업 목록

- [x] DiaryForm imgUrl 타입 수정
- [x] 일기 이미지 업로드 api 구현
- [x] 일기 이미지 업로드 api 연동
- [x] 반응형 이미지 컴포넌트 리팩토링 및 적용

<br />

## 🧐 PR Point

#### 이미지 업로드 API 연동
- 일기 작성 페이지에서 이미지 미리보기만 구현하고 이미지 업로드 API 연동을 하지 않아 문제 이미지 데이터가 `'{}'`로 들어갔습니다..
  - 해당 일기 상세 페이지에서 이미지로 인해 에러 발생하여 일기 이미지 API 연동을 통해 해결했습니다.

#### 반응형 next/image 컴포넌트
- 반응형 next/image 컴포넌트 사용시 해당 이미지의 너비, 높이 값을 지정해줘야  이미지 깨짐 없이, 에러없이 적용되었습니다.
  - 하지만 일기 작성 페이지처럼 사용자가 이미지를 업로드 하는 경우 해당 이미지의 너비, 높이 값을 알 수 없기 때문에 fill 속성을 이용하여 반응형 이미지 코드를 수정하였습니다. 
- fill 속성을 사용하면 자동으로 다음과 같은 스타일이 적용됩니다.
  ```
  style="position: absolute; height: 100%; width: 100%; inset: 0px; color: transparent;"
  ```
  ![image](https://github.com/a-daily-diary/ADD.FE/assets/85009583/8e0232a5-bce0-4de8-9bd4-a2b530baa61f)
- 자동으로 적용된 스타일 코드를 `!important`를 통해 수정하여 디자인 또는 해당 이미지 크기에 맞게 이미지가 나타나도록 했습니다.

<br />

## 💥 Trouble Shooting
- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크

- 내용을 입력해주세요.

<br />

## 📚 참고

- [`<Image>`](https://nextjs.org/docs/pages/api-reference/components/image)
- [next/image - Make image fill available space without specifying height or width](https://dev.to/tanahmed/next-image-make-image-fill-available-space-272o)

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다. 
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
