### PR TITLE
일기 상세 페이지 > 작성자가 아닌 경우 신고하기 메뉴 보여주기

### DIFF
--- a/src/containers/diary/DiaryContainer.tsx
+++ b/src/containers/diary/DiaryContainer.tsx
@@ -26,7 +26,7 @@ const DiaryContainer = ({
     <Container>
       <AuthorContainer>
         {author.imgUrl !== null && (
-          // TODO
+          // TODO:
           // 1. 유저 프로필 이미지 클릭 시 해당 프로필로 이동
           // 2. 프로필 이미지 컴포넌트 분리
           <AuthorImageContainer>
@@ -43,12 +43,11 @@ const DiaryContainer = ({
       </AuthorContainer>
       <ContentContainer>
         <Title>{title}</Title>
-        {/* NOTE: 잘못된 이미지 데이터로 인해 문제 해결 후 주석 해제 */}
-        {/* {imgUrl !== null && (
+        {imgUrl !== null && (
           <ImageContainer>
             <ResponsiveImage src={imgUrl} alt={title} />
           </ImageContainer>
-        )} */}
+        )}
         <Content>{content}</Content>
         {timeFormat(createdAt) !== null && (
           <TimeContainer>{timeFormat(createdAt)}</TimeContainer>

--- a/src/containers/diary/DiaryContainer.tsx
+++ b/src/containers/diary/DiaryContainer.tsx
@@ -1,8 +1,6 @@
 import styled from '@emotion/styled';
-import { useQuery } from '@tanstack/react-query';
 import Image from 'next/image';
-import { useRouter } from 'next/router';
-import * as api from 'api';
+import type { DiaryDetail } from 'types/Diary';
 import {
   BookmarkOffIcon,
   BookmarkOnIcon,
@@ -13,29 +11,17 @@ import {
 import ResponsiveImage from 'components/common/ResponsiveImage';
 import { dateFormat, timeFormat } from 'utils';
 
-const DiaryContainer = () => {
-  const router = useRouter();
-  const { id } = router.query;
-  const { data, isLoading } = useQuery(
-    ['diary-detail', id],
-    async () => await api.getDiaryDetail(id as string),
-  );
-
-  if (data === undefined) return <div />;
-  if (isLoading) return <div>Loading</div>;
-
-  const {
-    title,
-    content,
-    imgUrl,
-    favoriteCount,
-    commentCount,
-    createdAt,
-    author,
-    isBookmark,
-    isFavorite,
-  } = data;
-
+const DiaryContainer = ({
+  title,
+  content,
+  imgUrl,
+  favoriteCount,
+  commentCount,
+  createdAt,
+  author,
+  isBookmark,
+  isFavorite,
+}: DiaryDetail) => {
   return (
     <Container>
       <AuthorContainer>
@@ -60,10 +46,7 @@ const DiaryContainer = () => {
         {/* NOTE: 잘못된 이미지 데이터로 인해 문제 해결 후 주석 해제 */}
         {/* {imgUrl !== null && (
           <ImageContainer>
-            <ResponsiveImage
-              src={imgUrl}
-              alt={title}
-            />
+            <ResponsiveImage src={imgUrl} alt={title} />
           </ImageContainer>
         )} */}
         <Content>{content}</Content>

--- a/src/pages/diary/[id]/index.tsx
+++ b/src/pages/diary/[id]/index.tsx
@@ -44,12 +44,12 @@ const DiaryDetailPage: NextPage = () => {
   if (data === undefined) return <div />;
   if (isLoading) return <div>Loading</div>;
 
-  const { author } = data;
+  const { author, title } = data;
   const isAuthor = author.id === session?.user.id;
 
   return (
     <>
-      <Seo title={'a daily diary'} />
+      <Seo title={`${title} | a daily diary`} />
       <Header
         left={<HeaderLeft type="이전" />}
         right={

--- a/src/pages/diary/[id]/index.tsx
+++ b/src/pages/diary/[id]/index.tsx
@@ -1,12 +1,13 @@
 import styled from '@emotion/styled';
-import { QueryClient, dehydrate } from '@tanstack/react-query';
+import { QueryClient, dehydrate, useQuery } from '@tanstack/react-query';
 import { isAxiosError } from 'axios';
 import { useRouter } from 'next/router';
 import { getServerSession } from 'next-auth';
+import { useSession } from 'next-auth/react';
 import type { GetServerSideProps, NextPage } from 'next';
 import type { ErrorResponse } from 'types/Response';
 import * as api from 'api';
-import { EditIcon, TrashIcon } from 'assets/icons';
+import { EditIcon, ReportIcon, TrashIcon } from 'assets/icons';
 import FloatingMenu from 'components/common/FloatingMenu';
 import Seo from 'components/common/Seo';
 import { Header, HeaderLeft, HeaderRight } from 'components/layouts';
@@ -19,6 +20,11 @@ const DiaryDetailPage: NextPage = () => {
   const router = useRouter();
   const { id } = router.query;
   const { ref, isVisible, setIsVisible } = useClickOutside();
+  const { data, isLoading } = useQuery(
+    ['diary-detail', id],
+    async () => await api.getDiaryDetail(id as string),
+  );
+  const { data: session } = useSession();
 
   const handleDeleteDiary = async () => {
     if (confirm('삭제하시겠습니까?')) {
@@ -34,6 +40,12 @@ const DiaryDetailPage: NextPage = () => {
       }
     }
   };
+
+  if (data === undefined) return <div />;
+  if (isLoading) return <div>Loading</div>;
+
+  const { author } = data;
+  const isAuthor = author.id === session?.user.id;
 
   return (
     <>
@@ -52,23 +64,35 @@ const DiaryDetailPage: NextPage = () => {
       />
       {isVisible && (
         <FloatingMenu
-          items={[
-            {
-              icon: <EditIcon />,
-              label: '수정하기',
-              onClick: async () =>
-                await router.push(`/diary/${id as string}/edit`), // TODO: 일기 수정하기 페이지 생성 후 라우터 수정
-            },
-            {
-              icon: <TrashIcon />,
-              label: '삭제하기',
-              onClick: handleDeleteDiary,
-            },
-          ]}
+          items={
+            isAuthor
+              ? [
+                  {
+                    icon: <EditIcon />,
+                    label: '수정하기',
+                    onClick: async () =>
+                      await router.push(`/diary/${id as string}/edit`), // TODO: 일기 수정하기 페이지 생성 후 라우터 수정
+                  },
+                  {
+                    icon: <TrashIcon />,
+                    label: '삭제하기',
+                    onClick: handleDeleteDiary,
+                  },
+                ]
+              : [
+                  {
+                    icon: <ReportIcon />,
+                    label: '신고하기',
+                    onClick: () => {
+                      confirm('신고하시겠습니까?');
+                    }, // TODO: 일기 수정하기 페이지 생성 후 라우터 수정
+                  },
+                ]
+          }
         />
       )}
       <Section>
-        <DiaryContainer />
+        <DiaryContainer {...data} />
         <DiaryCommentsContainer />
       </Section>
     </>


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #134

<br />

## 🗒 작업 목록

- [x] 일기 작성자가 아닌 경우 신고하기 FloatingMenu 보여주기
- [x] 일기 상세의 잘못된 이미지 데이터로 인해 주석처리 했던 코드 주석 해제
- [x] 일기 상세 페이지의 Seo title에 일기 제목 적용

<br />

## 🧐 PR Point

- 일기 작성자가 아닌 경우 신고하기 메뉴가 FloatingMenu에 나타날 수 있도록 분기처리 했습니다.
  - 이를 적용하기 위해 DiaryContainer 컴포넌트에서 불러오던 데이터를 일기 상세 페이지에서 데이터를 불러오도록 수정하였습니다. 

**아래의 작업들은 해당 브랜치와 연관성이 낮은 작업이지만 일기 상세 페이지와 연관된 작업이고,  작업의 크기가 작아 함께 진행했습니다.
- 이 전 일기 작성 기능 구현시 잘못 넣어진 이미지 데이터로 인해 오류가 발생해여 이미지를 보여주는 코드를 주석처리 했었습니다.
  - 현재는 DB가 리셋되어 문제있던 데이터들이 삭제되었으므로 주석을 해제하였습니다. 
- 일기 상세 페이지의 Seo title에 해당 일기의 제목을 적용하였습니다.

<br />

## 💥 Trouble Shooting
- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크

- 내용을 입력해주세요.

<br />

## 📚 참고

- 참고한 내용 또는 링크를 입력해주세요.

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다. 
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
