### PR TITLE
SSR에서 accessToken이 전달되지 않은 문제 해결

### DIFF
--- a/src/api/diaries.ts
+++ b/src/api/diaries.ts
@@ -1,3 +1,4 @@
+import type { AxiosRequestConfig } from 'axios';
 import type { DiaryRequest, DiaryResponse, DiaryDetail } from 'types/Diary';
 import type { OnlyMessageResponse, SuccessResponse } from 'types/Response';
 import { API_PATH } from 'constants/api/path';
@@ -21,11 +22,15 @@ export const writeDiary = async ({
   return diaryData;
 };
 
-export const getDiaryDetail = async (id: string) => {
+export const getDiaryDetail = async (
+  id: string,
+  config?: AxiosRequestConfig,
+) => {
   const {
     data: { data },
   } = await axios.get<SuccessResponse<DiaryDetail>>(
     `${API_PATH.diaries.index}/${id}`,
+    config,
   );
   return data;
 };

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -12,13 +12,17 @@ const options: AxiosRequestConfig = {
 
 const client = axios.create(options);
 
-client.interceptors.request.use(async (request) => {
-  const session = await getSession();
+client.interceptors.request.use(
+  async (config) => {
+    const session = await getSession();
 
-  if (session != null)
-    request.headers.Authorization = `Bearer ${session.user.accessToken}`;
+    if (session !== null) {
+      config.headers.Authorization = `Bearer ${session.user.accessToken}`;
+    }
 
-  return request;
-});
+    return config;
+  },
+  async (error) => await Promise.reject(error),
+);
 
 export default client;


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #123

<br />

## 🗒 작업 목록

- [x] axios request interceptors에 에러 로직 추가
- [x] getDiaryDetail에 ssr에서 headers를 전달할 수 있도록 수정
  - headers를 매개변수로 전달받을 수 있게 함
  - 선택적 속성으로하여 csr에서는 interceptor를 사용할 수 있도록 함

<br />

## 🧐 PR Point

- axios request interceptors에서 ssr 시 session이 null 인 문제가 있었습니다.

#### 원인
- getSession이 서버 사이드와 클라이언트 모두 동작하는 줄 알았으나 클라이언트 사이드에서만 동작합니다. ([참고했던 링크](https://stackoverflow.com/questions/69234170/difference-between-usesession-and-getsession-in-next-auth))
- 따라서, SSR일 경우 session이 null이므로 interceptors에서 요청 헤더에 토큰 값을 전달하지 못합니다.

#### 해결 방법
- getServerSideProps를 사용할 경우 getServerSession를 이용하여 session의 토큰 값을 가져와 직접 요청 헤더에 넣어주는 방식으로 해결했습니다.
- 헤더를 넣어주기 위해 기존 getDiaryDetail api에 매개변수로 headers를 전달받을 수 있도록 했습니다.
- 클라이언트 사이드에서는 interceptors에 적용한 getSession이 토큰값을 받아오므로 headers는 선택적 속성으로 적용하였습니다.

#### 시도
1. getServerSession을 interceptors에 적용해보려고 했으나 서버 컴포넌트에서만 사용할 수 있어 에러가 발생합니다.
2. NEXTAUTH_URL=http://127.0.0.1:3000로 변경하는 방법이 제시되어 있어 적용해보았으나 해결되지 않았습니다.
⇒ 더 나은 방법이 있는지 찾아서 적용할 예정입니다.

<br />

## 💥 Trouble Shooting
- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크

- 내용을 입력해주세요.

<br />

## 📚 참고

- [Client API - getSession()](https://next-auth.js.org/getting-started/client#getsession)
- [NextJS next-auth get session always null](https://stackoverflow.com/questions/72457673/nextjs-next-auth-get-session-always-null)
- [getSession always returns null on server](https://github.com/nextauthjs/next-auth/discussions/1466)
- [[Next.js] SSR 페이지에서 session pre-fetch 하기 (next-auth)](https://cherishvert.tistory.com/103)
- [Difference between useSession and getSession in next-auth?](https://stackoverflow.com/questions/69234170/difference-between-usesession-and-getsession-in-next-auth)

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다. 
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
