### PR TITLE
일기 좋아요 기능 구현 

### DIFF
--- a/src/api/favorite.ts
+++ b/src/api/favorite.ts
@@ -1,0 +1,23 @@
+import type { OnlyMessageResponse, SuccessResponse } from 'types/Response';
+import { API_PATH } from 'constants/api/path';
+import axios from 'lib/axios';
+
+export const favoriteDiary = async (diaryId: string) => {
+  const {
+    data: { data },
+  } = await axios.post<SuccessResponse<OnlyMessageResponse>>(
+    `${API_PATH.diaries.index}/${diaryId}/favorite`,
+  );
+  return data;
+};
+
+export const cancelFavoriteDiary = async (diaryId: string) => {
+  const {
+    data: {
+      data: { message },
+    },
+  } = await axios.delete<SuccessResponse<OnlyMessageResponse>>(
+    `${API_PATH.diaries.index}/${diaryId}/favorite`,
+  );
+  return message;
+};

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -3,3 +3,4 @@ export * from './users';
 export * from './termsAgreements';
 export * from './diaries';
 export * from './comments';
+export * from './favorite';

--- a/src/components/diary/Diary.tsx
+++ b/src/components/diary/Diary.tsx
@@ -10,6 +10,7 @@ import {
   HeartOffIcon,
 } from 'assets/icons';
 import ResponsiveImage from 'components/common/ResponsiveImage';
+import { useHandleFavorite } from 'hooks/common';
 import { EllipsisStyle } from 'styles';
 import { dateFormat, timeFormat } from 'utils';
 
@@ -25,6 +26,8 @@ const Diary = ({
   createdAt,
   author,
 }: DiaryDetail) => {
+  const handleFavorite = useHandleFavorite({ isFavorite, id });
+
   return (
     <Container>
       <ContentContainer>
@@ -44,7 +47,7 @@ const Diary = ({
       </ContentContainer>
       <IconContainer>
         <IconInnerContainer>
-          <FavoriteButton type="button">
+          <FavoriteButton type="button" onClick={handleFavorite}>
             {isFavorite ? <HeartOnIcon /> : <HeartOffIcon />}
             {favoriteCount}
           </FavoriteButton>

--- a/src/containers/diary/DiaryContainer.tsx
+++ b/src/containers/diary/DiaryContainer.tsx
@@ -9,9 +9,11 @@ import {
   HeartOnIcon,
 } from 'assets/icons';
 import ResponsiveImage from 'components/common/ResponsiveImage';
+import { useHandleFavorite } from 'hooks/common';
 import { dateFormat, timeFormat } from 'utils';
 
 const DiaryContainer = ({
+  id,
   title,
   content,
   imgUrl,
@@ -22,22 +24,22 @@ const DiaryContainer = ({
   isBookmark,
   isFavorite,
 }: DiaryDetail) => {
+  const handleFavorite = useHandleFavorite({ isFavorite, id });
+
   return (
     <Container>
       <AuthorContainer>
-        {author.imgUrl !== null && (
-          // TODO:
-          // 1. 유저 프로필 이미지 클릭 시 해당 프로필로 이동
-          // 2. 프로필 이미지 컴포넌트 분리
-          <AuthorImageContainer>
-            <Image
-              src={author.imgUrl}
-              alt={author.username}
-              width={28}
-              height={28}
-            />
-          </AuthorImageContainer>
-        )}
+        {/* TODO:
+        1. 유저 프로필 이미지 클릭 시 해당 프로필로 이동
+        2. 프로필 이미지 컴포넌트 분리 */}
+        <AuthorImageContainer>
+          <Image
+            src={author.imgUrl}
+            alt={author.username}
+            width={28}
+            height={28}
+          />
+        </AuthorImageContainer>
         <UsernameText>{author.username}</UsernameText>
         <CreatedAtText>{dateFormat(createdAt)}</CreatedAtText>
       </AuthorContainer>
@@ -55,7 +57,7 @@ const DiaryContainer = ({
       </ContentContainer>
       <IconContainer>
         <IconInnerContainer>
-          <IconButton type="button">
+          <IconButton type="button" onClick={handleFavorite}>
             {isFavorite ? <HeartOnIcon /> : <HeartOffIcon />}
             {favoriteCount}
           </IconButton>

--- a/src/hooks/common/index.ts
+++ b/src/hooks/common/index.ts
@@ -1,0 +1,1 @@
+export * from './useHandleFavorite';

--- a/src/hooks/common/useHandleFavorite.ts
+++ b/src/hooks/common/useHandleFavorite.ts
@@ -1,0 +1,21 @@
+import { useFavoriteDiary, useCancelFavoriteDiary } from '../services';
+import type { MouseEventHandler } from 'react';
+import type { DiaryDetail } from 'types/Diary';
+
+export const useHandleFavorite = ({
+  isFavorite,
+  id,
+}: Pick<DiaryDetail, 'id' | 'isFavorite'>) => {
+  const favoriteMutation = useFavoriteDiary(id);
+  const cancelFavoriteMutation = useCancelFavoriteDiary(id);
+
+  const handleFavorite: MouseEventHandler<HTMLButtonElement> = () => {
+    if (isFavorite) {
+      cancelFavoriteMutation();
+    } else {
+      favoriteMutation();
+    }
+  };
+
+  return handleFavorite;
+};

--- a/src/hooks/services/index.ts
+++ b/src/hooks/services/index.ts
@@ -1,2 +1,4 @@
 export * from './mutations/useDeleteComment';
 export * from './mutations/useWriteComment';
+export * from './mutations/useCancelFavoriteDiary';
+export * from './mutations/useFavoriteDiary';

--- a/src/hooks/services/mutations/useCancelFavoriteDiary.ts
+++ b/src/hooks/services/mutations/useCancelFavoriteDiary.ts
@@ -1,0 +1,17 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import * as api from 'api';
+
+export const useCancelFavoriteDiary = (diaryId: string) => {
+  const queryClient = useQueryClient();
+  const { mutate } = useMutation(
+    async () => await api.cancelFavoriteDiary(diaryId),
+    {
+      onSuccess: async () => {
+        await queryClient.invalidateQueries(['diaries']);
+        await queryClient.invalidateQueries(['diary-detail', diaryId]);
+      },
+    },
+  );
+
+  return mutate;
+};

--- a/src/hooks/services/mutations/useFavoriteDiary.ts
+++ b/src/hooks/services/mutations/useFavoriteDiary.ts
@@ -1,0 +1,14 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import * as api from 'api';
+
+export const useFavoriteDiary = (diaryId: string) => {
+  const queryClient = useQueryClient();
+  const { mutate } = useMutation(async () => await api.favoriteDiary(diaryId), {
+    onSuccess: async () => {
+      await queryClient.invalidateQueries(['diaries']);
+      await queryClient.invalidateQueries(['diary-detail', diaryId]);
+    },
+  });
+
+  return mutate;
+};


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #137 

<br />

## 🗒 작업 목록

- [x] 좋아요/좋아요 취소 api 구현
- [x] 일기 좋아요/좋아요 취소 mutation 커스텀 훅 생성
- [x] 일기 좋아요/좋아요 취소 기능 구현
  - 일기 좋아요/좋아요 취소 기능 재사용성을 높이기 위해 useHandleFavorite 커스텀 훅 생성 및 적용

<br />

## 🧐 PR Point

- 일기 좋아요/좋아요 취소 기능을 구현했습니다.
- useMutation을 이용하여 기능을 구현하였고, 해당 기능은 메인 페이지와 일기 상세 페이지에서 사용됩니다.
  - 각 페이지에서 해당 기능이 동작 후 모두 데이터 갱신될 수 있도록 적용했습니다.
- 일기 좋아요/좋아요 취소 기능 재사용성을 높이기 위해 useHandleFavorite 커스텀 훅 생성하여 적용했습니다.

<br />

## 💥 Trouble Shooting
- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크

https://github.com/a-daily-diary/ADD.FE/assets/85009583/d07669a9-0c6e-483c-bef1-8670c4ce0a04

<br />

## 📚 참고

- 참고한 내용 또는 링크를 입력해주세요.

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다. 
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
