### PR TITLE
일기 수정 시 일기 내용이 상단 한 줄만 보이는 문제 해결 

### DIFF
--- a/src/components/common/FloatingMenu.tsx
+++ b/src/components/common/FloatingMenu.tsx
@@ -3,13 +3,16 @@ import FloatingMenuButton from './FloatingMenuButton';
 import type { FloatingMenuButtonProps } from './FloatingMenuButton';
 import { Z_INDEX } from 'constants/styles';
 
-interface FloatingMenuProps {
+interface FloatingMenuStyleProps {
+  position: 'absolute' | 'fixed';
+}
+interface FloatingMenuProps extends FloatingMenuStyleProps {
   items: FloatingMenuButtonProps[];
 }
 
-const FloatingMenu = ({ items }: FloatingMenuProps) => {
+const FloatingMenu = ({ items, position }: FloatingMenuProps) => {
   return (
-    <List>
+    <List position={position}>
       {items.map((item, index) => {
         const { label, icon, onClick } = item;
         return (
@@ -24,8 +27,8 @@ const FloatingMenu = ({ items }: FloatingMenuProps) => {
 
 export default FloatingMenu;
 
-const List = styled.ul`
-  position: absolute;
+const List = styled.ul<FloatingMenuStyleProps>`
+  position: ${({ position }) => position};
   top: 40px;
   right: 20px;
   z-index: ${Z_INDEX.dialog};

--- a/src/components/diary/Diary.tsx
+++ b/src/components/diary/Diary.tsx
@@ -83,6 +83,7 @@ const ContentLink = styled(Link)`
   ${EllipsisStyle}
   ${({ theme }) => theme.fonts.body_06}
   margin: 4px 0 6px;
+  white-space: pre-wrap;
   cursor: default;
 `;
 

--- a/src/components/diary/DiaryComment.tsx
+++ b/src/components/diary/DiaryComment.tsx
@@ -65,6 +65,7 @@ const DiaryComment = ({ diaryComment, diaryId }: DiaryCommentProps) => {
         <CommentContent>{comment}</CommentContent>
         {isVisible && (
           <FloatingMenu
+            position="absolute"
             items={
               isCommenter
                 ? [
@@ -98,7 +99,6 @@ const CommentItem = styled.li`
   padding: 12px 20px 16px;
 
   &:focus-within {
-    /* TODO: color constant에 추가하기 */
     background-color: ${({ theme }) => theme.colors.primary_04};
   }
 

--- a/src/components/layouts/header/HeaderRight.tsx
+++ b/src/components/layouts/header/HeaderRight.tsx
@@ -9,7 +9,7 @@ interface HeaderRightStyleProps {
 }
 
 interface HeaderRightProps extends HeaderRightStyleProps {
-  type: '더보기' | '검색' | '등록';
+  type: '더보기' | '검색' | '등록' | '수정';
   buttonRef?: ForwardedRef<HTMLButtonElement>;
   onClick?: () => void;
 }
@@ -32,9 +32,9 @@ export const HeaderRight = ({
           <SearchIcon />
         </SearchLink>
       )}
-      {type === '등록' && (
+      {(type === '등록' || type === '수정') && (
         <TextButton type="submit" onClick={onClick} disabled={disabled}>
-          등록
+          {type}
         </TextButton>
       )}
     </>

--- a/src/containers/diary/DiaryContainer.tsx
+++ b/src/containers/diary/DiaryContainer.tsx
@@ -120,8 +120,9 @@ const ImageContainer = styled.div`
 `;
 
 const Content = styled.p`
-  ${({ theme }) => theme.fonts.body_06}
   margin-top: 4px;
+  ${({ theme }) => theme.fonts.body_06}
+  white-space: pre-wrap;
 `;
 
 const TimeContainer = styled.div`

--- a/src/pages/diary/[id]/edit.tsx
+++ b/src/pages/diary/[id]/edit.tsx
@@ -151,7 +151,7 @@ const EditDiary: NextPage = () => {
               />
             }
             title={<HeaderTitle title={createdAtDate} fontWeight={700} />}
-            right={<HeaderRight type="등록" disabled={!isValid} />}
+            right={<HeaderRight type="수정" disabled={!isValid} />}
           />
           <FormHeader>
             {/* TODO: 일기 템플릿 추가 */}

--- a/src/pages/diary/[id]/edit.tsx
+++ b/src/pages/diary/[id]/edit.tsx
@@ -3,10 +3,10 @@ import { QueryClient, dehydrate, useQuery } from '@tanstack/react-query';
 import { isAxiosError } from 'axios';
 import { useRouter } from 'next/router';
 import { getServerSession } from 'next-auth';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import type { GetServerSideProps, NextPage } from 'next';
-import type { ChangeEventHandler } from 'react';
+import type { ChangeEventHandler, FocusEventHandler } from 'react';
 import type { SubmitHandler } from 'react-hook-form';
 import type { DiaryForm } from 'types/Diary';
 import type { ErrorResponse } from 'types/Response';
@@ -42,6 +42,10 @@ const EditDiary: NextPage = () => {
 
   useBeforeLeave({ message: DIARY_MESSAGE.popstate, path: router.asPath });
 
+  useEffect(() => {
+    setFocus('content');
+  }, [data]);
+
   if (data === undefined) return <div />;
   if (isLoading) return <div>Loading</div>;
 
@@ -58,6 +62,7 @@ const EditDiary: NextPage = () => {
     handleSubmit,
     watch,
     setValue,
+    setFocus,
     formState: { isValid },
   } = useForm<DiaryForm>({
     mode: 'onChange',
@@ -99,6 +104,13 @@ const EditDiary: NextPage = () => {
   const handleCancelImage = () => {
     setPreviewImage('');
     setValue('imgUrl', null);
+  };
+
+  const handleOnFocusTextarea: FocusEventHandler<HTMLTextAreaElement> = (e) => {
+    const { target } = e;
+    setTimeout(() => {
+      target.style.height = `${target.scrollHeight}px`;
+    }, 0);
   };
 
   const onSubmit: SubmitHandler<DiaryForm> = async (data) => {
@@ -208,6 +220,7 @@ const EditDiary: NextPage = () => {
                 onChange: textareaAutosize,
                 setValueAs: (value: string) => value.trim(),
               })}
+              onFocus={handleOnFocusTextarea}
             />
           </ContentContainer>
         </form>

--- a/src/pages/diary/[id]/index.tsx
+++ b/src/pages/diary/[id]/index.tsx
@@ -64,6 +64,7 @@ const DiaryDetailPage: NextPage = () => {
       />
       {isVisible && (
         <FloatingMenu
+          position="fixed"
           items={
             isAuthor
               ? [
@@ -71,7 +72,7 @@ const DiaryDetailPage: NextPage = () => {
                     icon: <EditIcon />,
                     label: '수정하기',
                     onClick: async () =>
-                      await router.push(`/diary/${id as string}/edit`), // TODO: 일기 수정하기 페이지 생성 후 라우터 수정
+                      await router.push(`/diary/${id as string}/edit`),
                   },
                   {
                     icon: <TrashIcon />,
@@ -85,7 +86,7 @@ const DiaryDetailPage: NextPage = () => {
                     label: '신고하기',
                     onClick: () => {
                       confirm('신고하시겠습니까?');
-                    }, // TODO: 일기 수정하기 페이지 생성 후 라우터 수정
+                    },
                   },
                 ]
           }


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #142 

<br />

## 🗒 작업 목록

- [x] defaultValues 설정 코드 리팩토링
- [x] onFocus 이벤트 시 textarea에 컨텐트 높이 적용하는 기능 구현
- [x] 일기 수정페이지 HeaderRight type에 수정 추가 및 적용
- [x] 일기 피드, 일기 상세 페이지에 개행이 나타날 수 있게 스타일 적용
- [x] FloatingMune position props 추가 및 적용

<br />

## 🧐 PR Point

- 일기 수정하기 페이지에서 여러 줄의 일기 내용 textarea로 나타내는 과정에서 상단 한 줄만 보여 나머지 내용이 보이지 않은 문제가 발생했습니다.
- 일기 수정 페이지 진입 시 content에 setFocus를 설정한 후 onFocus 이벤트를 이용하여 textarea의 scrollHeight를 인식할 수 있도록 적용했습니다.
  - setTimeout 내에서 scrollHeight를 textarea 높이에 적했습니다.
  - setTimeout을 이용하여 비동기적으로 처리했습니다.(setTimeout 없이 코드를 적용할 경우 높이값이 변경되지 않습니다.) 
- 일기의 내용이 보여지는 곳에 `white-wrap: pre-wrap;` 을 적용하여 개행이 정상적으로 나타날 수 있도록 적용했습니다. 
- 일기 수정하기 페이지의 Header에 일기 작성과 동일하게 '등록' 텍스트가 적용되어 사용자가 혼란스럽지 않도록 '수정' type을 추가하여 수정 버튼으로 나타날 수 있도록 적용했습니다.

<br />

## 💥 Trouble Shooting

#### 개행문자
- 이슈에 내용을 작성했던대로 textarea 태그를 p 태그로 변경하여 contentEditable 속성을 이용하여 해결하려고 했으나 contentEditable 사용시 content에 개행이 포함되면 개행을 핸들링하기 어려워 해당 방법을 이용하지 않았습니다.
  - textContent : 개행 문자가 들어가지 않습니다.
  - innerText : 개행 문자가 두 배로 들어가서, 수정 시 개행문자가 연속되어 있는 경우 replace를 이용하여 한 개만 들어갈 수 있도록 시도해보았으나, 연속된 개행문자가 작성된 일기에 아무것도 수정하지 않고 수정 버튼을 누른다면 replace가 동작하여 의도치 않은 결과를 가져와 문제 발생했습니다.

<br />

## 📸 스크린샷 / 피그마 링크

- 내용을 입력해주세요.

<br />

## 📚 참고

- [Set initial size Text Area that grows automatically](https://forum.mendix.com/link/space/ui-&-front-end/questions/122884)

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다. 
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
