### PR TITLE
일기 상세 페이지 > Header 적용

### DIFF
--- a/src/components/common/ResponsiveImage.tsx
+++ b/src/components/common/ResponsiveImage.tsx
@@ -33,6 +33,8 @@ const StyledImage = styled(Image)`
 `;
 
 const ImageContainer = styled.div<ResponsiveImageStyleProps>`
+  position: relative;
+
   ${StyledImage} {
     aspect-ratio: ${({ aspectRatio }) => aspectRatio};
   }

--- a/src/components/diary/DiaryCommentInput.tsx
+++ b/src/components/diary/DiaryCommentInput.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { SendActiveIcon, SendInactiveIcon } from 'assets/icons';
+import { Z_INDEX } from 'constants/styles';
 import { ERROR_MESSAGE } from 'constants/validation/Message';
 import { VALID_VALUE } from 'constants/validation/Value';
 import { SVGVerticalAlignStyle } from 'styles';
@@ -70,6 +71,7 @@ const CommentInputContainer = styled.div`
   right: 0;
   bottom: 0;
   left: 0;
+  z-index: ${Z_INDEX.dialog};
   padding: 10px 20px 8px;
   border-top: 1px solid ${({ theme }) => theme.colors.gray_06};
   background-color: ${({ theme }) => theme.colors.white};

--- a/src/components/layouts/Navbar.tsx
+++ b/src/components/layouts/Navbar.tsx
@@ -7,6 +7,7 @@ import {
   ProfileIcon,
   WriteDiaryIcon,
 } from 'assets/icons';
+import { Z_INDEX } from 'constants/styles';
 
 const NAVIGATION_LIST = [
   {
@@ -63,6 +64,7 @@ const Navigation = styled.nav`
   right: 0;
   bottom: 0;
   left: 0;
+  z-index: ${Z_INDEX.navigation};
   border-top: 1px solid ${({ theme }) => theme.colors.gray_06};
   background-color: ${({ theme }) => theme.colors.white};
 `;

--- a/src/components/layouts/header/Header.tsx
+++ b/src/components/layouts/header/Header.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import type { ReactNode } from 'react';
+import { Z_INDEX } from 'constants/styles';
 
 interface HeaderProps {
   children: ReactNode;
@@ -17,6 +18,7 @@ const HeaderLayout = styled.header`
   top: 0;
   right: 0;
   left: 0;
+  z-index: ${Z_INDEX.header};
   height: 54px;
   padding: 0 20px;
   border-bottom: 1px solid ${({ theme }) => theme.colors.gray_06};

--- a/src/constants/styles/colors.ts
+++ b/src/constants/styles/colors.ts
@@ -1,4 +1,4 @@
-const colors = Object.freeze({
+export const colors = {
   // Primary scale
   primary_00: '#00c73c',
   primary_01: '#80e39e',
@@ -20,6 +20,4 @@ const colors = Object.freeze({
   white: '#ffffff',
   error: '#f84d4d',
   pink: '#ff89d7',
-});
-
-export default colors;
+} as const;

--- a/src/constants/styles/index.ts
+++ b/src/constants/styles/index.ts
@@ -1,0 +1,2 @@
+export * from './colors';
+export * from './zIndex';

--- a/src/constants/styles/zIndex.ts
+++ b/src/constants/styles/zIndex.ts
@@ -1,0 +1,7 @@
+export const Z_INDEX = {
+  dialog: 100,
+  header: 100,
+  navigation: 100,
+  dimmed: 200,
+  modal: 300,
+} as const;

--- a/src/pages/account/register.tsx
+++ b/src/pages/account/register.tsx
@@ -18,6 +18,7 @@ import RegisterTerms from 'components/account/RegisterTerms';
 import Button from 'components/common/Button';
 import Seo from 'components/common/Seo';
 import { Layout, HeaderTitle, Header, HeaderLeft } from 'components/layouts';
+import { Z_INDEX } from 'constants/styles';
 import { errorResponseMessage } from 'utils';
 
 const Register: NextPageWithLayout = () => {
@@ -152,5 +153,6 @@ const ButtonContainer = styled.div`
   right: 0;
   bottom: 0;
   left: 0;
+  z-index: ${Z_INDEX.dialog};
   padding: 12px 20px;
 `;

--- a/src/pages/diary/[id].tsx
+++ b/src/pages/diary/[id].tsx
@@ -1,13 +1,34 @@
+import styled from '@emotion/styled';
+import type { ReactElement } from 'react';
+import Seo from 'components/common/Seo';
+import { Layout, Header, HeaderLeft, HeaderRight } from 'components/layouts';
 import DiaryCommentsContainer from 'containers/diary/DiaryCommentsContainer';
 import DiaryContainer from 'containers/diary/DiaryContainer';
 
 const DiaryDetailPage = () => {
   return (
-    <>
+    <Section>
       <DiaryContainer />
       <DiaryCommentsContainer />
-    </>
+    </Section>
+  );
+};
+
+DiaryDetailPage.getLayout = function getLayout(page: ReactElement) {
+  return (
+    <Layout>
+      <Seo title={'a daily diary'} />
+      <Header>
+        <HeaderLeft type="이전" />
+        <HeaderRight type="더보기" />
+      </Header>
+      {page}
+    </Layout>
   );
 };
 
 export default DiaryDetailPage;
+
+const Section = styled.section`
+  margin-top: 54px;
+`;

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -3,7 +3,7 @@ import { Montserrat } from '@next/font/google';
 import localFont from '@next/font/local';
 import type { SerializedStyles, Theme } from '@emotion/react';
 import type { NextFont } from '@next/font/dist/types';
-import colors from 'constants/colors';
+import { colors } from 'constants/styles';
 
 const pretendard = localFont({
   src: [


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #117 

<br />

## 🗒 작업 목록

- [x] fill 속성 가진 Image 컴포넌트 부모 요소에 position 지정
- [x] z-index 상수 생성
- [x] constants/styles 디렉토리 생성 및 관련 파일 이동
  - colors, zIndex 해당 디렉토리로 이동
- [x] z-index 적용
- [x] 일기 상세 페이지 Header 적용

<br />

## 🧐 PR Point

- 일기 상세 페이지에 적용되지 않았던 Header를 적용하면 z-index 값을 상수로 생성하여 적용하였습니다.

## 💥 Trouble Shooting
#### fill 속성 가진 Image 컴포넌트 부모 요소에 position 지정
- Image 컴포넌트에 fill 속성을 지정하면 fill 속성이 가진 position 때문에 부모 요소에 position 속성을 지정해줘야 합니다.
- 따라서, 부모 요소에 position: "relative" 지정하여 해결했습니다.
> The parent element must assign position: "relative", position: "fixed", or position: "absolute" style. 

<br />

## 📸 스크린샷 / 피그마 링크

- 내용을 입력해주세요.

<br />

## 📚 참고

- [`<Image>` - fill](https://nextjs.org/docs/pages/api-reference/components/image#fill)

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다. 
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
