### PR TITLE
댓글 조회, 작성, 삭제 기능 구현

### DIFF
--- a/src/api/bookmark.ts
+++ b/src/api/bookmark.ts
@@ -1,0 +1,23 @@
+import type { OnlyMessageResponse, SuccessResponse } from 'types/Response';
+import { API_PATH } from 'constants/api/path';
+import axios from 'lib/axios';
+
+export const bookmarkDiary = async (diaryId: string) => {
+  const {
+    data: { data },
+  } = await axios.post<SuccessResponse<OnlyMessageResponse>>(
+    `${API_PATH.diaries.index}/${diaryId}/bookmark`,
+  );
+  return data;
+};
+
+export const cancelBookmarkDiary = async (diaryId: string) => {
+  const {
+    data: {
+      data: { message },
+    },
+  } = await axios.delete<SuccessResponse<OnlyMessageResponse>>(
+    `${API_PATH.diaries.index}/${diaryId}/bookmark`,
+  );
+  return message;
+};

--- a/src/api/comments.ts
+++ b/src/api/comments.ts
@@ -1,8 +1,26 @@
 import type { AxiosRequestConfig } from 'axios';
-import type { CommentRequest, CommentResponse, Comments } from 'types/Comment';
-import type { SuccessResponse } from 'types/Response';
+import type {
+  CommentRequest,
+  CommentResponse,
+  Comments,
+  DeleteCommentRequest,
+} from 'types/Comment';
+import type { OnlyMessageResponse, SuccessResponse } from 'types/Response';
 import { API_PATH } from 'constants/api/path';
 import axios from 'lib/axios';
+
+export const getComments = async (
+  diaryId: string,
+  config?: AxiosRequestConfig,
+) => {
+  const {
+    data: { data },
+  } = await axios.get<SuccessResponse<Comments>>(
+    `${API_PATH.diaries.index}/${diaryId}/comment`,
+    config,
+  );
+  return data;
+};
 
 export const writeComment = async ({ diaryId, comment }: CommentRequest) => {
   const {
@@ -17,15 +35,16 @@ export const writeComment = async ({ diaryId, comment }: CommentRequest) => {
   return data;
 };
 
-export const getComments = async (
-  diaryId: string,
-  config?: AxiosRequestConfig,
-) => {
+export const deleteComments = async ({
+  diaryId,
+  commentId,
+}: DeleteCommentRequest) => {
   const {
-    data: { data },
-  } = await axios.get<SuccessResponse<Comments>>(
-    `${API_PATH.diaries.index}/${diaryId}/comment`,
-    config,
+    data: {
+      data: { message },
+    },
+  } = await axios.delete<SuccessResponse<OnlyMessageResponse>>(
+    `${API_PATH.diaries.index}/${diaryId}/comment/${commentId}`,
   );
-  return data;
+  return message;
 };

--- a/src/api/comments.ts
+++ b/src/api/comments.ts
@@ -1,9 +1,21 @@
 import type { AxiosRequestConfig } from 'axios';
-
-import type { Comments } from 'types/Comment';
+import type { CommentRequest, CommentResponse, Comments } from 'types/Comment';
 import type { SuccessResponse } from 'types/Response';
 import { API_PATH } from 'constants/api/path';
 import axios from 'lib/axios';
+
+export const writeComment = async ({ diaryId, comment }: CommentRequest) => {
+  const {
+    data: { data },
+  } = await axios.post<SuccessResponse<CommentResponse>>(
+    `${API_PATH.diaries.index}/${diaryId}/comment`,
+    {
+      diaryId,
+      comment,
+    },
+  );
+  return data;
+};
 
 export const getComments = async (
   diaryId: string,

--- a/src/api/comments.ts
+++ b/src/api/comments.ts
@@ -1,0 +1,19 @@
+import type { AxiosRequestConfig } from 'axios';
+
+import type { Comments } from 'types/Comment';
+import type { SuccessResponse } from 'types/Response';
+import { API_PATH } from 'constants/api/path';
+import axios from 'lib/axios';
+
+export const getComments = async (
+  diaryId: string,
+  config?: AxiosRequestConfig,
+) => {
+  const {
+    data: { data },
+  } = await axios.get<SuccessResponse<Comments>>(
+    `${API_PATH.diaries.index}/${diaryId}/comment`,
+    config,
+  );
+  return data;
+};

--- a/src/api/favorite.ts
+++ b/src/api/favorite.ts
@@ -1,0 +1,23 @@
+import type { OnlyMessageResponse, SuccessResponse } from 'types/Response';
+import { API_PATH } from 'constants/api/path';
+import axios from 'lib/axios';
+
+export const favoriteDiary = async (diaryId: string) => {
+  const {
+    data: { data },
+  } = await axios.post<SuccessResponse<OnlyMessageResponse>>(
+    `${API_PATH.diaries.index}/${diaryId}/favorite`,
+  );
+  return data;
+};
+
+export const cancelFavoriteDiary = async (diaryId: string) => {
+  const {
+    data: {
+      data: { message },
+    },
+  } = await axios.delete<SuccessResponse<OnlyMessageResponse>>(
+    `${API_PATH.diaries.index}/${diaryId}/favorite`,
+  );
+  return message;
+};

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -4,3 +4,4 @@ export * from './termsAgreements';
 export * from './diaries';
 export * from './comments';
 export * from './favorite';
+export * from './bookmark';

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -2,3 +2,4 @@ export * from './image';
 export * from './users';
 export * from './termsAgreements';
 export * from './diaries';
+export * from './comments';

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -3,3 +3,4 @@ export * from './users';
 export * from './termsAgreements';
 export * from './diaries';
 export * from './comments';
+export * from './favorite';

--- a/src/components/common/FloatingMenu.tsx
+++ b/src/components/common/FloatingMenu.tsx
@@ -25,7 +25,7 @@ const FloatingMenu = ({ items }: FloatingMenuProps) => {
 export default FloatingMenu;
 
 const List = styled.ul`
-  position: fixed;
+  position: absolute;
   top: 40px;
   right: 20px;
   z-index: ${Z_INDEX.dialog};

--- a/src/components/diary/Diary.tsx
+++ b/src/components/diary/Diary.tsx
@@ -10,7 +10,7 @@ import {
   HeartOffIcon,
 } from 'assets/icons';
 import ResponsiveImage from 'components/common/ResponsiveImage';
-import { useHandleFavorite } from 'hooks/common';
+import { useHandleFavorite, useHandleBookmark } from 'hooks/common';
 import { EllipsisStyle } from 'styles';
 import { dateFormat, timeFormat } from 'utils';
 
@@ -27,6 +27,7 @@ const Diary = ({
   author,
 }: DiaryDetail) => {
   const handleFavorite = useHandleFavorite({ isFavorite, id });
+  const handleBookmark = useHandleBookmark({ isBookmark, id });
 
   return (
     <Container>
@@ -56,7 +57,7 @@ const Diary = ({
             {commentCount}
           </CommentLink>
         </IconInnerContainer>
-        <button type="button">
+        <button type="button" onClick={handleBookmark}>
           {isBookmark ? <BookmarkOnIcon /> : <BookmarkOffIcon />}
         </button>
       </IconContainer>

--- a/src/components/diary/Diary.tsx
+++ b/src/components/diary/Diary.tsx
@@ -10,6 +10,7 @@ import {
   HeartOffIcon,
 } from 'assets/icons';
 import ResponsiveImage from 'components/common/ResponsiveImage';
+import { useHandleFavorite } from 'hooks/common';
 import { EllipsisStyle } from 'styles';
 import { dateFormat, timeFormat } from 'utils';
 
@@ -25,6 +26,8 @@ const Diary = ({
   createdAt,
   author,
 }: DiaryDetail) => {
+  const handleFavorite = useHandleFavorite({ isFavorite, id });
+
   return (
     <Container>
       <ContentContainer>
@@ -44,7 +47,7 @@ const Diary = ({
       </ContentContainer>
       <IconContainer>
         <IconInnerContainer>
-          <FavoriteButton type="button">
+          <FavoriteButton type="button" onClick={handleFavorite}>
             {isFavorite ? <HeartOnIcon /> : <HeartOffIcon />}
             {favoriteCount}
           </FavoriteButton>

--- a/src/components/diary/DiaryComment.tsx
+++ b/src/components/diary/DiaryComment.tsx
@@ -1,39 +1,22 @@
 import styled from '@emotion/styled';
 import Image from 'next/image';
+import type { Comment } from 'types/Comment';
 import { MoreIcon } from 'assets/icons';
 import { timeFormat, dateFormat } from 'utils';
 
-interface CommentProps {
-  comment: {
-    id: number;
-    authorUsername: string;
-    authorThumbnailUrl: string;
-    content: string;
-    createdAt: string;
-    modifiedAt: string;
-  };
-}
-
-const DiaryComment = ({ comment }: CommentProps) => {
-  const { authorUsername, authorThumbnailUrl, content, createdAt } = comment;
-
+const DiaryComment = ({ id, createdAt, comment, commenter }: Comment) => {
   return (
     <CommentItem>
       <CommentHead>
-        {authorThumbnailUrl !== null && (
-          // TODO
-          // 1. 유저 프로필 이미지 클릭 시 해당 프로필로 이동
-          // 2. 프로필 이미지 컴포넌트 분리
-          <ProfileImageBox>
-            <Image
-              src={authorThumbnailUrl}
-              alt={authorUsername}
-              width={20}
-              height={20}
-            />
-          </ProfileImageBox>
-        )}
-        <UsernameSpan>{authorUsername}</UsernameSpan>
+        <ProfileImageBox>
+          <Image
+            src={commenter.imgUrl}
+            alt={commenter.username}
+            width={20}
+            height={20}
+          />
+        </ProfileImageBox>
+        <UsernameSpan>{commenter.username}</UsernameSpan>
         <CreatedAtSpan>
           {timeFormat(createdAt) !== null
             ? timeFormat(createdAt)
@@ -43,7 +26,7 @@ const DiaryComment = ({ comment }: CommentProps) => {
           <StyledMoreIcon />
         </MoreButton>
       </CommentHead>
-      <CommentContent>{content}</CommentContent>
+      <CommentContent>{comment}</CommentContent>
     </CommentItem>
   );
 };
@@ -56,7 +39,7 @@ const CommentItem = styled.li`
 
   &:focus-within {
     /* TODO: color constant에 추가하기 */
-    background-color: #f5fdf7;
+    background-color: ${({ theme }) => theme.colors.primary_04};
   }
 
   &::after {

--- a/src/components/diary/DiaryCommentInput.tsx
+++ b/src/components/diary/DiaryCommentInput.tsx
@@ -10,7 +10,7 @@ import { SendActiveIcon, SendInactiveIcon } from 'assets/icons';
 import { Z_INDEX } from 'constants/styles';
 import { ERROR_MESSAGE } from 'constants/validation/Message';
 import { VALID_VALUE } from 'constants/validation/Value';
-import { useWriteComment } from 'hooks/services/mutations/useWriteComment';
+import { useWriteComment } from 'hooks/services';
 import { SVGVerticalAlignStyle } from 'styles';
 import { errorResponseMessage, textareaAutosize } from 'utils';
 

--- a/src/components/diary/DiaryCommentInput.tsx
+++ b/src/components/diary/DiaryCommentInput.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import { useRouter } from 'next/router';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { SendActiveIcon, SendInactiveIcon } from 'assets/icons';
 import { Z_INDEX } from 'constants/styles';
@@ -20,17 +20,15 @@ const DiaryCommentInput = () => {
     setValue,
     getValues,
     setFocus,
-    formState: { errors },
+    formState: { errors, isValid },
   } = useForm<DiaryCommentInputProps>({ mode: 'onChange' });
   const { content: contentValue } = getValues();
   const { content: contentError } = errors;
 
-  // TODO: react-hook-form 연결하기
-  const [isActiveSendButton, setIsActiveSendButton] = useState<boolean>(false);
-
   useEffect(() => {
     if (contentError?.type === 'maxLength') {
       setValue('content', contentValue.slice(0, VALID_VALUE.commentMaxLength));
+      // TODO: 모달로 수정하기
       alert(contentError.message);
     }
   }, [contentError]);
@@ -42,13 +40,14 @@ const DiaryCommentInput = () => {
   }, [setFocus]);
 
   return (
-    <CommentInputContainer>
-      <CommentForm>
-        <CommentTextarea
+    <Container>
+      <Form>
+        <Textarea
           id="diaryCommentTextarea"
           placeholder="댓글을 입력해주세요."
           rows={1}
           {...register('content', {
+            required: true,
             maxLength: {
               value: VALID_VALUE.commentMaxLength,
               message: ERROR_MESSAGE.commentMaxLength,
@@ -56,17 +55,17 @@ const DiaryCommentInput = () => {
             onChange: textareaAutosize,
           })}
         />
-        <CommentSendButton type="submit">
-          {isActiveSendButton ? <SendActiveIcon /> : <SendInactiveIcon />}
-        </CommentSendButton>
-      </CommentForm>
-    </CommentInputContainer>
+        <SubmitButton type="submit" disabled={!isValid}>
+          {isValid ? <SendActiveIcon /> : <SendInactiveIcon />}
+        </SubmitButton>
+      </Form>
+    </Container>
   );
 };
 
 export default DiaryCommentInput;
 
-const CommentInputContainer = styled.div`
+const Container = styled.div`
   position: fixed;
   right: 0;
   bottom: 0;
@@ -77,25 +76,27 @@ const CommentInputContainer = styled.div`
   background-color: ${({ theme }) => theme.colors.white};
 `;
 
-const CommentForm = styled.form`
+const Form = styled.form`
   display: grid;
   grid-template-columns: auto 20px;
   align-items: center;
+  gap: 8px;
   padding: 7px 12px 7px 14px;
-  border-radius: 34px;
+  border-radius: 17px;
   background-color: ${({ theme }) => theme.colors.bg_01};
 `;
 
-const CommentTextarea = styled.textarea`
+const Textarea = styled.textarea`
   max-height: 79px;
   color: ${({ theme }) => theme.colors.gray_00};
   ${({ theme }) => theme.fonts.body_07};
+  word-break: keep-all;
 
   &::placeholder {
     color: ${({ theme }) => theme.colors.gray_02};
   }
 `;
 
-const CommentSendButton = styled.button`
+const SubmitButton = styled.button`
   ${SVGVerticalAlignStyle}
 `;

--- a/src/components/diary/DiaryComments.tsx
+++ b/src/components/diary/DiaryComments.tsx
@@ -3,7 +3,13 @@ import DiaryComment from './DiaryComment';
 import type { Comments } from 'types/Comment';
 import { ScreenReaderOnly } from 'styles';
 
-const DiaryComments = ({ comments, totalCount }: Comments) => {
+interface DiaryCommentsProps {
+  diaryComments: Comments;
+  diaryId: string;
+}
+
+const DiaryComments = ({ diaryComments, diaryId }: DiaryCommentsProps) => {
+  const { comments, totalCount } = diaryComments;
   return (
     <>
       {totalCount > 0 ? (
@@ -14,7 +20,8 @@ const DiaryComments = ({ comments, totalCount }: Comments) => {
               return (
                 <DiaryComment
                   key={`diary-comment-${comment.id}`}
-                  {...comment}
+                  diaryComment={comment}
+                  diaryId={diaryId}
                 />
               );
             })}

--- a/src/components/diary/DiaryComments.tsx
+++ b/src/components/diary/DiaryComments.tsx
@@ -1,35 +1,20 @@
 import styled from '@emotion/styled';
 import DiaryComment from './DiaryComment';
+import type { Comments } from 'types/Comment';
 import { ScreenReaderOnly } from 'styles';
 
-// TODO: 타입 디렉토리에 분리하기
-interface CommentProps {
-  id: number;
-  authorUsername: string;
-  authorThumbnailUrl: string;
-  content: string;
-  createdAt: string;
-  modifiedAt: string;
-}
-
-interface CommentsProps {
-  comments: CommentProps[];
-}
-
-const DiaryComments = ({ comments }: CommentsProps) => {
-  const commentsCount = comments.length;
-
+const DiaryComments = ({ comments, totalCount }: Comments) => {
   return (
     <>
-      {commentsCount > 0 ? (
+      {totalCount > 0 ? (
         <>
-          <CommentTitle>{commentsCount}개의 댓글</CommentTitle>
+          <CommentTitle>{totalCount}개의 댓글</CommentTitle>
           <ul>
             {comments.map((comment) => {
               return (
                 <DiaryComment
                   key={`diary-comment-${comment.id}`}
-                  comment={comment}
+                  {...comment}
                 />
               );
             })}

--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -1,0 +1,9 @@
+export const queryKeys = {
+  badges: 'badges',
+  bookmark: 'bookmark',
+  comment: 'comment',
+  diaries: 'diaries',
+  favorite: 'favorite',
+  terms: 'terms-agreements',
+  users: 'users',
+} as const;

--- a/src/containers/diary/DiaryCommentsContainer.tsx
+++ b/src/containers/diary/DiaryCommentsContainer.tsx
@@ -19,7 +19,7 @@ const DiaryCommentsContainer = ({ diaryId }: DiaryCommentsContainerProps) => {
 
   return (
     <DiaryCommentSection>
-      <DiaryComments {...data} />
+      <DiaryComments diaryComments={data} diaryId={diaryId} />
       <WriteCommentLabel htmlFor="diaryCommentTextarea">
         <WriteCommentIcon />
         <WriteCommentSpan>댓글쓰기</WriteCommentSpan>

--- a/src/containers/diary/DiaryCommentsContainer.tsx
+++ b/src/containers/diary/DiaryCommentsContainer.tsx
@@ -24,7 +24,7 @@ const DiaryCommentsContainer = ({ diaryId }: DiaryCommentsContainerProps) => {
         <WriteCommentIcon />
         <WriteCommentSpan>댓글쓰기</WriteCommentSpan>
       </WriteCommentLabel>
-      <DiaryCommentInput />
+      <DiaryCommentInput diaryId={diaryId} />
     </DiaryCommentSection>
   );
 };

--- a/src/containers/diary/DiaryCommentsContainer.tsx
+++ b/src/containers/diary/DiaryCommentsContainer.tsx
@@ -1,30 +1,25 @@
 import styled from '@emotion/styled';
-import { useState, useEffect } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import * as api from 'api';
 import { WriteCommentIcon } from 'assets/icons';
 import DiaryCommentInput from 'components/diary/DiaryCommentInput';
 import DiaryComments from 'components/diary/DiaryComments';
-import { COMMENT_LIST_MOCK_DATA } from 'mocks/CommentList';
 
-// TODO: 타입 디렉토리에 분리하기
-interface CommentProps {
-  id: number;
-  authorUsername: string;
-  authorThumbnailUrl: string;
-  content: string;
-  createdAt: string;
-  modifiedAt: string;
+interface DiaryCommentsContainerProps {
+  diaryId: string;
 }
 
-const DiaryCommentsContainer = () => {
-  const [comments, setComments] = useState<CommentProps[]>([]);
+const DiaryCommentsContainer = ({ diaryId }: DiaryCommentsContainerProps) => {
+  const { data } = useQuery(
+    ['comments', diaryId],
+    async () => await api.getComments(diaryId),
+  );
 
-  useEffect(() => {
-    setComments(COMMENT_LIST_MOCK_DATA);
-  }, []);
+  if (data === undefined) return <div />;
 
   return (
     <DiaryCommentSection>
-      <DiaryComments comments={comments} />
+      <DiaryComments {...data} />
       <WriteCommentLabel htmlFor="diaryCommentTextarea">
         <WriteCommentIcon />
         <WriteCommentSpan>댓글쓰기</WriteCommentSpan>

--- a/src/containers/diary/DiaryContainer.tsx
+++ b/src/containers/diary/DiaryContainer.tsx
@@ -9,9 +9,11 @@ import {
   HeartOnIcon,
 } from 'assets/icons';
 import ResponsiveImage from 'components/common/ResponsiveImage';
+import { useHandleFavorite } from 'hooks/common';
 import { dateFormat, timeFormat } from 'utils';
 
 const DiaryContainer = ({
+  id,
   title,
   content,
   imgUrl,
@@ -22,22 +24,22 @@ const DiaryContainer = ({
   isBookmark,
   isFavorite,
 }: DiaryDetail) => {
+  const handleFavorite = useHandleFavorite({ isFavorite, id });
+
   return (
     <Container>
       <AuthorContainer>
-        {author.imgUrl !== null && (
-          // TODO:
-          // 1. 유저 프로필 이미지 클릭 시 해당 프로필로 이동
-          // 2. 프로필 이미지 컴포넌트 분리
-          <AuthorImageContainer>
-            <Image
-              src={author.imgUrl}
-              alt={author.username}
-              width={28}
-              height={28}
-            />
-          </AuthorImageContainer>
-        )}
+        {/* TODO:
+        1. 유저 프로필 이미지 클릭 시 해당 프로필로 이동
+        2. 프로필 이미지 컴포넌트 분리 */}
+        <AuthorImageContainer>
+          <Image
+            src={author.imgUrl}
+            alt={author.username}
+            width={28}
+            height={28}
+          />
+        </AuthorImageContainer>
         <UsernameText>{author.username}</UsernameText>
         <CreatedAtText>{dateFormat(createdAt)}</CreatedAtText>
       </AuthorContainer>
@@ -55,7 +57,7 @@ const DiaryContainer = ({
       </ContentContainer>
       <IconContainer>
         <IconInnerContainer>
-          <IconButton type="button">
+          <IconButton type="button" onClick={handleFavorite}>
             {isFavorite ? <HeartOnIcon /> : <HeartOffIcon />}
             {favoriteCount}
           </IconButton>

--- a/src/containers/diary/DiaryContainer.tsx
+++ b/src/containers/diary/DiaryContainer.tsx
@@ -9,7 +9,7 @@ import {
   HeartOnIcon,
 } from 'assets/icons';
 import ResponsiveImage from 'components/common/ResponsiveImage';
-import { useHandleFavorite } from 'hooks/common';
+import { useHandleFavorite, useHandleBookmark } from 'hooks/common';
 import { dateFormat, timeFormat } from 'utils';
 
 const DiaryContainer = ({
@@ -25,6 +25,7 @@ const DiaryContainer = ({
   isFavorite,
 }: DiaryDetail) => {
   const handleFavorite = useHandleFavorite({ isFavorite, id });
+  const handleBookmark = useHandleBookmark({ isBookmark, id });
 
   return (
     <Container>
@@ -66,7 +67,7 @@ const DiaryContainer = ({
             {commentCount}
           </IconButton>
         </IconInnerContainer>
-        <button type="button">
+        <button type="button" onClick={handleBookmark}>
           {isBookmark ? <BookmarkOnIcon /> : <BookmarkOffIcon />}
         </button>
       </IconContainer>

--- a/src/hooks/common/index.ts
+++ b/src/hooks/common/index.ts
@@ -1,1 +1,2 @@
 export * from './useHandleFavorite';
+export * from './useHandleBookmark';

--- a/src/hooks/common/index.ts
+++ b/src/hooks/common/index.ts
@@ -1,0 +1,1 @@
+export * from './useHandleFavorite';

--- a/src/hooks/common/useHandleBookmark.ts
+++ b/src/hooks/common/useHandleBookmark.ts
@@ -1,0 +1,21 @@
+import { useBookmarkDiary, useCancelBookmarkDiary } from '../services';
+import type { MouseEventHandler } from 'react';
+import type { DiaryDetail } from 'types/Diary';
+
+export const useHandleBookmark = ({
+  isBookmark,
+  id,
+}: Pick<DiaryDetail, 'id' | 'isBookmark'>) => {
+  const bookmarkMutation = useBookmarkDiary(id);
+  const cancelBookmarkMutation = useCancelBookmarkDiary(id);
+
+  const handleBookmark: MouseEventHandler<HTMLButtonElement> = () => {
+    if (isBookmark) {
+      cancelBookmarkMutation();
+    } else {
+      bookmarkMutation();
+    }
+  };
+
+  return handleBookmark;
+};

--- a/src/hooks/common/useHandleFavorite.ts
+++ b/src/hooks/common/useHandleFavorite.ts
@@ -1,0 +1,21 @@
+import { useFavoriteDiary, useCancelFavoriteDiary } from '../services';
+import type { MouseEventHandler } from 'react';
+import type { DiaryDetail } from 'types/Diary';
+
+export const useHandleFavorite = ({
+  isFavorite,
+  id,
+}: Pick<DiaryDetail, 'id' | 'isFavorite'>) => {
+  const favoriteMutation = useFavoriteDiary(id);
+  const cancelFavoriteMutation = useCancelFavoriteDiary(id);
+
+  const handleFavorite: MouseEventHandler<HTMLButtonElement> = () => {
+    if (isFavorite) {
+      cancelFavoriteMutation();
+    } else {
+      favoriteMutation();
+    }
+  };
+
+  return handleFavorite;
+};

--- a/src/hooks/services/index.ts
+++ b/src/hooks/services/index.ts
@@ -1,2 +1,4 @@
 export * from './mutations/useDeleteComment';
 export * from './mutations/useWriteComment';
+export * from './mutations/useCancelFavoriteDiary';
+export * from './mutations/useFavoriteDiary';

--- a/src/hooks/services/index.ts
+++ b/src/hooks/services/index.ts
@@ -1,0 +1,2 @@
+export * from './mutations/useDeleteComment';
+export * from './mutations/useWriteComment';

--- a/src/hooks/services/index.ts
+++ b/src/hooks/services/index.ts
@@ -2,3 +2,5 @@ export * from './mutations/useDeleteComment';
 export * from './mutations/useWriteComment';
 export * from './mutations/useCancelFavoriteDiary';
 export * from './mutations/useFavoriteDiary';
+export * from './mutations/useCancelBookmarkDiary';
+export * from './mutations/useBookmarkDiary';

--- a/src/hooks/services/mutations/useBookmarkDiary.ts
+++ b/src/hooks/services/mutations/useBookmarkDiary.ts
@@ -1,0 +1,14 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import * as api from 'api';
+
+export const useBookmarkDiary = (diaryId: string) => {
+  const queryClient = useQueryClient();
+  const { mutate } = useMutation(async () => await api.bookmarkDiary(diaryId), {
+    onSuccess: async () => {
+      await queryClient.invalidateQueries(['diaries']);
+      await queryClient.invalidateQueries(['diary-detail', diaryId]);
+    },
+  });
+
+  return mutate;
+};

--- a/src/hooks/services/mutations/useCancelBookmarkDiary.ts
+++ b/src/hooks/services/mutations/useCancelBookmarkDiary.ts
@@ -1,0 +1,17 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import * as api from 'api';
+
+export const useCancelBookmarkDiary = (diaryId: string) => {
+  const queryClient = useQueryClient();
+  const { mutate } = useMutation(
+    async () => await api.cancelBookmarkDiary(diaryId),
+    {
+      onSuccess: async () => {
+        await queryClient.invalidateQueries(['diaries']);
+        await queryClient.invalidateQueries(['diary-detail', diaryId]);
+      },
+    },
+  );
+
+  return mutate;
+};

--- a/src/hooks/services/mutations/useCancelFavoriteDiary.ts
+++ b/src/hooks/services/mutations/useCancelFavoriteDiary.ts
@@ -1,0 +1,17 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import * as api from 'api';
+
+export const useCancelFavoriteDiary = (diaryId: string) => {
+  const queryClient = useQueryClient();
+  const { mutate } = useMutation(
+    async () => await api.cancelFavoriteDiary(diaryId),
+    {
+      onSuccess: async () => {
+        await queryClient.invalidateQueries(['diaries']);
+        await queryClient.invalidateQueries(['diary-detail', diaryId]);
+      },
+    },
+  );
+
+  return mutate;
+};

--- a/src/hooks/services/mutations/useDeleteComment.ts
+++ b/src/hooks/services/mutations/useDeleteComment.ts
@@ -13,6 +13,7 @@ export const useDeleteComment = (diaryId: string) => {
     {
       onSuccess: async () => {
         await queryClient.invalidateQueries(['comments', diaryId]);
+        await queryClient.invalidateQueries(['diary-detail', diaryId]);
       },
     },
   );

--- a/src/hooks/services/mutations/useDeleteComment.ts
+++ b/src/hooks/services/mutations/useDeleteComment.ts
@@ -1,0 +1,21 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import type { DeleteCommentRequest } from 'types/Comment';
+import * as api from 'api';
+
+export const useDeleteComment = (diaryId: string) => {
+  const queryClient = useQueryClient();
+  const { mutate } = useMutation(
+    async ({ diaryId, commentId }: DeleteCommentRequest) =>
+      await api.deleteComments({
+        diaryId,
+        commentId,
+      }),
+    {
+      onSuccess: async () => {
+        await queryClient.invalidateQueries(['comments', diaryId]);
+      },
+    },
+  );
+
+  return mutate;
+};

--- a/src/hooks/services/mutations/useFavoriteDiary.ts
+++ b/src/hooks/services/mutations/useFavoriteDiary.ts
@@ -1,0 +1,14 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import * as api from 'api';
+
+export const useFavoriteDiary = (diaryId: string) => {
+  const queryClient = useQueryClient();
+  const { mutate } = useMutation(async () => await api.favoriteDiary(diaryId), {
+    onSuccess: async () => {
+      await queryClient.invalidateQueries(['diaries']);
+      await queryClient.invalidateQueries(['diary-detail', diaryId]);
+    },
+  });
+
+  return mutate;
+};

--- a/src/hooks/services/mutations/useWriteComment.ts
+++ b/src/hooks/services/mutations/useWriteComment.ts
@@ -13,6 +13,7 @@ export const useWriteComment = (diaryId: string) => {
     {
       onSuccess: async () => {
         await queryClient.invalidateQueries(['comments', diaryId]);
+        await queryClient.invalidateQueries(['diary-detail', diaryId]);
       },
     },
   );

--- a/src/hooks/services/mutations/useWriteComment.ts
+++ b/src/hooks/services/mutations/useWriteComment.ts
@@ -1,0 +1,21 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import type { CommentRequest } from 'types/Comment';
+import * as api from 'api';
+
+export const useWriteComment = (diaryId: string) => {
+  const queryClient = useQueryClient();
+  const { mutate } = useMutation(
+    async ({ diaryId, comment }: CommentRequest) =>
+      await api.writeComment({
+        diaryId,
+        comment,
+      }),
+    {
+      onSuccess: async () => {
+        await queryClient.invalidateQueries(['comments', diaryId]);
+      },
+    },
+  );
+
+  return mutate;
+};

--- a/src/pages/diary/[id]/index.tsx
+++ b/src/pages/diary/[id]/index.tsx
@@ -93,7 +93,7 @@ const DiaryDetailPage: NextPage = () => {
       )}
       <Section>
         <DiaryContainer {...data} />
-        <DiaryCommentsContainer />
+        <DiaryCommentsContainer diaryId={id as string} />
       </Section>
     </>
   );
@@ -112,16 +112,20 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
       },
     };
   }
+  const headers = {
+    headers: {
+      Authorization: `Bearer ${session.user.accessToken}`,
+    },
+  };
 
   const queryClient = new QueryClient();
   await queryClient.prefetchQuery(
     ['diary-detail', id],
-    async () =>
-      await api.getDiaryDetail(id as string, {
-        headers: {
-          Authorization: `Bearer ${session.user.accessToken}`,
-        },
-      }),
+    async () => await api.getDiaryDetail(id as string, headers),
+  );
+  await queryClient.prefetchQuery(
+    ['comments', id],
+    async () => await api.getComments(id as string, headers),
   );
   return { props: { dehydratedState: dehydrate(queryClient) } };
 };

--- a/src/types/Comment.ts
+++ b/src/types/Comment.ts
@@ -1,0 +1,21 @@
+import type { User } from 'next-auth';
+
+/*
+ * Other Types
+ */
+
+// 댓글
+export interface Comment {
+  id: string;
+  createdAt: string;
+  updatedAt: string;
+  comment: string;
+  commenter: User;
+}
+
+// 댓글 리스트
+export interface Comments {
+  comments: Comment[];
+  totalCount: number;
+  totalPage: number;
+}

--- a/src/types/Comment.ts
+++ b/src/types/Comment.ts
@@ -13,6 +13,12 @@ export interface CommentRequest extends CommentForm {
   diaryId: string;
 }
 
+// 댓글 삭제
+export interface DeleteCommentRequest {
+  diaryId: string;
+  commentId: string;
+}
+
 /*
  * Response Data Types
  */

--- a/src/types/Comment.ts
+++ b/src/types/Comment.ts
@@ -1,5 +1,28 @@
 import type { User } from 'next-auth';
 
+export interface CommentForm {
+  comment: string;
+}
+
+/*
+ * Request Data Types
+ */
+
+// 댓글 작성
+export interface CommentRequest extends CommentForm {
+  diaryId: string;
+}
+
+/*
+ * Response Data Types
+ */
+
+// 댓글 작성
+export interface CommentResponse {
+  comment: Comment;
+  // TODO: badge 추가 예정
+}
+
 /*
  * Other Types
  */


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #133 

<br />

## 🗒 작업 목록

- [x] 댓글 조회, 작성, 삭제 관련 타입 정의
- [x] 댓글 리스트 조회, 작성, 삭제 api 구현 및 적용
- [x] Mutaion 커스텀 훅 생성 및 적용
  - useWriteComment : 댓글 작성 후 데이터 갱신
  - useDeleteComment : 댓글 작성 후 데이터 갱신
- [x] 댓글 조회, 작성, 삭제 기능 구현
- [x] DiaryCommentInput 컴포넌트 자잘한 수정
- [x] 댓글 작성/ 삭제 시 일기 상세 데이터 갱신

<br />

## 🧐 PR Point

- 댓글 조회, 작성, 삭제 기능을 구현하고 댓글 작성/삭제를 완료한 후 데이터가 갱신될 수 있도록 useMutation을 적용했습니다.
- 각 뮤테이션은 커스텀 훅을 생성하여 적용하였고, 폴더 구조는 다음을 참고하여 적용했습니다. [참고 링크](https://develogger.kro.kr/blog/LKHcoding/153)
![image](https://github.com/a-daily-diary/ADD.FE/assets/85009583/7cbdf681-21d5-4444-8cd0-7dbe86e11fce)
- 댓글 수정 기능은 현재 디자인이 나와있지 않은 상태이므로, 디자인 완료 후 진행하겠습니다.
⇒ 디자인이 누락되어 있었습니다.

#### TODO
- 댓글 수정 기능 구현
- useQuery 커스텀 훅 생성하여 적용하기
- queryKeys 적용하기

<br />

## 💥 Trouble Shooting
- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크

https://github.com/a-daily-diary/ADD.FE/assets/85009583/e233c3ba-1916-41e9-b219-767e73bf8be5

<br />

## 📚 참고

- [React Example: Auto Refetching](https://tanstack.com/query/latest/docs/react/examples/react/auto-refetching)
- [[React-Query] React-Query 개념잡기
](https://velog.io/@kandy1002/React-Query-%ED%91%B9-%EC%B0%8D%EC%96%B4%EB%A8%B9%EA%B8%B0)
- [React Query](https://velog.io/@cloud_oort/React-Query-%EA%B3%B5%EB%B6%80-2)
- [react-query 사내 도입 회고](https://develogger.kro.kr/blog/LKHcoding/153)

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다. 
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
