### PR TITLE
getLayout 제거

### DIFF
--- a/src/components/layouts/Layout.tsx
+++ b/src/components/layouts/Layout.tsx
@@ -1,11 +1,29 @@
+import styled from '@emotion/styled';
+import { useRouter } from 'next/router';
+import Navbar from './Navbar';
 import type { ReactJSXElement } from '@emotion/react/types/jsx-namespace';
 import type { ReactNode } from 'react';
+
 interface LayoutProps {
   children?: ReactNode;
 }
 
+const SHOW_NAVBAR_PAGES = ['/', '/profile'];
+
 const Layout = ({ children }: LayoutProps): ReactJSXElement => {
-  return <main>{children}</main>;
+  const { pathname } = useRouter();
+  const showNavbar = SHOW_NAVBAR_PAGES.includes(pathname);
+
+  return (
+    <Main showNavbar={showNavbar}>
+      {children}
+      {showNavbar && <Navbar />}
+    </Main>
+  );
 };
 
 export default Layout;
+
+const Main = styled.main<{ showNavbar: boolean }>`
+  ${({ showNavbar }) => showNavbar && 'margin-bottom: 63px;'};
+`;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -7,30 +7,11 @@ import {
 import Head from 'next/head';
 import { SessionProvider } from 'next-auth/react';
 import { useState } from 'react';
-import type { DehydratedState } from '@tanstack/react-query';
-import type { NextPage } from 'next';
 import type { AppProps } from 'next/app';
-import type { Session } from 'next-auth';
-import type { ReactElement, ReactNode } from 'react';
+import { Layout } from 'components/layouts';
 import { theme, GlobalStyle } from 'styles';
 
-export type NextPageWithLayout<P = Record<string, unknown>> = NextPage<P> & {
-  getLayout?: (page: ReactElement) => ReactNode;
-};
-
-type AppPropsWithLayout<P> = AppProps<P> & {
-  Component: NextPageWithLayout;
-  pageProps: P & {
-    session?: Session;
-    dehydratedState: DehydratedState;
-  };
-};
-
-export default function App({
-  Component,
-  pageProps,
-}: AppPropsWithLayout<{ session: Session }>) {
-  const getLayout = Component.getLayout ?? ((page) => page);
+export default function App({ Component, pageProps }: AppProps) {
   const [queryClient] = useState(new QueryClient());
 
   return (
@@ -43,7 +24,9 @@ export default function App({
           <SessionProvider session={pageProps.session}>
             <ThemeProvider theme={theme}>
               <Global styles={GlobalStyle} />
-              {getLayout(<Component {...pageProps} />)}
+              <Layout>
+                <Component {...pageProps} />
+              </Layout>
             </ThemeProvider>
           </SessionProvider>
         </Hydrate>

--- a/src/pages/account/register.tsx
+++ b/src/pages/account/register.tsx
@@ -92,6 +92,11 @@ const Register: NextPageWithLayout = () => {
 
   return (
     <>
+      <Seo title={'회원가입 | a daily diary'} />
+      <Header
+        left={<HeaderLeft type="이전" />}
+        title={<HeaderTitle title={'회원가입'} position={'left'} />}
+      />
       {!registerStep.welcomeMessage && (
         <FormProvider {...methods}>
           <From onSubmit={handleSubmit(onSubmit)}>
@@ -122,16 +127,7 @@ const Register: NextPageWithLayout = () => {
 };
 
 Register.getLayout = function getLayout(page: ReactElement) {
-  return (
-    <Layout>
-      <Seo title={'회원가입 | a daily diary'} />
-      <Header
-        left={<HeaderLeft type="이전" />}
-        title={<HeaderTitle title={'회원가입'} position={'left'} />}
-      />
-      {page}
-    </Layout>
-  );
+  return <Layout>{page}</Layout>;
 };
 
 export const getStaticProps: GetStaticProps = async () => {

--- a/src/pages/account/register.tsx
+++ b/src/pages/account/register.tsx
@@ -3,9 +3,7 @@ import { QueryClient, dehydrate } from '@tanstack/react-query';
 import { isAxiosError } from 'axios';
 import { useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
-import type { GetStaticProps } from 'next';
-import type { NextPageWithLayout } from 'pages/_app';
-import type { ReactElement } from 'react';
+import type { GetStaticProps, NextPage } from 'next';
 import type { SubmitHandler } from 'react-hook-form';
 import type { RegisterForm, RegisterStep } from 'types/Register';
 import type { ErrorResponse } from 'types/Response';
@@ -17,11 +15,11 @@ import RegisterProfileImage from 'components/account/RegisterProfileImage';
 import RegisterTerms from 'components/account/RegisterTerms';
 import Button from 'components/common/Button';
 import Seo from 'components/common/Seo';
-import { Layout, HeaderTitle, Header, HeaderLeft } from 'components/layouts';
+import { HeaderTitle, Header, HeaderLeft } from 'components/layouts';
 import { Z_INDEX } from 'constants/styles';
 import { errorResponseMessage } from 'utils';
 
-const Register: NextPageWithLayout = () => {
+const Register: NextPage = () => {
   const methods = useForm<RegisterForm>({ mode: 'onChange' });
   const {
     handleSubmit,
@@ -124,10 +122,6 @@ const Register: NextPageWithLayout = () => {
       {registerStep.welcomeMessage && <CompleteRegister />}
     </>
   );
-};
-
-Register.getLayout = function getLayout(page: ReactElement) {
-  return <Layout>{page}</Layout>;
 };
 
 export const getStaticProps: GetStaticProps = async () => {

--- a/src/pages/diary/[id]/edit.tsx
+++ b/src/pages/diary/[id]/edit.tsx
@@ -124,93 +124,96 @@ const EditDiary: NextPageWithLayout = () => {
   const createdAtDate = dateFormat(data?.createdAt) as string;
 
   return (
-    <Section>
-      <Title>일기 편집</Title>
-      <form onSubmit={handleSubmit(onSubmit)}>
-        {/* NOTE: 등록 버튼을 사용하기 위해 form 요소 내에 Header가 존재함 */}
-        <Header
-          left={
-            <HeaderLeft
-              type="닫기"
-              onClick={() => {
-                router.back();
-              }}
+    <>
+      <Seo title="일기 편집 | a daily diary" />
+      <Section>
+        <Title>일기 편집</Title>
+        <form onSubmit={handleSubmit(onSubmit)}>
+          {/* NOTE: 등록 버튼을 사용하기 위해 form 요소 내에 Header가 존재함 */}
+          <Header
+            left={
+              <HeaderLeft
+                type="닫기"
+                onClick={() => {
+                  router.back();
+                }}
+              />
+            }
+            title={<HeaderTitle title={createdAtDate} fontWeight={700} />}
+            right={<HeaderRight type="등록" disabled={!isValid} />}
+          />
+          <FormHeader>
+            {/* TODO: 일기 템플릿 추가 */}
+            <ImageFileLabel
+              htmlFor="selectImageFile"
+              isPhotoActive={!isPhotoActive}
+            >
+              {isPhotoActive ? <PhotoInactiveIcon /> : <PhotoActiveIcon />}
+              사진 추가
+              <PhotoText isPhotoActive={!isPhotoActive}>(1장)</PhotoText>
+            </ImageFileLabel>
+            <ImageFileInput
+              type="file"
+              id="selectImageFile"
+              accept="image/*"
+              onChange={handleOnChangeImageFile}
             />
-          }
-          title={<HeaderTitle title={createdAtDate} fontWeight={700} />}
-          right={<HeaderRight type="등록" disabled={!isValid} />}
-        />
-        <FormHeader>
-          {/* TODO: 일기 템플릿 추가 */}
-          <ImageFileLabel
-            htmlFor="selectImageFile"
-            isPhotoActive={!isPhotoActive}
-          >
-            {isPhotoActive ? <PhotoInactiveIcon /> : <PhotoActiveIcon />}
-            사진 추가
-            <PhotoText isPhotoActive={!isPhotoActive}>(1장)</PhotoText>
-          </ImageFileLabel>
-          <ImageFileInput
-            type="file"
-            id="selectImageFile"
-            accept="image/*"
-            onChange={handleOnChangeImageFile}
-          />
-          <PublicLabel htmlFor="isPublic" isPublic={watchIsPublic}>
-            {watchIsPublic ? (
-              <>
-                <UnlockIcon />
-                공개
-              </>
-            ) : (
-              <>
-                <LockIcon />
-                비공개
-              </>
+            <PublicLabel htmlFor="isPublic" isPublic={watchIsPublic}>
+              {watchIsPublic ? (
+                <>
+                  <UnlockIcon />
+                  공개
+                </>
+              ) : (
+                <>
+                  <LockIcon />
+                  비공개
+                </>
+              )}
+            </PublicLabel>
+            <PublicCheckbox
+              id="isPublic"
+              type="checkbox"
+              {...register('isPublic')}
+            />
+          </FormHeader>
+          <ContentContainer>
+            <TitleTextarea
+              id="title"
+              placeholder="일기 제목을 작성해주세요."
+              rows={1}
+              {...register('title', {
+                required: true,
+                onChange: textareaAutosize,
+                setValueAs: (value: string) => value.trim(),
+              })}
+            />
+            {isPhotoActive && (
+              <PreviewImageContainer>
+                <ResponsiveImage src={previewImage} alt={watchTitle} />
+                <CancelImageButton
+                  type="button"
+                  aria-label="사진 선택 취소"
+                  onClick={handleCancelImage}
+                >
+                  <DeleteIcon />
+                </CancelImageButton>
+              </PreviewImageContainer>
             )}
-          </PublicLabel>
-          <PublicCheckbox
-            id="isPublic"
-            type="checkbox"
-            {...register('isPublic')}
-          />
-        </FormHeader>
-        <ContentContainer>
-          <TitleTextarea
-            id="title"
-            placeholder="일기 제목을 작성해주세요."
-            rows={1}
-            {...register('title', {
-              required: true,
-              onChange: textareaAutosize,
-              setValueAs: (value: string) => value.trim(),
-            })}
-          />
-          {isPhotoActive && (
-            <PreviewImageContainer>
-              <ResponsiveImage src={previewImage} alt={watchTitle} />
-              <CancelImageButton
-                type="button"
-                aria-label="사진 선택 취소"
-                onClick={handleCancelImage}
-              >
-                <DeleteIcon />
-              </CancelImageButton>
-            </PreviewImageContainer>
-          )}
-          <ContentTextarea
-            id="content"
-            placeholder="일기 내용을 작성해주세요."
-            rows={1}
-            {...register('content', {
-              required: true,
-              onChange: textareaAutosize,
-              setValueAs: (value: string) => value.trim(),
-            })}
-          />
-        </ContentContainer>
-      </form>
-    </Section>
+            <ContentTextarea
+              id="content"
+              placeholder="일기 내용을 작성해주세요."
+              rows={1}
+              {...register('content', {
+                required: true,
+                onChange: textareaAutosize,
+                setValueAs: (value: string) => value.trim(),
+              })}
+            />
+          </ContentContainer>
+        </form>
+      </Section>
+    </>
   );
 };
 
@@ -242,12 +245,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 };
 
 EditDiary.getLayout = function getLayout(page: ReactElement) {
-  return (
-    <Layout>
-      <Seo title="일기 편집 | a daily diary" />
-      {page}
-    </Layout>
-  );
+  return <Layout>{page}</Layout>;
 };
 
 export default EditDiary;

--- a/src/pages/diary/[id]/edit.tsx
+++ b/src/pages/diary/[id]/edit.tsx
@@ -5,9 +5,8 @@ import { useRouter } from 'next/router';
 import { getServerSession } from 'next-auth';
 import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
-import type { GetServerSideProps } from 'next';
-import type { NextPageWithLayout } from 'pages/_app';
-import type { ReactElement, ChangeEventHandler } from 'react';
+import type { GetServerSideProps, NextPage } from 'next';
+import type { ChangeEventHandler } from 'react';
 import type { SubmitHandler } from 'react-hook-form';
 import type { DiaryForm } from 'types/Diary';
 import type { ErrorResponse } from 'types/Response';
@@ -22,7 +21,6 @@ import {
 import ResponsiveImage from 'components/common/ResponsiveImage';
 import Seo from 'components/common/Seo';
 import {
-  Layout,
   Header,
   HeaderLeft,
   HeaderRight,
@@ -34,7 +32,7 @@ import { authOptions } from 'pages/api/auth/[...nextauth]';
 import { ScreenReaderOnly } from 'styles';
 import { dateFormat, errorResponseMessage, textareaAutosize } from 'utils';
 
-const EditDiary: NextPageWithLayout = () => {
+const EditDiary: NextPage = () => {
   const router = useRouter();
   const { id } = router.query;
   const { data, isLoading } = useQuery(
@@ -242,10 +240,6 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
       }),
   );
   return { props: { dehydratedState: dehydrate(queryClient) } };
-};
-
-EditDiary.getLayout = function getLayout(page: ReactElement) {
-  return <Layout>{page}</Layout>;
 };
 
 export default EditDiary;

--- a/src/pages/diary/[id]/index.tsx
+++ b/src/pages/diary/[id]/index.tsx
@@ -3,22 +3,20 @@ import { QueryClient, dehydrate } from '@tanstack/react-query';
 import { isAxiosError } from 'axios';
 import { useRouter } from 'next/router';
 import { getServerSession } from 'next-auth';
-import { type ReactElement } from 'react';
-import type { GetServerSideProps } from 'next';
-import type { NextPageWithLayout } from 'pages/_app';
+import type { GetServerSideProps, NextPage } from 'next';
 import type { ErrorResponse } from 'types/Response';
 import * as api from 'api';
 import { EditIcon, TrashIcon } from 'assets/icons';
 import FloatingMenu from 'components/common/FloatingMenu';
 import Seo from 'components/common/Seo';
-import { Layout, Header, HeaderLeft, HeaderRight } from 'components/layouts';
+import { Header, HeaderLeft, HeaderRight } from 'components/layouts';
 import DiaryCommentsContainer from 'containers/diary/DiaryCommentsContainer';
 import DiaryContainer from 'containers/diary/DiaryContainer';
 import { useClickOutside } from 'hooks';
 import { authOptions } from 'pages/api/auth/[...nextauth]';
 import { errorResponseMessage } from 'utils';
 
-const DiaryDetailPage: NextPageWithLayout = () => {
+const DiaryDetailPage: NextPage = () => {
   const router = useRouter();
   const { id } = router.query;
   const { ref, isVisible, setIsVisible } = useClickOutside();
@@ -103,10 +101,6 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
       }),
   );
   return { props: { dehydratedState: dehydrate(queryClient) } };
-};
-
-DiaryDetailPage.getLayout = (page: ReactElement) => {
-  return <Layout>{page}</Layout>;
 };
 
 export default DiaryDetailPage;

--- a/src/pages/diary/[id]/index.tsx
+++ b/src/pages/diary/[id]/index.tsx
@@ -39,37 +39,42 @@ const DiaryDetailPage: NextPageWithLayout = () => {
   };
 
   return (
-    <Section>
-      <Header>
-        <HeaderLeft type="이전" />
-        <HeaderRight
-          buttonRef={ref}
-          type="더보기"
-          onClick={() => {
-            setIsVisible((state) => !state);
-          }}
-        />
-        {isVisible && (
-          <FloatingMenu
-            items={[
-              {
-                icon: <EditIcon />,
-                label: '수정하기',
-                onClick: async () =>
-                  await router.push(`/diary/${id as string}/edit`), // TODO: 일기 수정하기 페이지 생성 후 라우터 수정
-              },
-              {
-                icon: <TrashIcon />,
-                label: '삭제하기',
-                onClick: handleDeleteDiary,
-              },
-            ]}
+    <>
+      <Seo title={'a daily diary'} />
+      <Header
+        left={<HeaderLeft type="이전" />}
+        right={
+          <HeaderRight
+            buttonRef={ref}
+            type="더보기"
+            onClick={() => {
+              setIsVisible((state) => !state);
+            }}
           />
-        )}
-      </Header>
-      <DiaryContainer />
-      <DiaryCommentsContainer />
-    </Section>
+        }
+      />
+      {isVisible && (
+        <FloatingMenu
+          items={[
+            {
+              icon: <EditIcon />,
+              label: '수정하기',
+              onClick: async () =>
+                await router.push(`/diary/${id as string}/edit`), // TODO: 일기 수정하기 페이지 생성 후 라우터 수정
+            },
+            {
+              icon: <TrashIcon />,
+              label: '삭제하기',
+              onClick: handleDeleteDiary,
+            },
+          ]}
+        />
+      )}
+      <Section>
+        <DiaryContainer />
+        <DiaryCommentsContainer />
+      </Section>
+    </>
   );
 };
 
@@ -101,12 +106,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 };
 
 DiaryDetailPage.getLayout = (page: ReactElement) => {
-  return (
-    <Layout>
-      <Seo title={'a daily diary'} />
-      {page}
-    </Layout>
-  );
+  return <Layout>{page}</Layout>;
 };
 
 export default DiaryDetailPage;

--- a/src/pages/diary/index.tsx
+++ b/src/pages/diary/index.tsx
@@ -3,8 +3,8 @@ import { isAxiosError } from 'axios';
 import { useRouter } from 'next/router';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
-import type { NextPageWithLayout } from 'pages/_app';
-import type { ReactElement, ChangeEventHandler } from 'react';
+import type { NextPage } from 'next';
+import type { ChangeEventHandler } from 'react';
 import type { SubmitHandler } from 'react-hook-form';
 import type { DiaryForm } from 'types/Diary';
 import type { ErrorResponse } from 'types/Response';
@@ -19,7 +19,6 @@ import {
 import ResponsiveImage from 'components/common/ResponsiveImage';
 import Seo from 'components/common/Seo';
 import {
-  Layout,
   Header,
   HeaderLeft,
   HeaderRight,
@@ -30,7 +29,7 @@ import { useBeforeLeave } from 'hooks';
 import { ScreenReaderOnly } from 'styles';
 import { dateFormat, errorResponseMessage, textareaAutosize } from 'utils';
 
-const WriteDiary: NextPageWithLayout = () => {
+const WriteDiary: NextPage = () => {
   const today = dateFormat(new Date().toISOString()) as string;
   const router = useRouter();
   const {
@@ -194,10 +193,6 @@ const WriteDiary: NextPageWithLayout = () => {
       </Section>
     </>
   );
-};
-
-WriteDiary.getLayout = function getLayout(page: ReactElement) {
-  return <Layout>{page}</Layout>;
 };
 
 export default WriteDiary;

--- a/src/pages/diary/index.tsx
+++ b/src/pages/diary/index.tsx
@@ -103,103 +103,101 @@ const WriteDiary: NextPageWithLayout = () => {
   };
 
   return (
-    <Section>
-      <Title>일기 작성</Title>
-      <form onSubmit={handleSubmit(onSubmit)}>
-        {/* NOTE: 등록 버튼을 사용하기 위해 form 요소 내에 Header가 존재함 */}
-        <Header
-          left={
-            <HeaderLeft
-              type="닫기"
-              onClick={() => {
-                router.back();
-              }}
+    <>
+      <Seo title="일기 작성 | a daily diary" />
+      <Section>
+        <Title>일기 작성</Title>
+        <form onSubmit={handleSubmit(onSubmit)}>
+          {/* NOTE: 등록 버튼을 사용하기 위해 form 요소 내에 Header가 존재함 */}
+          <Header
+            left={
+              <HeaderLeft
+                type="닫기"
+                onClick={() => {
+                  router.back();
+                }}
+              />
+            }
+            title={<HeaderTitle title={today} fontWeight={700} />}
+            right={<HeaderRight type="등록" disabled={!isValid} />}
+          />
+          <FormHeader>
+            {/* TODO: 일기 템플릿 추가 */}
+            <ImageFileLabel
+              htmlFor="selectImageFile"
+              isPhotoActive={!isPhotoActive}
+            >
+              {isPhotoActive ? <PhotoInactiveIcon /> : <PhotoActiveIcon />}
+              사진 추가
+              <PhotoText isPhotoActive={!isPhotoActive}>(1장)</PhotoText>
+            </ImageFileLabel>
+            <ImageFileInput
+              type="file"
+              id="selectImageFile"
+              accept="image/*"
+              onChange={handleOnChangeImageFile}
             />
-          }
-          title={<HeaderTitle title={today} fontWeight={700} />}
-          right={<HeaderRight type="등록" disabled={!isValid} />}
-        />
-        <FormHeader>
-          {/* TODO: 일기 템플릿 추가 */}
-          <ImageFileLabel
-            htmlFor="selectImageFile"
-            isPhotoActive={!isPhotoActive}
-          >
-            {isPhotoActive ? <PhotoInactiveIcon /> : <PhotoActiveIcon />}
-            사진 추가
-            <PhotoText isPhotoActive={!isPhotoActive}>(1장)</PhotoText>
-          </ImageFileLabel>
-          <ImageFileInput
-            type="file"
-            id="selectImageFile"
-            accept="image/*"
-            onChange={handleOnChangeImageFile}
-          />
-          <PublicLabel htmlFor="isPublic" isPublic={watchIsPublic}>
-            {watchIsPublic ? (
-              <>
-                <UnlockIcon />
-                공개
-              </>
-            ) : (
-              <>
-                <LockIcon />
-                비공개
-              </>
+            <PublicLabel htmlFor="isPublic" isPublic={watchIsPublic}>
+              {watchIsPublic ? (
+                <>
+                  <UnlockIcon />
+                  공개
+                </>
+              ) : (
+                <>
+                  <LockIcon />
+                  비공개
+                </>
+              )}
+            </PublicLabel>
+            <PublicCheckbox
+              id="isPublic"
+              type="checkbox"
+              {...register('isPublic')}
+            />
+          </FormHeader>
+          <ContentContainer>
+            <TitleTextarea
+              id="title"
+              placeholder="일기 제목을 작성해주세요."
+              rows={1}
+              {...register('title', {
+                required: true,
+                onChange: textareaAutosize,
+                setValueAs: (value: string) => value.trim(),
+              })}
+            />
+            {isPhotoActive && (
+              <PreviewImageContainer>
+                <ResponsiveImage src={previewImage} alt={watchTitle} />
+                <CancelImageButton
+                  type="button"
+                  aria-label="사진 선택 취소"
+                  onClick={handleCancelImage}
+                >
+                  <DeleteIcon />
+                </CancelImageButton>
+              </PreviewImageContainer>
             )}
-          </PublicLabel>
-          <PublicCheckbox
-            id="isPublic"
-            type="checkbox"
-            {...register('isPublic')}
-          />
-        </FormHeader>
-        <ContentContainer>
-          <TitleTextarea
-            id="title"
-            placeholder="일기 제목을 작성해주세요."
-            rows={1}
-            {...register('title', {
-              required: true,
-              onChange: textareaAutosize,
-              setValueAs: (value: string) => value.trim(),
-            })}
-          />
-          {isPhotoActive && (
-            <PreviewImageContainer>
-              <ResponsiveImage src={previewImage} alt={watchTitle} />
-              <CancelImageButton
-                type="button"
-                aria-label="사진 선택 취소"
-                onClick={handleCancelImage}
-              >
-                <DeleteIcon />
-              </CancelImageButton>
-            </PreviewImageContainer>
-          )}
-          <ContentTextarea
-            id="content"
-            placeholder="일기 내용을 작성해주세요."
-            rows={1}
-            {...register('content', {
-              required: true,
-              onChange: textareaAutosize,
-              setValueAs: (value: string) => value.trim(),
-            })}
-          />
-        </ContentContainer>
-      </form>
-    </Section>
+            <ContentTextarea
+              id="content"
+              placeholder="일기 내용을 작성해주세요."
+              rows={1}
+              {...register('content', {
+                required: true,
+                onChange: textareaAutosize,
+                setValueAs: (value: string) => value.trim(),
+              })}
+            />
+          </ContentContainer>
+        </form>
+      </Section>
+    </>
   );
 };
 
 WriteDiary.getLayout = function getLayout(page: ReactElement) {
-  return (
-    <Layout>
-      <Seo title="일기 작성 | a daily diary" />
-      {page}
-    </Layout>
-  );
+  return <Layout>{page}</Layout>;
 };
 
 export default WriteDiary;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -16,6 +16,11 @@ import {
 const Home: NextPageWithLayout = () => {
   return (
     <>
+      <Seo title={'a daily diary'} />
+      <Header
+        left={<HeaderLeft type="로고" />}
+        right={<HeaderRight type="검색" />}
+      />
       <BannerContainer>
         <Link href={'/write'}>
           <ResponsiveImage
@@ -33,11 +38,6 @@ const Home: NextPageWithLayout = () => {
 Home.getLayout = function getLayout(page: ReactElement) {
   return (
     <Layout>
-      <Seo title={'a daily diary'} />
-      <Header
-        left={<HeaderLeft type="로고" />}
-        right={<HeaderRight type="검색" />}
-      />
       {page}
       <Navbar />
     </Layout>
@@ -47,5 +47,6 @@ Home.getLayout = function getLayout(page: ReactElement) {
 export default Home;
 
 const BannerContainer = styled.div`
+  margin-top: 54px;
   padding: 12px 20px 0;
 `;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,19 +1,12 @@
 import styled from '@emotion/styled';
 import Link from 'next/link';
-import type { NextPageWithLayout } from './_app';
-import type { ReactElement } from 'react';
+import type { NextPage } from 'next';
 import ResponsiveImage from 'components/common/ResponsiveImage';
 import Seo from 'components/common/Seo';
 import DiaryList from 'components/diary/DiaryList';
-import {
-  Header,
-  HeaderLeft,
-  HeaderRight,
-  Layout,
-  Navbar,
-} from 'components/layouts';
+import { Header, HeaderLeft, HeaderRight } from 'components/layouts';
 
-const Home: NextPageWithLayout = () => {
+const Home: NextPage = () => {
   return (
     <>
       <Seo title={'a daily diary'} />
@@ -32,15 +25,6 @@ const Home: NextPageWithLayout = () => {
       </BannerContainer>
       <DiaryList />
     </>
-  );
-};
-
-Home.getLayout = function getLayout(page: ReactElement) {
-  return (
-    <Layout>
-      {page}
-      <Navbar />
-    </Layout>
   );
 };
 

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -23,6 +23,7 @@ const Profile: NextPageWithLayout = () => {
 
   return (
     <>
+      <Seo title="프로필 | a daily diary" />
       <UserInfoContainer>
         <SettingLink href={'/setting'}>
           <SettingIcon />
@@ -73,7 +74,6 @@ const Profile: NextPageWithLayout = () => {
 Profile.getLayout = function getLayout(page: ReactElement) {
   return (
     <Layout>
-      <Seo title="프로필 | a daily diary" />
       {page}
       <Navbar />
     </Layout>

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -1,12 +1,10 @@
 import styled from '@emotion/styled';
 import Link from 'next/link';
 import { useRef, useState } from 'react';
-import type { NextPageWithLayout } from 'pages/_app';
-import type { ReactElement } from 'react';
+import type { NextPage } from 'next';
 import { SettingIcon } from 'assets/icons';
 import Seo from 'components/common/Seo';
 import Tab from 'components/common/Tab';
-import { Layout, Navbar } from 'components/layouts';
 import Empty from 'components/profile/Empty';
 import { useTabIndicator } from 'hooks';
 
@@ -16,7 +14,7 @@ const PROFILE_TAB_LIST = [
   { id: 'bookmarks', title: '북마크', content: null },
 ];
 
-const Profile: NextPageWithLayout = () => {
+const Profile: NextPage = () => {
   const [activeIndex, setActiveIndex] = useState<number>(0);
   const tabsRef = useRef<Array<HTMLButtonElement | null>>([]);
   const indicator = useTabIndicator({ tabsRef, activeIndex });
@@ -68,15 +66,6 @@ const Profile: NextPageWithLayout = () => {
         </article>
       </section>
     </>
-  );
-};
-
-Profile.getLayout = function getLayout(page: ReactElement) {
-  return (
-    <Layout>
-      {page}
-      <Navbar />
-    </Layout>
   );
 };
 

--- a/src/types/next.d.ts
+++ b/src/types/next.d.ts
@@ -1,0 +1,18 @@
+import type { DehydratedState } from '@tanstack/react-query';
+import type { NextComponentType, NextPageContext } from 'next';
+import type { Router } from 'next/router';
+import type { Session } from 'next-auth';
+
+declare module 'next/app' {
+  interface AppProps<P = Record<string, unknown>> {
+    Component: NextComponentType<NextPageContext, any, P>;
+    router: Router;
+    __N_SSG?: boolean;
+    __N_SSP?: boolean;
+    pageProps: P & {
+      /** Initial session passed in from `getServerSideProps` or `getInitialProps` */
+      session?: Session;
+      dehydratedState: DehydratedState;
+    };
+  }
+}


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #129

<br />

## 🗒 작업 목록

- [x] Header, Seo 컴포넌트 코드 위치 변경
- [x] getLayout 제거 및 next.d.ts 타입 선언 병합
  - _app에 적용된 getLayout 코드 제거
  - getLayout 적용된 각 페이지 수정
  - next-auth, react-query를 위한 next.d.ts 타입 선언 
- [x] pathname에 따라 Navbar 보여지는 Layout 적용 

<br />

## 🧐 PR Point

- Header 컴포넌트에 특정 이벤트나 데이터를 전달해야하는 경우, getLayout 내에서 전달하는 것이 어려워 페이지 코드에 Header 컴포넌트를 적용해야하는 경우 발생했습니다.
- 따라서 Header 컴포넌트를 페이지 코드로 이동하면 getLayout이 필요없는 경우가 많아져 getLayout을 제거하였습니다.
- 공통 Layout을 적용하고, pathname에 따라 Navbar를 노출여부를 적용하였습니다.
- getLayout을 적용하면서 관련 타입 정의를 _app 내에 작성하였으나, 코드를 수정하면서 타입을 next.d.ts에 정의하여 가독성을 높였습니다.

<br />

## 💥 Trouble Shooting
- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크

- 내용을 입력해주세요.

<br />

## 📚 참고

- [next-auth-typescript-example](https://github.com/nextauthjs/next-auth-typescript-example/blob/main/types/next.d.ts)

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다. 
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
