### PR TITLE
일기 북마크 기능 구현

### DIFF
--- a/src/api/bookmark.ts
+++ b/src/api/bookmark.ts
@@ -1,0 +1,23 @@
+import type { OnlyMessageResponse, SuccessResponse } from 'types/Response';
+import { API_PATH } from 'constants/api/path';
+import axios from 'lib/axios';
+
+export const bookmarkDiary = async (diaryId: string) => {
+  const {
+    data: { data },
+  } = await axios.post<SuccessResponse<OnlyMessageResponse>>(
+    `${API_PATH.diaries.index}/${diaryId}/bookmark`,
+  );
+  return data;
+};
+
+export const cancelBookmarkDiary = async (diaryId: string) => {
+  const {
+    data: {
+      data: { message },
+    },
+  } = await axios.delete<SuccessResponse<OnlyMessageResponse>>(
+    `${API_PATH.diaries.index}/${diaryId}/bookmark`,
+  );
+  return message;
+};

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -4,3 +4,4 @@ export * from './termsAgreements';
 export * from './diaries';
 export * from './comments';
 export * from './favorite';
+export * from './bookmark';

--- a/src/components/diary/Diary.tsx
+++ b/src/components/diary/Diary.tsx
@@ -10,7 +10,7 @@ import {
   HeartOffIcon,
 } from 'assets/icons';
 import ResponsiveImage from 'components/common/ResponsiveImage';
-import { useHandleFavorite } from 'hooks/common';
+import { useHandleFavorite, useHandleBookmark } from 'hooks/common';
 import { EllipsisStyle } from 'styles';
 import { dateFormat, timeFormat } from 'utils';
 
@@ -27,6 +27,7 @@ const Diary = ({
   author,
 }: DiaryDetail) => {
   const handleFavorite = useHandleFavorite({ isFavorite, id });
+  const handleBookmark = useHandleBookmark({ isBookmark, id });
 
   return (
     <Container>
@@ -56,7 +57,7 @@ const Diary = ({
             {commentCount}
           </CommentLink>
         </IconInnerContainer>
-        <button type="button">
+        <button type="button" onClick={handleBookmark}>
           {isBookmark ? <BookmarkOnIcon /> : <BookmarkOffIcon />}
         </button>
       </IconContainer>

--- a/src/containers/diary/DiaryContainer.tsx
+++ b/src/containers/diary/DiaryContainer.tsx
@@ -9,7 +9,7 @@ import {
   HeartOnIcon,
 } from 'assets/icons';
 import ResponsiveImage from 'components/common/ResponsiveImage';
-import { useHandleFavorite } from 'hooks/common';
+import { useHandleFavorite, useHandleBookmark } from 'hooks/common';
 import { dateFormat, timeFormat } from 'utils';
 
 const DiaryContainer = ({
@@ -25,6 +25,7 @@ const DiaryContainer = ({
   isFavorite,
 }: DiaryDetail) => {
   const handleFavorite = useHandleFavorite({ isFavorite, id });
+  const handleBookmark = useHandleBookmark({ isBookmark, id });
 
   return (
     <Container>
@@ -66,7 +67,7 @@ const DiaryContainer = ({
             {commentCount}
           </IconButton>
         </IconInnerContainer>
-        <button type="button">
+        <button type="button" onClick={handleBookmark}>
           {isBookmark ? <BookmarkOnIcon /> : <BookmarkOffIcon />}
         </button>
       </IconContainer>

--- a/src/hooks/common/index.ts
+++ b/src/hooks/common/index.ts
@@ -1,1 +1,2 @@
 export * from './useHandleFavorite';
+export * from './useHandleBookmark';

--- a/src/hooks/common/useHandleBookmark.ts
+++ b/src/hooks/common/useHandleBookmark.ts
@@ -1,0 +1,21 @@
+import { useBookmarkDiary, useCancelBookmarkDiary } from '../services';
+import type { MouseEventHandler } from 'react';
+import type { DiaryDetail } from 'types/Diary';
+
+export const useHandleBookmark = ({
+  isBookmark,
+  id,
+}: Pick<DiaryDetail, 'id' | 'isBookmark'>) => {
+  const bookmarkMutation = useBookmarkDiary(id);
+  const cancelBookmarkMutation = useCancelBookmarkDiary(id);
+
+  const handleBookmark: MouseEventHandler<HTMLButtonElement> = () => {
+    if (isBookmark) {
+      cancelBookmarkMutation();
+    } else {
+      bookmarkMutation();
+    }
+  };
+
+  return handleBookmark;
+};

--- a/src/hooks/services/index.ts
+++ b/src/hooks/services/index.ts
@@ -2,3 +2,5 @@ export * from './mutations/useDeleteComment';
 export * from './mutations/useWriteComment';
 export * from './mutations/useCancelFavoriteDiary';
 export * from './mutations/useFavoriteDiary';
+export * from './mutations/useCancelBookmarkDiary';
+export * from './mutations/useBookmarkDiary';

--- a/src/hooks/services/mutations/useBookmarkDiary.ts
+++ b/src/hooks/services/mutations/useBookmarkDiary.ts
@@ -1,0 +1,14 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import * as api from 'api';
+
+export const useBookmarkDiary = (diaryId: string) => {
+  const queryClient = useQueryClient();
+  const { mutate } = useMutation(async () => await api.bookmarkDiary(diaryId), {
+    onSuccess: async () => {
+      await queryClient.invalidateQueries(['diaries']);
+      await queryClient.invalidateQueries(['diary-detail', diaryId]);
+    },
+  });
+
+  return mutate;
+};

--- a/src/hooks/services/mutations/useCancelBookmarkDiary.ts
+++ b/src/hooks/services/mutations/useCancelBookmarkDiary.ts
@@ -1,0 +1,17 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import * as api from 'api';
+
+export const useCancelBookmarkDiary = (diaryId: string) => {
+  const queryClient = useQueryClient();
+  const { mutate } = useMutation(
+    async () => await api.cancelBookmarkDiary(diaryId),
+    {
+      onSuccess: async () => {
+        await queryClient.invalidateQueries(['diaries']);
+        await queryClient.invalidateQueries(['diary-detail', diaryId]);
+      },
+    },
+  );
+
+  return mutate;
+};


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #139  
##### #138과 북마크/좋아요의 차이일 뿐 동일한 내용입니다.
<br />

## 🗒 작업 목록

- [x] 북마크/북마크 취소 api 구현
- [x] 일기 북마크/북마크 취소 mutation 커스텀 훅 생성
- [x] 일기 북마크/북마크 취소 기능 구현
  - 일기 북마크/북마크 취소 기능 재사용성을 높이기 위해 useHandleBookmark 커스텀 훅 생성 및 적용

<br />

## 🧐 PR Point

- 일기 북마크/북마크 취소 기능을 구현했습니다.
- useMutation을 이용하여 기능을 구현하였고, 해당 기능은 메인 페이지와 일기 상세 페이지에서 사용됩니다.
  - 각 페이지에서 해당 기능이 동작 후 모두 데이터 갱신될 수 있도록 적용했습니다.
- 일기 북마크/북마크 취소 기능 재사용성을 높이기 위해 useHandleBookmark 커스텀 훅 생성하여 적용했습니다.

<br />

## 💥 Trouble Shooting
- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크

- 내용을 입력해주세요.

<br />

## 📚 참고

- 참고한 내용 또는 링크를 입력해주세요.

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다. 
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
