### PR TITLE
일기 삭제 기능 구현 

### DIFF
--- a/src/api/diaries.ts
+++ b/src/api/diaries.ts
@@ -1,5 +1,5 @@
 import type { DiaryRequest, DiaryResponse, DiaryDetail } from 'types/Diary';
-import type { SuccessResponse } from 'types/Response';
+import type { OnlyMessageResponse, SuccessResponse } from 'types/Response';
 import { API_PATH } from 'constants/api/path';
 import axios from 'lib/axios';
 
@@ -28,4 +28,15 @@ export const getDiaryDetail = async (id: string) => {
     `${API_PATH.diaries.index}/${id}`,
   );
   return data;
+};
+
+export const deleteDiaryDetail = async (id: string) => {
+  const {
+    data: {
+      data: { message },
+    },
+  } = await axios.delete<SuccessResponse<OnlyMessageResponse>>(
+    `${API_PATH.diaries.index}/${id}`,
+  );
+  return message;
 };

--- a/src/api/users.ts
+++ b/src/api/users.ts
@@ -1,10 +1,6 @@
 import type { LoginRequest, LoginResponse } from 'types/Login';
-import type {
-  ExistsRequest,
-  RegisterRequest,
-  RegisterResponse,
-} from 'types/Register';
-import type { SuccessResponse } from 'types/Response';
+import type { ExistsRequest, RegisterRequest } from 'types/Register';
+import type { OnlyMessageResponse, SuccessResponse } from 'types/Response';
 import { API_PATH } from 'constants/api/path';
 import axios from 'lib/axios';
 
@@ -15,7 +11,7 @@ export const register = async ({
   imgUrl,
   termsAgreementIdList,
 }: RegisterRequest) => {
-  return await axios.post<SuccessResponse<RegisterResponse>>(
+  return await axios.post<SuccessResponse<OnlyMessageResponse>>(
     API_PATH.users.register,
     {
       email,
@@ -28,7 +24,7 @@ export const register = async ({
 };
 
 export const emailExists = async ({ email }: ExistsRequest) => {
-  return await axios.post<SuccessResponse<RegisterResponse>>(
+  return await axios.post<SuccessResponse<OnlyMessageResponse>>(
     API_PATH.users.emailExists,
     {
       email,
@@ -37,7 +33,7 @@ export const emailExists = async ({ email }: ExistsRequest) => {
 };
 
 export const usernameExists = async ({ username }: ExistsRequest) => {
-  return await axios.post<SuccessResponse<RegisterResponse>>(
+  return await axios.post<SuccessResponse<OnlyMessageResponse>>(
     API_PATH.users.usernameExists,
     {
       username,

--- a/src/assets/icons/edit.svg
+++ b/src/assets/icons/edit.svg
@@ -1,0 +1,11 @@
+<svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_522_725)">
+<path d="M12.37 3.48L14.7 5.81L6.49003 14.02L3.46003 14.72L4.16003 11.68L12.37 3.47M12.37 2C12.06 2 11.75 2.12 11.51 2.36L3.13003 10.73C2.97003 10.89 2.86003 11.1 2.80003 11.32L2.03003 14.68C1.85003 15.46 2.46003 16.17 3.21003 16.17C3.30003 16.17 3.39003 16.16 3.49003 16.14L6.85003 15.36C7.07002 15.31 7.28003 15.2 7.44003 15.03L15.82 6.67C16.3 6.19 16.3 5.42 15.82 4.95L13.23 2.36C12.99 2.12 12.68 2 12.37 2Z" fill="#00C73C"/>
+<path d="M10.09 5.25L12.95 8.11" stroke="#00C73C" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+<defs>
+<clipPath id="clip0_522_725">
+<rect width="14.18" height="14.18" fill="white" transform="translate(2 2)"/>
+</clipPath>
+</defs>
+</svg>

--- a/src/assets/icons/index.ts
+++ b/src/assets/icons/index.ts
@@ -7,6 +7,7 @@ import CheckedOnIcon from './checkbox_on.svg';
 import CloseIcon from './close.svg';
 import CommentIcon from './comment.svg';
 import DeleteIcon from './delete.svg';
+import EditIcon from './edit.svg';
 import HeartOffIcon from './heart_off.svg';
 import HeartOnIcon from './heart_on.svg';
 import HideIcon from './hide_pw.svg';
@@ -20,12 +21,14 @@ import PhotoActiveIcon from './photo_active.svg';
 import PhotoInactiveIcon from './photo_inactive.svg';
 import ProfileIcon from './profile.svg';
 import QuestionIcon from './question.svg';
+import ReportIcon from './report.svg';
 import SearchIcon from './search.svg';
 import SendActiveIcon from './send_active.svg';
 import SendInactiveIcon from './send_inactive.svg';
 import SettingIcon from './setting.svg';
 import ShowIcon from './show_pw.svg';
 import TemplateIcon from './template.svg';
+import TrashIcon from './trash.svg';
 import UnlockIcon from './unlock.svg';
 import WriteCommentIcon from './write_comment.svg';
 import WriteDiaryIcon from './write_diary.svg';
@@ -33,10 +36,14 @@ import WriteDiaryIcon from './write_diary.svg';
 export {
   ArrowRightIcon,
   BackIcon,
+  BookmarkOffIcon,
+  BookmarkOnIcon,
+  CommentIcon,
   CloseIcon,
   CheckedOffIcon,
   CheckedOnIcon,
   DeleteIcon,
+  EditIcon,
   HideIcon,
   ShowIcon,
   MoreIcon,
@@ -47,14 +54,12 @@ export {
   SettingIcon,
   HomeIcon,
   MatchingIcon,
-  WriteDiaryIcon,
   ProfileIcon,
-  BookmarkOffIcon,
-  BookmarkOnIcon,
-  CommentIcon,
   HeartOffIcon,
   HeartOnIcon,
   WriteCommentIcon,
+  WriteDiaryIcon,
+  ReportIcon,
   SendActiveIcon,
   SendInactiveIcon,
   LockIcon,
@@ -62,4 +67,5 @@ export {
   PhotoActiveIcon,
   PhotoInactiveIcon,
   TemplateIcon,
+  TrashIcon,
 };

--- a/src/assets/icons/report.svg
+++ b/src/assets/icons/report.svg
@@ -1,0 +1,12 @@
+<svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_390_740)">
+<path d="M15.7 14.7H1.7" stroke="#F84D4D" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M8.7 14.7V9.69995" stroke="#F84D4D" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M3.7 13.7V7.69995C3.7 4.93995 5.94 2.69995 8.7 2.69995C11.46 2.69995 13.7 4.93995 13.7 7.69995V13.7" stroke="#F84D4D" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+<defs>
+<clipPath id="clip0_390_740">
+<rect width="15.4" height="13.4" fill="white" transform="translate(1 2)"/>
+</clipPath>
+</defs>
+</svg>

--- a/src/assets/icons/trash.svg
+++ b/src/assets/icons/trash.svg
@@ -1,0 +1,14 @@
+<svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_522_734)">
+<path d="M10.7 3.70001V2.70001C10.7 2.15001 10.25 1.70001 9.70001 1.70001H7.70001C7.15001 1.70001 6.70001 2.15001 6.70001 2.70001V3.70001" stroke="#999999" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M2.70001 3.70001H14.7" stroke="#999999" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M13.7 6.20001V13.2C13.7 14.3 12.8 15.2 11.7 15.2H5.70001C4.60001 15.2 3.70001 14.3 3.70001 13.2V6.20001" stroke="#999999" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M10.2 7.20001V12.2" stroke="#999999" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M7.20001 7.20001V12.2" stroke="#999999" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+<defs>
+<clipPath id="clip0_522_734">
+<rect width="13.4" height="14.9" fill="white" transform="translate(2 1)"/>
+</clipPath>
+</defs>
+</svg>

--- a/src/components/common/FloatingMenu.tsx
+++ b/src/components/common/FloatingMenu.tsx
@@ -1,0 +1,37 @@
+import styled from '@emotion/styled';
+import FloatingMenuButton from './FloatingMenuButton';
+import type { FloatingMenuButtonProps } from './FloatingMenuButton';
+import { Z_INDEX } from 'constants/styles';
+
+interface FloatingMenuProps {
+  items: FloatingMenuButtonProps[];
+}
+
+const FloatingMenu = ({ items }: FloatingMenuProps) => {
+  return (
+    <List>
+      {items.map((item, index) => {
+        const { label, icon, onClick } = item;
+        return (
+          <li key={`floating-item-${index}`}>
+            <FloatingMenuButton icon={icon} label={label} onClick={onClick} />
+          </li>
+        );
+      })}
+    </List>
+  );
+};
+
+export default FloatingMenu;
+
+const List = styled.ul`
+  position: absolute;
+  top: 40px;
+  right: 20px;
+  z-index: ${Z_INDEX.dialog};
+  padding: 6px 0;
+  border: 1px solid ${({ theme }) => theme.colors.gray_06};
+  border-radius: 10px;
+  background-color: ${({ theme }) => theme.colors.white};
+  filter: drop-shadow(4px 4px 10px rgba(0, 0, 0, 0.08));
+`;

--- a/src/components/common/FloatingMenuButton.tsx
+++ b/src/components/common/FloatingMenuButton.tsx
@@ -1,0 +1,33 @@
+import styled from '@emotion/styled';
+import type { ReactNode } from 'react';
+
+export interface FloatingMenuButtonProps {
+  icon?: ReactNode;
+  label: string;
+  onClick: () => void;
+}
+
+const FloatingMenuButton = ({
+  icon,
+  label,
+  onClick,
+}: FloatingMenuButtonProps) => {
+  return (
+    <Button type="button" onClick={onClick}>
+      {icon}
+      {label}
+    </Button>
+  );
+};
+
+export default FloatingMenuButton;
+
+const Button = styled.button`
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 140px;
+  padding: 10px 16px;
+  color: ${({ theme }) => theme.colors.gray_01};
+  ${({ theme }) => theme.fonts.button_01};
+`;

--- a/src/components/layouts/header/HeaderRight.tsx
+++ b/src/components/layouts/header/HeaderRight.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import Link from 'next/link';
+import type { ForwardedRef } from 'react';
 import { MoreIcon, SearchIcon } from 'assets/icons';
 import { SVGVerticalAlignStyle } from 'styles';
 
@@ -9,14 +10,20 @@ interface HeaderRightStyleProps {
 
 interface HeaderRightProps extends HeaderRightStyleProps {
   type: '더보기' | '검색' | '등록';
+  buttonRef?: ForwardedRef<HTMLButtonElement>;
   onClick?: () => void;
 }
 
-export const HeaderRight = ({ type, onClick, disabled }: HeaderRightProps) => {
+export const HeaderRight = ({
+  type,
+  buttonRef,
+  onClick,
+  disabled,
+}: HeaderRightProps) => {
   return (
     <>
       {type === '더보기' && (
-        <MoreButton type="button" onClick={onClick}>
+        <MoreButton type="button" onClick={onClick} ref={buttonRef}>
           <StyledMoreIcon />
         </MoreButton>
       )}

--- a/src/hooks/useClickOutside.ts
+++ b/src/hooks/useClickOutside.ts
@@ -1,0 +1,24 @@
+import { useEffect, useRef, useState } from 'react';
+
+const useClickOutside = () => {
+  const [isVisible, setIsVisible] = useState<boolean>(false);
+  const ref = useRef<HTMLButtonElement | null>(null);
+
+  useEffect(() => {
+    document.addEventListener('click', handleClickOutside);
+    return () => {
+      document.removeEventListener('click', handleClickOutside);
+    };
+  }, [isVisible]);
+
+  const handleClickOutside = (e: globalThis.MouseEvent) => {
+    const { target } = e;
+    if (target === null || ref.current === null) return;
+    if (!ref.current.contains(target as HTMLElement)) {
+      setIsVisible(false);
+    }
+  };
+  return { ref, isVisible, setIsVisible };
+};
+
+export default useClickOutside;

--- a/src/pages/diary/[id].tsx
+++ b/src/pages/diary/[id].tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import { useRouter } from 'next/router';
-import { useState, type ReactElement } from 'react';
+import { useRef, useState, useEffect, type ReactElement } from 'react';
 import type { NextPageWithLayout } from 'pages/_app';
 import { EditIcon, TrashIcon } from 'assets/icons';
 import FloatingMenu from 'components/common/FloatingMenu';
@@ -12,12 +12,29 @@ import DiaryContainer from 'containers/diary/DiaryContainer';
 const DiaryDetailPage: NextPageWithLayout = () => {
   const router = useRouter();
   const [showFloatingMenu, setShowFloatingMenu] = useState<boolean>(false);
+  const toggleButtonRef = useRef<HTMLButtonElement | null>(null);
+
+  useEffect(() => {
+    document.addEventListener('click', handleClickOutside);
+    return () => {
+      document.removeEventListener('click', handleClickOutside);
+    };
+  }, [showFloatingMenu]);
+
+  const handleClickOutside = (e: globalThis.MouseEvent) => {
+    const { target } = e;
+    if (target === null || toggleButtonRef.current === null) return;
+    if (!toggleButtonRef.current.contains(target as HTMLElement)) {
+      setShowFloatingMenu(false);
+    }
+  };
 
   return (
     <Section>
       <Header>
         <HeaderLeft type="이전" />
         <HeaderRight
+          buttonRef={toggleButtonRef}
           type="더보기"
           onClick={() => {
             setShowFloatingMenu((state) => !state);
@@ -29,7 +46,7 @@ const DiaryDetailPage: NextPageWithLayout = () => {
               {
                 icon: <EditIcon />,
                 label: '수정하기',
-                onClick: async () => await router.push(`/diary`),
+                onClick: async () => await router.push(`/diary`), // TODO: 일기 수정하기 페이지 생성 후 라우터 수정
               },
               {
                 icon: <TrashIcon />,

--- a/src/pages/diary/[id].tsx
+++ b/src/pages/diary/[id].tsx
@@ -1,7 +1,10 @@
 import styled from '@emotion/styled';
+import { isAxiosError } from 'axios';
 import { useRouter } from 'next/router';
 import { type ReactElement } from 'react';
 import type { NextPageWithLayout } from 'pages/_app';
+import type { ErrorResponse } from 'types/Response';
+import * as api from 'api';
 import { EditIcon, TrashIcon } from 'assets/icons';
 import FloatingMenu from 'components/common/FloatingMenu';
 import Seo from 'components/common/Seo';
@@ -9,10 +12,27 @@ import { Layout, Header, HeaderLeft, HeaderRight } from 'components/layouts';
 import DiaryCommentsContainer from 'containers/diary/DiaryCommentsContainer';
 import DiaryContainer from 'containers/diary/DiaryContainer';
 import useClickOutside from 'hooks/useClickOutside';
+import { errorResponseMessage } from 'utils';
 
 const DiaryDetailPage: NextPageWithLayout = () => {
   const router = useRouter();
+  const { id } = router.query;
   const { ref, isVisible, setIsVisible } = useClickOutside();
+
+  const handleDeleteDiary = async () => {
+    if (confirm('삭제하시겠습니까?')) {
+      try {
+        const message = await api.deleteDiaryDetail(id as string);
+        alert(message);
+        // TODO: 일기 삭제 후 라우팅 처리 수정
+        router.back();
+      } catch (error) {
+        if (isAxiosError<ErrorResponse>(error)) {
+          alert(errorResponseMessage(error.response?.data.message));
+        }
+      }
+    }
+  };
 
   return (
     <Section>
@@ -36,9 +56,7 @@ const DiaryDetailPage: NextPageWithLayout = () => {
               {
                 icon: <TrashIcon />,
                 label: '삭제하기',
-                onClick: () => {
-                  alert('삭제하시겠습니까?');
-                },
+                onClick: handleDeleteDiary,
               },
             ]}
           />

--- a/src/pages/diary/[id].tsx
+++ b/src/pages/diary/[id].tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import { useRouter } from 'next/router';
-import { useRef, useState, useEffect, type ReactElement } from 'react';
+import { type ReactElement } from 'react';
 import type { NextPageWithLayout } from 'pages/_app';
 import { EditIcon, TrashIcon } from 'assets/icons';
 import FloatingMenu from 'components/common/FloatingMenu';
@@ -8,39 +8,24 @@ import Seo from 'components/common/Seo';
 import { Layout, Header, HeaderLeft, HeaderRight } from 'components/layouts';
 import DiaryCommentsContainer from 'containers/diary/DiaryCommentsContainer';
 import DiaryContainer from 'containers/diary/DiaryContainer';
+import useClickOutside from 'hooks/useClickOutside';
 
 const DiaryDetailPage: NextPageWithLayout = () => {
   const router = useRouter();
-  const [showFloatingMenu, setShowFloatingMenu] = useState<boolean>(false);
-  const toggleButtonRef = useRef<HTMLButtonElement | null>(null);
-
-  useEffect(() => {
-    document.addEventListener('click', handleClickOutside);
-    return () => {
-      document.removeEventListener('click', handleClickOutside);
-    };
-  }, [showFloatingMenu]);
-
-  const handleClickOutside = (e: globalThis.MouseEvent) => {
-    const { target } = e;
-    if (target === null || toggleButtonRef.current === null) return;
-    if (!toggleButtonRef.current.contains(target as HTMLElement)) {
-      setShowFloatingMenu(false);
-    }
-  };
+  const { ref, isVisible, setIsVisible } = useClickOutside();
 
   return (
     <Section>
       <Header>
         <HeaderLeft type="이전" />
         <HeaderRight
-          buttonRef={toggleButtonRef}
+          buttonRef={ref}
           type="더보기"
           onClick={() => {
-            setShowFloatingMenu((state) => !state);
+            setIsVisible((state) => !state);
           }}
         />
-        {showFloatingMenu && (
+        {isVisible && (
           <FloatingMenu
             items={[
               {

--- a/src/pages/diary/[id].tsx
+++ b/src/pages/diary/[id].tsx
@@ -1,27 +1,57 @@
 import styled from '@emotion/styled';
-import type { ReactElement } from 'react';
+import { useRouter } from 'next/router';
+import { useState, type ReactElement } from 'react';
+import type { NextPageWithLayout } from 'pages/_app';
+import { EditIcon, TrashIcon } from 'assets/icons';
+import FloatingMenu from 'components/common/FloatingMenu';
 import Seo from 'components/common/Seo';
 import { Layout, Header, HeaderLeft, HeaderRight } from 'components/layouts';
 import DiaryCommentsContainer from 'containers/diary/DiaryCommentsContainer';
 import DiaryContainer from 'containers/diary/DiaryContainer';
 
-const DiaryDetailPage = () => {
+const DiaryDetailPage: NextPageWithLayout = () => {
+  const router = useRouter();
+  const [showFloatingMenu, setShowFloatingMenu] = useState<boolean>(false);
+
   return (
     <Section>
+      <Header>
+        <HeaderLeft type="이전" />
+        <HeaderRight
+          type="더보기"
+          onClick={() => {
+            setShowFloatingMenu((state) => !state);
+          }}
+        />
+        {showFloatingMenu && (
+          <FloatingMenu
+            items={[
+              {
+                icon: <EditIcon />,
+                label: '수정하기',
+                onClick: async () => await router.push(`/diary`),
+              },
+              {
+                icon: <TrashIcon />,
+                label: '삭제하기',
+                onClick: () => {
+                  alert('삭제하시겠습니까?');
+                },
+              },
+            ]}
+          />
+        )}
+      </Header>
       <DiaryContainer />
       <DiaryCommentsContainer />
     </Section>
   );
 };
 
-DiaryDetailPage.getLayout = function getLayout(page: ReactElement) {
+DiaryDetailPage.getLayout = (page: ReactElement) => {
   return (
     <Layout>
       <Seo title={'a daily diary'} />
-      <Header>
-        <HeaderLeft type="이전" />
-        <HeaderRight type="더보기" />
-      </Header>
       {page}
     </Layout>
   );

--- a/src/types/Register.ts
+++ b/src/types/Register.ts
@@ -30,15 +30,6 @@ export interface RegisterRequest {
 }
 
 /*
- * Response Data Types
- */
-
-// 이메일/유저이름 중복 체크, 회원가입
-export interface RegisterResponse {
-  message: string;
-}
-
-/*
  * Other Types
  */
 

--- a/src/types/Response.ts
+++ b/src/types/Response.ts
@@ -11,3 +11,11 @@ export interface SuccessResponse<T> {
   success: true;
   data: T;
 }
+
+/*
+ * Common Response Data Types
+ */
+
+export interface OnlyMessageResponse {
+  message: string;
+}


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #119 

<br />

## 🗒 작업 목록

- [x] 신고, 수정, 삭제 svg 추가
- [x] FloatingMenu 컴포넌트 생성 및 적용
- [x] 더보기 버튼 이외의 영역 클릭 시 FloatingMenu 닫기 기능 구현
- [x] useClickOutside 훅 생성 및 적용
- [x] OnlyMessageResponse 생성 및 적용
  - 응답 데이터에 메시지만 있는 경우 Common Response data type으로 생성하여 적용
  - 기존 Register의 메시지 응답 데이터 타입 삭제
- [x] 일기 삭제 api 구현 및 연동

<br />

## 🧐 PR Point

- 일기 삭제/수정을 구현하기 위해 필요한 FloatingMenu 컴포넌트를 생성했습니다.
  - Header의 더보기 버튼을 클릭하면 FloatingMenu가 보여지거나 닫히게 하였고, 더보기 버튼 이외의 영역을 클릭하면 컴포넌트가 닫힐 수 있도록 구현했습니다.
  - FloatingMenu 내 각 메뉴들의 onClick 동작이 정상적으로 이루어지고, 동작 이후 FloatingMenu가 닫혀야하므로 FloatingMenu를 클릭할 경우 FloatingMenu가 닫히지 않도록 하는 동작은 적용하지 않았습니다.
- useClickOutside 훅을 생성하여 재사용성과 가독성을 높였습니다.
- message만 반환하는 응답 데이터 타입을 재사용하기 위해 Response에 Common Respense Data Type으로 생성하여 적용했습니다.
  - 기존에 Register에서 사용했던 같은 타입은 삭제하고,  생성한 OnlyMessageResponse을 적용했습니다.

#### TODO
- 일기 삭제 후 라우팅 처리 : 일단 뒤로가기 적용해놓음
- 내가 작성한 일기가 아닌 경우 신고하기 메뉴 보이기

<br />

## 💥 Trouble Shooting
- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크

- 내용을 입력해주세요.

<br />

## 📚 참고

- [합성 컴포넌트로 재사용성 극대화하기](https://fe-developers.kakaoent.com/2022/220731-composition-component/)
- [react-custom-hooks: useClickOutside](https://github.com/sarat9/react-custom-hooks/blob/master/hooks/useClickOutside.jsx)

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다. 
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
