### PR TITLE
일기 수정 페이지 및 기능 구현

### DIFF
--- a/src/api/diaries.ts
+++ b/src/api/diaries.ts
@@ -30,6 +30,23 @@ export const getDiaryDetail = async (id: string) => {
   return data;
 };
 
+export const editDiaryDetail = async (
+  { title, content, imgUrl, isPublic }: DiaryRequest,
+  id: string,
+) => {
+  const { data: diaryData } = await axios.put<SuccessResponse<DiaryResponse>>(
+    `${API_PATH.diaries.index}/${id}`,
+    {
+      title,
+      content,
+      imgUrl,
+      isPublic,
+    },
+  );
+  // TODO: 수정 완료 후 메시지 반환으로 변경 요청 후 해당 반환값 수정
+  return diaryData;
+};
+
 export const deleteDiaryDetail = async (id: string) => {
   const {
     data: {

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,0 +1,3 @@
+export { default as useBeforeLeave } from './useBeforeLeave';
+export { default as useClickOutside } from './useClickOutside';
+export { default as useTabIndicator } from './useTabIndicator';

--- a/src/hooks/useBeforeLeave.ts
+++ b/src/hooks/useBeforeLeave.ts
@@ -1,0 +1,32 @@
+import router from 'next/router';
+import { useEffect } from 'react';
+
+interface useBeforeLeaveProps {
+  message: string;
+  path: string;
+}
+
+const useBeforeLeave = ({ message, path }: useBeforeLeaveProps) => {
+  const handleConfirm = () => {
+    window.history.pushState(null, '', path);
+    if (confirm(message)) return true;
+    return false;
+  };
+
+  const handleBeforeunload = (e: BeforeUnloadEvent) => {
+    e.preventDefault();
+    return (e.returnValue = '');
+  };
+
+  useEffect(() => {
+    window.addEventListener('beforeunload', handleBeforeunload);
+    router.beforePopState(() => handleConfirm());
+
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeunload);
+      router.beforePopState(() => true);
+    };
+  }, [handleBeforeunload, handleConfirm]);
+};
+
+export default useBeforeLeave;

--- a/src/hooks/useBeforeLeave.ts
+++ b/src/hooks/useBeforeLeave.ts
@@ -1,12 +1,12 @@
 import router from 'next/router';
 import { useEffect } from 'react';
 
-interface useBeforeLeaveProps {
+interface UseBeforeLeaveProps {
   message: string;
   path: string;
 }
 
-const useBeforeLeave = ({ message, path }: useBeforeLeaveProps) => {
+const useBeforeLeave = ({ message, path }: UseBeforeLeaveProps) => {
   const handleConfirm = () => {
     window.history.pushState(null, '', path);
     if (confirm(message)) return true;

--- a/src/hooks/useTabIndicator.ts
+++ b/src/hooks/useTabIndicator.ts
@@ -6,12 +6,12 @@ interface IndicatorProps {
   offsetLeft: number;
 }
 
-interface useTabIndicatorProps {
+interface UseTabIndicatorProps {
   tabsRef: MutableRefObject<Array<HTMLButtonElement | null>>;
   activeIndex: number;
 }
 
-const useTabIndicator = ({ tabsRef, activeIndex }: useTabIndicatorProps) => {
+const useTabIndicator = ({ tabsRef, activeIndex }: UseTabIndicatorProps) => {
   const [indicator, setIndicator] = useState<IndicatorProps>({
     width: 0,
     offsetLeft: 0,

--- a/src/pages/diary/[id]/edit.tsx
+++ b/src/pages/diary/[id]/edit.tsx
@@ -1,0 +1,341 @@
+import styled from '@emotion/styled';
+import { QueryClient, dehydrate, useQuery } from '@tanstack/react-query';
+import { isAxiosError } from 'axios';
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import type { GetServerSideProps } from 'next';
+import type { NextPageWithLayout } from 'pages/_app';
+import type { ReactElement, ChangeEventHandler } from 'react';
+import type { SubmitHandler } from 'react-hook-form';
+import type { DiaryForm } from 'types/Diary';
+import type { ErrorResponse } from 'types/Response';
+import * as api from 'api';
+import {
+  PhotoInactiveIcon,
+  PhotoActiveIcon,
+  UnlockIcon,
+  LockIcon,
+  DeleteIcon,
+} from 'assets/icons';
+import ResponsiveImage from 'components/common/ResponsiveImage';
+import Seo from 'components/common/Seo';
+import {
+  Layout,
+  Header,
+  HeaderLeft,
+  HeaderRight,
+  HeaderTitle,
+} from 'components/layouts';
+import { DIARY_MESSAGE } from 'constants/diary';
+import { ScreenReaderOnly } from 'styles';
+import { dateFormat, errorResponseMessage, textareaAutosize } from 'utils';
+
+const EditDiary: NextPageWithLayout = () => {
+  const router = useRouter();
+  const { id } = router.query;
+  const { data, isLoading } = useQuery(
+    ['diary-detail', id],
+    async () => await api.getDiaryDetail(id as string),
+  );
+
+  const {
+    register,
+    handleSubmit,
+    watch,
+    setValue,
+    formState: { isValid },
+  } = useForm<DiaryForm>({ mode: 'onChange' });
+  const { isPublic: watchIsPublic, title: watchTitle } = watch();
+
+  const [previewImage, setPreviewImage] = useState<string>(
+    data?.imgUrl == null ? '' : data?.imgUrl,
+  );
+  const isPhotoActive = previewImage.length > 0;
+
+  useEffect(() => {
+    if (data === undefined) return;
+    setValue('title', data.title, { shouldValidate: true });
+    setValue('content', data.content, { shouldValidate: true });
+    setValue('imgUrl', data.imgUrl, { shouldValidate: true });
+    setValue('isPublic', data.isPublic, { shouldValidate: true });
+  }, [data]);
+
+  // TODO: 일기작성 페이지 벗어났을 때 동작하는 코드 수정 필요
+  // 커스텀 훅으로 생성하는 것이 좋을 것 같음
+  const handleConfirmMessage = () => {
+    if (confirm(DIARY_MESSAGE.popstate)) return true;
+    return false;
+  };
+
+  useEffect(() => {
+    router.beforePopState(() => handleConfirmMessage());
+    return () => {
+      router.beforePopState(() => true);
+    };
+  }, []);
+
+  const handleOnChangeImageFile: ChangeEventHandler<HTMLInputElement> = async (
+    e,
+  ) => {
+    const { files } = e.target;
+    if (files !== null) {
+      try {
+        const imageFormData = new FormData();
+        imageFormData.append('image', files[0]);
+
+        const {
+          data: {
+            data: { imgUrl },
+          },
+        } = await api.uploadDiaryImage(imageFormData);
+
+        setPreviewImage(imgUrl);
+        setValue('imgUrl', imgUrl);
+      } catch (error) {
+        if (isAxiosError<ErrorResponse>(error)) {
+          // TODO: 이미지 업로드 시 에러 처리
+          console.log(error);
+        }
+      }
+    }
+  };
+
+  const handleCancelImage = () => {
+    setPreviewImage('');
+    setValue('imgUrl', null);
+  };
+
+  const onSubmit: SubmitHandler<DiaryForm> = async (data) => {
+    try {
+      const { title, content, imgUrl, isPublic } = data;
+      await api.editDiaryDetail(
+        {
+          title,
+          content,
+          imgUrl,
+          isPublic,
+        },
+        id as string,
+      );
+
+      await router.replace(`/diary/${id as string}`);
+    } catch (error) {
+      if (isAxiosError<ErrorResponse>(error)) {
+        alert(errorResponseMessage(error.response?.data.message));
+      }
+    }
+  };
+
+  if (data === undefined) return <div />;
+  if (isLoading) return <div>Loading</div>;
+
+  const createdAtDate = dateFormat(data?.createdAt) as string;
+
+  return (
+    <Section>
+      <Title>일기 편집</Title>
+      <form onSubmit={handleSubmit(onSubmit)}>
+        {/* NOTE: 등록 버튼을 사용하기 위해 form 요소 내에 Header가 존재함 */}
+        <Header>
+          <HeaderLeft
+            type="닫기"
+            onClick={() => {
+              router.back();
+            }}
+          />
+          <HeaderTitle title={createdAtDate} fontWeight={700} />
+          <HeaderRight type="등록" disabled={!isValid} />
+        </Header>
+        <FormHeader>
+          {/* TODO: 일기 템플릿 추가 */}
+          <ImageFileLabel
+            htmlFor="selectImageFile"
+            isPhotoActive={!isPhotoActive}
+          >
+            {isPhotoActive ? <PhotoInactiveIcon /> : <PhotoActiveIcon />}
+            사진 추가
+            <PhotoText isPhotoActive={!isPhotoActive}>(1장)</PhotoText>
+          </ImageFileLabel>
+          <ImageFileInput
+            type="file"
+            id="selectImageFile"
+            accept="image/*"
+            onChange={handleOnChangeImageFile}
+          />
+          <PublicLabel htmlFor="isPublic" isPublic={watchIsPublic}>
+            {watchIsPublic ? (
+              <>
+                <UnlockIcon />
+                공개
+              </>
+            ) : (
+              <>
+                <LockIcon />
+                비공개
+              </>
+            )}
+          </PublicLabel>
+          <PublicCheckbox
+            id="isPublic"
+            type="checkbox"
+            {...register('isPublic')}
+          />
+        </FormHeader>
+        <ContentContainer>
+          <TitleTextarea
+            id="title"
+            placeholder="일기 제목을 작성해주세요."
+            rows={1}
+            {...register('title', {
+              required: true,
+              onChange: textareaAutosize,
+              setValueAs: (value: string) => value.trim(),
+            })}
+          />
+          {isPhotoActive && (
+            <PreviewImageContainer>
+              <ResponsiveImage src={previewImage} alt={watchTitle} />
+              <CancelImageButton
+                type="button"
+                aria-label="사진 선택 취소"
+                onClick={handleCancelImage}
+              >
+                <DeleteIcon />
+              </CancelImageButton>
+            </PreviewImageContainer>
+          )}
+          <ContentTextarea
+            id="content"
+            placeholder="일기 내용을 작성해주세요."
+            rows={1}
+            {...register('content', {
+              required: true,
+              onChange: textareaAutosize,
+              setValueAs: (value: string) => value.trim(),
+            })}
+          />
+        </ContentContainer>
+      </form>
+    </Section>
+  );
+};
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const { id } = context.query;
+  const queryClient = new QueryClient();
+  await queryClient.prefetchQuery(
+    ['diary-detail', id],
+    async () => await api.getDiaryDetail(id as string),
+  );
+
+  return { props: { dehydratedState: dehydrate(queryClient) } };
+};
+
+EditDiary.getLayout = function getLayout(page: ReactElement) {
+  return (
+    <Layout>
+      <Seo title="일기 편집 | a daily diary" />
+      {page}
+    </Layout>
+  );
+};
+
+export default EditDiary;
+
+const Section = styled.section`
+  margin-top: 54px;
+  min-height: 100vh;
+`;
+
+const Title = styled.h1`
+  ${ScreenReaderOnly}
+`;
+
+const FormHeader = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+  background-color: ${({ theme }) => theme.colors.bg_01};
+  ${({ theme }) => theme.fonts.caption_01}
+`;
+
+const ImageFileLabel = styled.label<{ isPhotoActive: boolean }>`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  color: ${({ theme, isPhotoActive }) =>
+    isPhotoActive ? theme.colors.gray_00 : theme.colors.gray_04};
+  cursor: pointer;
+`;
+
+const PhotoText = styled.span<{ isPhotoActive: boolean }>`
+  color: ${({ theme, isPhotoActive }) =>
+    isPhotoActive ? theme.colors.gray_02 : theme.colors.gray_04};
+`;
+
+const ImageFileInput = styled.input`
+  ${ScreenReaderOnly}
+`;
+
+const PublicLabel = styled.label<{ isPublic: boolean }>`
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  color: ${({ theme, isPublic }) =>
+    isPublic ? theme.colors.gray_01 : theme.colors.error};
+  cursor: pointer;
+
+  &::before {
+    content: '';
+    display: block;
+    width: 1px;
+    height: 20px;
+    margin-right: 12px;
+    background-color: ${({ theme }) => theme.colors.gray_05};
+  }
+`;
+
+const PublicCheckbox = styled.input`
+  ${ScreenReaderOnly}
+`;
+
+const ContentContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  padding: 16px 20px;
+`;
+
+const TitleTextarea = styled.textarea`
+  padding-bottom: 10px;
+  border-bottom: 1px solid ${({ theme }) => theme.colors.gray_06};
+  ${({ theme }) => theme.fonts.headline_01}
+  font-weight: 500;
+
+  &::placeholder {
+    color: ${({ theme }) => theme.colors.gray_04};
+  }
+`;
+
+const PreviewImageContainer = styled.div`
+  position: relative;
+  margin-top: 16px;
+`;
+
+const CancelImageButton = styled.button`
+  position: absolute;
+  top: 0;
+  right: 0;
+  padding: 10px;
+`;
+
+const ContentTextarea = styled.textarea`
+  margin-top: 16px;
+  ${({ theme }) => theme.fonts.body_04}
+
+  &::placeholder {
+    color: ${({ theme }) => theme.colors.gray_04};
+  }
+`;

--- a/src/pages/diary/[id]/edit.tsx
+++ b/src/pages/diary/[id]/edit.tsx
@@ -28,6 +28,7 @@ import {
   HeaderTitle,
 } from 'components/layouts';
 import { DIARY_MESSAGE } from 'constants/diary';
+import { useBeforeLeave } from 'hooks';
 import { ScreenReaderOnly } from 'styles';
 import { dateFormat, errorResponseMessage, textareaAutosize } from 'utils';
 
@@ -61,19 +62,7 @@ const EditDiary: NextPageWithLayout = () => {
     setValue('isPublic', data.isPublic, { shouldValidate: true });
   }, [data]);
 
-  // TODO: 일기작성 페이지 벗어났을 때 동작하는 코드 수정 필요
-  // 커스텀 훅으로 생성하는 것이 좋을 것 같음
-  const handleConfirmMessage = () => {
-    if (confirm(DIARY_MESSAGE.popstate)) return true;
-    return false;
-  };
-
-  useEffect(() => {
-    router.beforePopState(() => handleConfirmMessage());
-    return () => {
-      router.beforePopState(() => true);
-    };
-  }, []);
+  useBeforeLeave({ message: DIARY_MESSAGE.popstate, path: router.asPath });
 
   const handleOnChangeImageFile: ChangeEventHandler<HTMLInputElement> = async (
     e,

--- a/src/pages/diary/[id]/index.tsx
+++ b/src/pages/diary/[id]/index.tsx
@@ -51,7 +51,8 @@ const DiaryDetailPage: NextPageWithLayout = () => {
               {
                 icon: <EditIcon />,
                 label: '수정하기',
-                onClick: async () => await router.push(`/diary`), // TODO: 일기 수정하기 페이지 생성 후 라우터 수정
+                onClick: async () =>
+                  await router.push(`/diary/${id as string}/edit`), // TODO: 일기 수정하기 페이지 생성 후 라우터 수정
               },
               {
                 icon: <TrashIcon />,

--- a/src/pages/diary/[id]/index.tsx
+++ b/src/pages/diary/[id]/index.tsx
@@ -11,7 +11,7 @@ import Seo from 'components/common/Seo';
 import { Layout, Header, HeaderLeft, HeaderRight } from 'components/layouts';
 import DiaryCommentsContainer from 'containers/diary/DiaryCommentsContainer';
 import DiaryContainer from 'containers/diary/DiaryContainer';
-import useClickOutside from 'hooks/useClickOutside';
+import { useClickOutside } from 'hooks';
 import { errorResponseMessage } from 'utils';
 
 const DiaryDetailPage: NextPageWithLayout = () => {

--- a/src/pages/diary/index.tsx
+++ b/src/pages/diary/index.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import { isAxiosError } from 'axios';
 import { useRouter } from 'next/router';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import type { NextPageWithLayout } from 'pages/_app';
 import type { ReactElement, ChangeEventHandler } from 'react';
@@ -26,6 +26,7 @@ import {
   HeaderTitle,
 } from 'components/layouts';
 import { DIARY_MESSAGE } from 'constants/diary';
+import { useBeforeLeave } from 'hooks';
 import { ScreenReaderOnly } from 'styles';
 import { dateFormat, errorResponseMessage, textareaAutosize } from 'utils';
 
@@ -47,18 +48,7 @@ const WriteDiary: NextPageWithLayout = () => {
   const [previewImage, setPreviewImage] = useState<string>('');
   const isPhotoActive = previewImage.length > 0;
 
-  // TODO: 일기작성 페이지 벗어났을 때 동작하는 코드 수정 필요
-  const handleConfirmMessage = () => {
-    if (confirm(DIARY_MESSAGE.popstate)) return true;
-    return false;
-  };
-
-  useEffect(() => {
-    router.beforePopState(() => handleConfirmMessage());
-    return () => {
-      router.beforePopState(() => true);
-    };
-  }, []);
+  useBeforeLeave({ message: DIARY_MESSAGE.popstate, path: router.asPath });
 
   const handleOnChangeImageFile: ChangeEventHandler<HTMLInputElement> = async (
     e,

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -8,7 +8,7 @@ import Seo from 'components/common/Seo';
 import Tab from 'components/common/Tab';
 import { Layout, Navbar } from 'components/layouts';
 import Empty from 'components/profile/Empty';
-import useTabIndicator from 'hooks/useTabIndicator';
+import { useTabIndicator } from 'hooks';
 
 const PROFILE_TAB_LIST = [
   { id: 'activities', title: '활동' },


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #121 

<br />

## 🗒 작업 목록

- [x] 일기 수정하기 api 구현
- [x] diary/[id] 디렉토리 생성 및 파일 이동
- [x] 일기 수정 페이지 구현 및 일기 수정하기 기능 구현
- [x] useBeforeLeave 커스텀 훅 생성 및 적용
- [x] hooks 디렉토리 모듈 다시 내보내기 적용으로 import 문 수정

<br />

## 🧐 PR Point

- 일기 수정하기 페이지 구현 및 기능을 구현했습니다.
- 수정할 일기에 대한 정보는 SSR로 데이터를 불러옵니다.
⇒ 따라서 기존에 있는 next.js 서버에서 로그인 인증 문제 발생
- react-hook-form의 setValue를 통해 불러온 데이터를 나타냅니다.

#### 일기 작성/수정 페이지를 벗어나는 경우
- 기존에 beforePopState를 이용하여 구현되어 있던 코드를 고도화했고, useBeforeLeave 커스텀 훅을 생성하여 적용했습니다.
- 일기 작성/수정 페이지에서 새로고침, 탭 닫기, 뒤로가기 이벤트가 발생하는 경우 작성이 완료되지 않아 내용이 저장되지 않음을 다음과 같이 명시하였습니다.
- 새로고침, 탭 닫기가 발생하는 경우
![image](https://github.com/a-daily-diary/ADD.FE/assets/85009583/977f1e26-e1ac-4ad1-9b51-841c850c6390)
- 뒤로가기 이벤트가 발생하는 경우
  - 추후 모달 UI를 구현하여 적용할 예정입니다. 
![image](https://github.com/a-daily-diary/ADD.FE/assets/85009583/e1e09878-9b50-43ac-a49e-9850cab33f5c)

<br />

## 💥 Trouble Shooting
- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크

- 내용을 입력해주세요.

<br />

## 📚 참고

- [Window: beforeunload event](https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event)
- [React - 뒤로가기 막기 및 새로고침 알림 띄우기 구현(popstate, beforeunload 이벤트)](https://velog.io/@jinyoung234/2.-React-%EB%92%A4%EB%A1%9C%EA%B0%80%EA%B8%B0-%EB%A7%89%EA%B8%B0-%EB%B0%8F-%EC%83%88%EB%A1%9C%EA%B3%A0%EC%B9%A8-%EC%95%8C%EB%A6%BC-%EB%9D%84%EC%9A%B0%EA%B8%B0-%EA%B5%AC%ED%98%84)
- [eventlistener beforeunload not working in react](https://stackoverflow.com/questions/63524447/eventlistener-beforeunload-not-working-in-react)
- [[Next.js] 브라우저 뒤로가기 막기 beforePopState 문제점](https://irondeveloper.tistory.com/21)
- [next.js 브라우저 뒤로가기 이벤트 막기](https://careerly.co.kr/qnas/760)


<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다. 
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
