### PR TITLE
useQuery 및 useMutation 추상화

### DIFF
--- a/src/api/diaries.ts
+++ b/src/api/diaries.ts
@@ -4,6 +4,8 @@ import type {
   DiaryResponse,
   DiaryDetail,
   Diaries,
+  EditDiaryRequest,
+  DeleteDiaryRequest,
 } from 'types/Diary';
 import type { OnlyMessageResponse, SuccessResponse } from 'types/Response';
 import { API_PATH } from 'constants/api/path';
@@ -50,10 +52,13 @@ export const getDiaryDetail = async (
   return data;
 };
 
-export const editDiaryDetail = async (
-  { title, content, imgUrl, isPublic }: DiaryRequest,
-  id: string,
-) => {
+export const editDiaryDetail = async ({
+  title,
+  content,
+  imgUrl,
+  isPublic,
+  id,
+}: EditDiaryRequest) => {
   const { data: diaryData } = await axios.put<SuccessResponse<DiaryResponse>>(
     `${API_PATH.diaries.index}/${id}`,
     {
@@ -67,7 +72,7 @@ export const editDiaryDetail = async (
   return diaryData;
 };
 
-export const deleteDiaryDetail = async (id: string) => {
+export const deleteDiaryDetail = async ({ id }: DeleteDiaryRequest) => {
   const {
     data: {
       data: { message },

--- a/src/api/image.ts
+++ b/src/api/image.ts
@@ -6,19 +6,12 @@ import type {
 import { API_PATH } from 'constants/api/path';
 import axios from 'lib/axios';
 
-export const uploadUserImage = async (imageFormData: UploadImageRequest) => {
+export const uploadImage = async ({
+  path,
+  imageFormData,
+}: UploadImageRequest) => {
   return await axios.post<SuccessResponse<UploadImageResponse>>(
-    API_PATH.users.image,
-    imageFormData,
-    {
-      headers: { 'Content-Type': 'multipart/form-data' },
-    },
-  );
-};
-
-export const uploadDiaryImage = async (imageFormData: UploadImageRequest) => {
-  return await axios.post<SuccessResponse<UploadImageResponse>>(
-    API_PATH.diaries.image,
+    API_PATH[path].image,
     imageFormData,
     {
       headers: { 'Content-Type': 'multipart/form-data' },

--- a/src/components/account/RegisterProfileImage.tsx
+++ b/src/components/account/RegisterProfileImage.tsx
@@ -35,7 +35,10 @@ const RegisterProfileImage = () => {
         const imageFormData = new FormData();
         imageFormData.append('image', files[0]);
 
-        const { data } = await api.uploadUserImage(imageFormData);
+        const { data } = await api.uploadImage({
+          path: 'users',
+          imageFormData,
+        });
 
         setPreviewImage(data.data.imgUrl);
       } catch (error) {

--- a/src/components/account/RegisterTerms.tsx
+++ b/src/components/account/RegisterTerms.tsx
@@ -1,11 +1,10 @@
 import styled from '@emotion/styled';
-import { useQuery } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 import type { ChangeEventHandler } from 'react';
 import type { RegisterForm } from 'types/Register';
-import * as api from 'api';
 import { CheckedOffIcon, CheckedOnIcon } from 'assets/icons';
+import { useTermsAgreements } from 'hooks/services';
 import { FadeInAnimationStyle } from 'styles';
 
 interface TermsAgreementState {
@@ -21,11 +20,7 @@ type TermsAgreementField =
   | 'termsAgreement.marketing';
 
 const RegisterTerms = () => {
-  const { data: termsAgreement } = useQuery(
-    ['terms-agreement'],
-    api.getTermsAgreement,
-  );
-
+  const { termsAgreementsData } = useTermsAgreements();
   const { register, setValue } = useFormContext<RegisterForm>();
 
   const [agreedToTerms, setAgreedToTerms] = useState<TermsAgreementState>({
@@ -119,7 +114,7 @@ const RegisterTerms = () => {
         약관 전체 동의하기
       </CheckboxLabel>
       <CheckboxList>
-        {termsAgreement?.map((term) => {
+        {termsAgreementsData?.map((term) => {
           const { id, title, isRequired } = term;
           const fieldName = `termsAgreement.${id}` as TermsAgreementField;
           return (

--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -1,9 +1,9 @@
 export const queryKeys = {
   badges: 'badges',
   bookmark: 'bookmark',
-  comment: 'comment',
+  comments: 'comments',
   diaries: 'diaries',
   favorite: 'favorite',
-  terms: 'terms-agreements',
+  termsAgreements: 'terms-agreements',
   users: 'users',
 } as const;

--- a/src/containers/diary/DiariesContainer.tsx
+++ b/src/containers/diary/DiariesContainer.tsx
@@ -1,18 +1,14 @@
 import styled from '@emotion/styled';
-import { useQuery } from '@tanstack/react-query';
 import Diary from '../../components/diary/Diary';
-import * as api from 'api';
+import { useDiaries } from 'hooks/services';
 
 const DiariesContainer = () => {
-  const { data, isLoading } = useQuery(
-    ['diaries'],
-    async () => await api.getDiaries(),
-  );
+  const { diariesData, isLoading } = useDiaries();
 
-  if (data === undefined) return <div />;
+  if (diariesData === undefined) return <div />;
   if (isLoading) return <div>Loading</div>;
 
-  const { diaries } = data;
+  const { diaries } = diariesData;
   return (
     <List>
       {diaries.map((diary) => {

--- a/src/containers/diary/DiaryCommentsContainer.tsx
+++ b/src/containers/diary/DiaryCommentsContainer.tsx
@@ -1,25 +1,21 @@
 import styled from '@emotion/styled';
-import { useQuery } from '@tanstack/react-query';
-import * as api from 'api';
 import { WriteCommentIcon } from 'assets/icons';
 import DiaryCommentInput from 'components/diary/DiaryCommentInput';
 import DiaryComments from 'components/diary/DiaryComments';
+import { useComments } from 'hooks/services';
 
 interface DiaryCommentsContainerProps {
   diaryId: string;
 }
 
 const DiaryCommentsContainer = ({ diaryId }: DiaryCommentsContainerProps) => {
-  const { data } = useQuery(
-    ['comments', diaryId],
-    async () => await api.getComments(diaryId),
-  );
+  const { commentsData } = useComments(diaryId);
 
-  if (data === undefined) return <div />;
+  if (commentsData === undefined) return <div />;
 
   return (
     <DiaryCommentSection>
-      <DiaryComments diaryComments={data} diaryId={diaryId} />
+      <DiaryComments diaryComments={commentsData} diaryId={diaryId} />
       <WriteCommentLabel htmlFor="diaryCommentTextarea">
         <WriteCommentIcon />
         <WriteCommentSpan>댓글쓰기</WriteCommentSpan>

--- a/src/hooks/services/index.ts
+++ b/src/hooks/services/index.ts
@@ -4,3 +4,8 @@ export * from './mutations/useCancelFavoriteDiary';
 export * from './mutations/useFavoriteDiary';
 export * from './mutations/useCancelBookmarkDiary';
 export * from './mutations/useBookmarkDiary';
+
+export * from './queries/useDiaries';
+export * from './queries/useDiary';
+export * from './queries/useComments';
+export * from './queries/useTermsAgreements';

--- a/src/hooks/services/index.ts
+++ b/src/hooks/services/index.ts
@@ -4,6 +4,9 @@ export * from './mutations/useCancelFavoriteDiary';
 export * from './mutations/useFavoriteDiary';
 export * from './mutations/useCancelBookmarkDiary';
 export * from './mutations/useBookmarkDiary';
+export * from './mutations/useDeleteDiary';
+export * from './mutations/useWriteDiary';
+export * from './mutations/useRegisterUser';
 
 export * from './queries/useDiaries';
 export * from './queries/useDiary';

--- a/src/hooks/services/mutations/useBookmarkDiary.ts
+++ b/src/hooks/services/mutations/useBookmarkDiary.ts
@@ -1,12 +1,13 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import * as api from 'api';
+import { queryKeys } from 'constants/queryKeys';
 
 export const useBookmarkDiary = (diaryId: string) => {
   const queryClient = useQueryClient();
   const { mutate } = useMutation(async () => await api.bookmarkDiary(diaryId), {
     onSuccess: async () => {
-      await queryClient.invalidateQueries(['diaries']);
-      await queryClient.invalidateQueries(['diary-detail', diaryId]);
+      await queryClient.invalidateQueries([queryKeys.diaries]);
+      await queryClient.invalidateQueries([queryKeys.diaries, diaryId]);
     },
   });
 

--- a/src/hooks/services/mutations/useCancelBookmarkDiary.ts
+++ b/src/hooks/services/mutations/useCancelBookmarkDiary.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import * as api from 'api';
+import { queryKeys } from 'constants/queryKeys';
 
 export const useCancelBookmarkDiary = (diaryId: string) => {
   const queryClient = useQueryClient();
@@ -7,8 +8,8 @@ export const useCancelBookmarkDiary = (diaryId: string) => {
     async () => await api.cancelBookmarkDiary(diaryId),
     {
       onSuccess: async () => {
-        await queryClient.invalidateQueries(['diaries']);
-        await queryClient.invalidateQueries(['diary-detail', diaryId]);
+        await queryClient.invalidateQueries([queryKeys.diaries]);
+        await queryClient.invalidateQueries([queryKeys.diaries, diaryId]);
       },
     },
   );

--- a/src/hooks/services/mutations/useDeleteComment.ts
+++ b/src/hooks/services/mutations/useDeleteComment.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import type { DeleteCommentRequest } from 'types/Comment';
 import * as api from 'api';
+import { queryKeys } from 'constants/queryKeys';
 
 export const useDeleteComment = (diaryId: string) => {
   const queryClient = useQueryClient();
@@ -12,8 +13,8 @@ export const useDeleteComment = (diaryId: string) => {
       }),
     {
       onSuccess: async () => {
-        await queryClient.invalidateQueries(['comments', diaryId]);
-        await queryClient.invalidateQueries(['diary-detail', diaryId]);
+        await queryClient.invalidateQueries([queryKeys.comments, diaryId]);
+        await queryClient.invalidateQueries([queryKeys.diaries, diaryId]);
       },
     },
   );

--- a/src/hooks/services/mutations/useDeleteDiary.ts
+++ b/src/hooks/services/mutations/useDeleteDiary.ts
@@ -1,15 +1,18 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import type { DeleteDiaryRequest } from 'types/Diary';
 import * as api from 'api';
 import { queryKeys } from 'constants/queryKeys';
 
-export const useCancelFavoriteDiary = (diaryId: string) => {
+export const useDeleteDiary = ({ id }: DeleteDiaryRequest) => {
   const queryClient = useQueryClient();
   const { mutate } = useMutation(
-    async () => await api.cancelFavoriteDiary(diaryId),
+    async ({ id }: DeleteDiaryRequest) => {
+      await api.deleteDiaryDetail({ id });
+    },
     {
       onSuccess: async () => {
         await queryClient.invalidateQueries([queryKeys.diaries]);
-        await queryClient.invalidateQueries([queryKeys.diaries, diaryId]);
+        await queryClient.invalidateQueries([queryKeys.diaries, id]);
       },
     },
   );

--- a/src/hooks/services/mutations/useEditDiary.ts
+++ b/src/hooks/services/mutations/useEditDiary.ts
@@ -1,0 +1,25 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import type { EditDiaryRequest } from 'types/Diary';
+import * as api from 'api';
+import { queryKeys } from 'constants/queryKeys';
+
+export const useEditDiary = (id: string) => {
+  const queryClient = useQueryClient();
+  const { mutate } = useMutation(
+    async ({ title, content, imgUrl, isPublic, id }: EditDiaryRequest) =>
+      await api.editDiaryDetail({
+        title,
+        content,
+        imgUrl,
+        isPublic,
+        id,
+      }),
+    {
+      onSuccess: async () => {
+        await queryClient.invalidateQueries([queryKeys.diaries, id]);
+      },
+    },
+  );
+
+  return mutate;
+};

--- a/src/hooks/services/mutations/useFavoriteDiary.ts
+++ b/src/hooks/services/mutations/useFavoriteDiary.ts
@@ -1,12 +1,13 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import * as api from 'api';
+import { queryKeys } from 'constants/queryKeys';
 
 export const useFavoriteDiary = (diaryId: string) => {
   const queryClient = useQueryClient();
   const { mutate } = useMutation(async () => await api.favoriteDiary(diaryId), {
     onSuccess: async () => {
-      await queryClient.invalidateQueries(['diaries']);
-      await queryClient.invalidateQueries(['diary-detail', diaryId]);
+      await queryClient.invalidateQueries([queryKeys.diaries]);
+      await queryClient.invalidateQueries([queryKeys.diaries, diaryId]);
     },
   });
 

--- a/src/hooks/services/mutations/useImageUpload.ts
+++ b/src/hooks/services/mutations/useImageUpload.ts
@@ -1,0 +1,27 @@
+import { useMutation } from '@tanstack/react-query';
+import * as api from 'api';
+
+interface useImageUploadProps {
+  path: 'users' | 'diaries';
+  onSuccess: (imgUrl: string) => void;
+}
+
+export const useImageUpload = ({ path, onSuccess }: useImageUploadProps) => {
+  const { mutate } = useMutation(
+    async (imageFormData: FormData) => {
+      const {
+        data: {
+          data: { imgUrl },
+        },
+      } = await api.uploadImage({ path, imageFormData });
+      return imgUrl;
+    },
+    {
+      onSuccess: (imgUrl) => {
+        onSuccess(imgUrl);
+      },
+    },
+  );
+
+  return mutate;
+};

--- a/src/hooks/services/mutations/useRegisterUser.ts
+++ b/src/hooks/services/mutations/useRegisterUser.ts
@@ -1,0 +1,33 @@
+import { useMutation } from '@tanstack/react-query';
+import type { RegisterRequest } from 'types/Register';
+import * as api from 'api';
+
+interface UseRegisterUserProps {
+  onSuccess: () => void;
+}
+
+export const useRegisterUser = ({ onSuccess }: UseRegisterUserProps) => {
+  const { mutate } = useMutation(
+    async ({
+      email,
+      username,
+      password,
+      imgUrl,
+      termsAgreementIdList,
+    }: RegisterRequest) => {
+      await api.register({
+        email,
+        username,
+        password,
+        imgUrl,
+        termsAgreementIdList,
+      });
+    },
+    {
+      onSuccess: () => {
+        onSuccess();
+      },
+    },
+  );
+  return mutate;
+};

--- a/src/hooks/services/mutations/useWriteComment.ts
+++ b/src/hooks/services/mutations/useWriteComment.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import type { CommentRequest } from 'types/Comment';
 import * as api from 'api';
+import { queryKeys } from 'constants/queryKeys';
 
 export const useWriteComment = (diaryId: string) => {
   const queryClient = useQueryClient();
@@ -12,8 +13,8 @@ export const useWriteComment = (diaryId: string) => {
       }),
     {
       onSuccess: async () => {
-        await queryClient.invalidateQueries(['comments', diaryId]);
-        await queryClient.invalidateQueries(['diary-detail', diaryId]);
+        await queryClient.invalidateQueries([queryKeys.comments, diaryId]);
+        await queryClient.invalidateQueries([queryKeys.diaries, diaryId]);
       },
     },
   );

--- a/src/hooks/services/mutations/useWriteDiary.ts
+++ b/src/hooks/services/mutations/useWriteDiary.ts
@@ -1,0 +1,31 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useRouter } from 'next/router';
+import type { DiaryRequest } from 'types/Diary';
+import * as api from 'api';
+import { queryKeys } from 'constants/queryKeys';
+
+export const useWriteDiary = () => {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const { mutate } = useMutation(
+    async ({ title, content, imgUrl, isPublic }: DiaryRequest) => {
+      const {
+        data: { diary },
+      } = await api.writeDiary({
+        title,
+        content,
+        imgUrl,
+        isPublic,
+      });
+      return diary;
+    },
+    {
+      onSuccess: async (diary) => {
+        await queryClient.invalidateQueries([queryKeys.diaries, diary.id]);
+        await router.replace(`/diary/${diary.id}`);
+      },
+    },
+  );
+
+  return mutate;
+};

--- a/src/hooks/services/queries/useComments.ts
+++ b/src/hooks/services/queries/useComments.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+import * as api from 'api';
+import { queryKeys } from 'constants/queryKeys';
+
+export const useComments = (diaryId: string) => {
+  const { data: commentsData, isLoading } = useQuery(
+    [queryKeys.comments, diaryId],
+    async () => await api.getComments(diaryId),
+  );
+  return { commentsData, isLoading };
+};

--- a/src/hooks/services/queries/useDiaries.ts
+++ b/src/hooks/services/queries/useDiaries.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+import * as api from 'api';
+import { queryKeys } from 'constants/queryKeys';
+
+export const useDiaries = () => {
+  const { data: diariesData, isLoading } = useQuery(
+    [queryKeys.diaries],
+    api.getDiaries,
+  );
+  return { diariesData, isLoading };
+};

--- a/src/hooks/services/queries/useDiary.ts
+++ b/src/hooks/services/queries/useDiary.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+import * as api from 'api';
+import { queryKeys } from 'constants/queryKeys';
+
+export const useDiary = (id: string) => {
+  const { data: diaryData, isLoading } = useQuery(
+    [queryKeys.diaries, id],
+    async () => await api.getDiaryDetail(id),
+  );
+  return { diaryData, isLoading };
+};

--- a/src/hooks/services/queries/useTermsAgreements.ts
+++ b/src/hooks/services/queries/useTermsAgreements.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+import * as api from 'api';
+import { queryKeys } from 'constants/queryKeys';
+
+export const useTermsAgreements = () => {
+  const { data: termsAgreementsData, isLoading } = useQuery(
+    [queryKeys.termsAgreements],
+    api.getTermsAgreement,
+  );
+  return { termsAgreementsData, isLoading };
+};

--- a/src/pages/diary/[id]/edit.tsx
+++ b/src/pages/diary/[id]/edit.tsx
@@ -87,7 +87,7 @@ const EditDiary: NextPage = () => {
           data: {
             data: { imgUrl },
           },
-        } = await api.uploadDiaryImage(imageFormData);
+        } = await api.uploadImage({ path: 'diaries', imageFormData });
 
         setPreviewImage(imgUrl);
         setValue('imgUrl', imgUrl);

--- a/src/pages/diary/[id]/index.tsx
+++ b/src/pages/diary/[id]/index.tsx
@@ -15,21 +15,25 @@ import { queryKeys } from 'constants/queryKeys';
 import { DiaryCommentsContainer, DiaryContainer } from 'containers/diary';
 import { useClickOutside } from 'hooks';
 import { useDiary } from 'hooks/services';
+import { useDeleteDiary } from 'hooks/services/mutations/useDeleteDiary';
 import { authOptions } from 'pages/api/auth/[...nextauth]';
 import { errorResponseMessage } from 'utils';
 
 const DiaryDetailPage: NextPage = () => {
   const router = useRouter();
   const { id } = router.query;
-  const { ref, isVisible, setIsVisible } = useClickOutside();
-  const { diaryData, isLoading } = useDiary(id as string);
   const { data: session } = useSession();
 
-  const handleDeleteDiary = async () => {
+  const { diaryData, isLoading } = useDiary(id as string);
+
+  const { ref, isVisible, setIsVisible } = useClickOutside();
+
+  const deleteDiaryMutation = useDeleteDiary({ id: id as string });
+
+  const handleDeleteDiary = () => {
     if (confirm('삭제하시겠습니까?')) {
       try {
-        const message = await api.deleteDiaryDetail(id as string);
-        alert(message);
+        deleteDiaryMutation({ id: id as string });
         // TODO: 일기 삭제 후 라우팅 처리 수정
         router.back();
       } catch (error) {

--- a/src/pages/diary/index.tsx
+++ b/src/pages/diary/index.tsx
@@ -62,7 +62,7 @@ const WriteDiary: NextPage = () => {
           data: {
             data: { imgUrl },
           },
-        } = await api.uploadDiaryImage(imageFormData);
+        } = await api.uploadImage({ path: 'diaries', imageFormData });
 
         setPreviewImage(imgUrl);
         setValue('imgUrl', imgUrl);
@@ -80,20 +80,11 @@ const WriteDiary: NextPage = () => {
     setValue('imgUrl', null);
   };
 
-  const onSubmit: SubmitHandler<DiaryForm> = async (data) => {
+  const onSubmit: SubmitHandler<DiaryForm> = (data) => {
     try {
       const { title, content, imgUrl, isPublic } = data;
-      const {
-        data: { diary },
-      } = await api.writeDiary({
-        title,
-        content,
-        imgUrl,
-        isPublic,
-      });
-
+      writeDiaryMutation({ title, content, imgUrl, isPublic });
       // TODO: badge 데이터가 있는 경우, 모달로 배지 획득 알람 띄우기
-      await router.replace(`/diary/${diary.id}`);
     } catch (error) {
       if (isAxiosError<ErrorResponse>(error)) {
         alert(errorResponseMessage(error.response?.data.message));

--- a/src/pages/diary/index.tsx
+++ b/src/pages/diary/index.tsx
@@ -8,7 +8,6 @@ import type { ChangeEventHandler } from 'react';
 import type { SubmitHandler } from 'react-hook-form';
 import type { DiaryForm } from 'types/Diary';
 import type { ErrorResponse } from 'types/Response';
-import * as api from 'api';
 import {
   PhotoInactiveIcon,
   PhotoActiveIcon,
@@ -26,12 +25,18 @@ import {
 } from 'components/layouts';
 import { DIARY_MESSAGE } from 'constants/diary';
 import { useBeforeLeave } from 'hooks';
+import { useWriteDiary } from 'hooks/services';
+import { useImageUpload } from 'hooks/services/mutations/useImageUpload';
 import { ScreenReaderOnly } from 'styles';
 import { dateFormat, errorResponseMessage, textareaAutosize } from 'utils';
 
 const WriteDiary: NextPage = () => {
   const today = dateFormat(new Date().toISOString()) as string;
   const router = useRouter();
+
+  const [previewImage, setPreviewImage] = useState<string>('');
+  const isPhotoActive = previewImage.length > 0;
+
   const {
     register,
     handleSubmit,
@@ -44,28 +49,25 @@ const WriteDiary: NextPage = () => {
   });
   const { isPublic: watchIsPublic, title: watchTitle } = watch();
 
-  const [previewImage, setPreviewImage] = useState<string>('');
-  const isPhotoActive = previewImage.length > 0;
-
   useBeforeLeave({ message: DIARY_MESSAGE.popstate, path: router.asPath });
 
-  const handleOnChangeImageFile: ChangeEventHandler<HTMLInputElement> = async (
-    e,
-  ) => {
+  const writeDiaryMutation = useWriteDiary();
+  const imageUploadMutation = useImageUpload({
+    path: 'diaries',
+    onSuccess: (imgUrl: string) => {
+      setPreviewImage(imgUrl);
+      setValue('imgUrl', imgUrl);
+    },
+  });
+
+  const handleImageFile: ChangeEventHandler<HTMLInputElement> = (e) => {
     const { files } = e.target;
     if (files !== null) {
       try {
         const imageFormData = new FormData();
         imageFormData.append('image', files[0]);
 
-        const {
-          data: {
-            data: { imgUrl },
-          },
-        } = await api.uploadImage({ path: 'diaries', imageFormData });
-
-        setPreviewImage(imgUrl);
-        setValue('imgUrl', imgUrl);
+        imageUploadMutation(imageFormData);
       } catch (error) {
         if (isAxiosError<ErrorResponse>(error)) {
           // TODO: 이미지 업로드 시 에러 처리
@@ -125,7 +127,7 @@ const WriteDiary: NextPage = () => {
               type="file"
               id="selectImageFile"
               accept="image/*"
-              onChange={handleOnChangeImageFile}
+              onChange={handleImageFile}
             />
             <PublicLabel htmlFor="isPublic" isPublic={watchIsPublic}>
               {watchIsPublic ? (

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -8,6 +8,7 @@ import * as api from 'api';
 import ResponsiveImage from 'components/common/ResponsiveImage';
 import Seo from 'components/common/Seo';
 import { Header, HeaderLeft, HeaderRight } from 'components/layouts';
+import { queryKeys } from 'constants/queryKeys';
 import { DiariesContainer } from 'containers/diary';
 
 const Home: NextPage = () => {
@@ -47,7 +48,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 
   const queryClient = new QueryClient();
   await queryClient.prefetchQuery(
-    ['diaries'],
+    [queryKeys.diaries],
     async () =>
       await api.getDiaries({
         headers: {

--- a/src/types/Diary.ts
+++ b/src/types/Diary.ts
@@ -14,6 +14,11 @@ export interface DiaryForm {
 // 다이어리 작성
 export type DiaryRequest = DiaryForm;
 
+// 다이어리 편집
+export interface EditDiaryRequest extends DiaryRequest {
+  diaryId: string;
+}
+
 /*
  * Response Data Types
  */

--- a/src/types/Diary.ts
+++ b/src/types/Diary.ts
@@ -15,9 +15,12 @@ export interface DiaryForm {
 export type DiaryRequest = DiaryForm;
 
 // 다이어리 편집
-export interface EditDiaryRequest extends DiaryRequest {
-  diaryId: string;
-}
+export type EditDiaryRequest = Pick<
+  DiaryDetail,
+  'id' | 'title' | 'content' | 'imgUrl' | 'isPublic'
+>;
+
+export type DeleteDiaryRequest = Pick<DiaryDetail, 'id'>;
 
 /*
  * Response Data Types

--- a/src/types/UploadImage.ts
+++ b/src/types/UploadImage.ts
@@ -3,7 +3,10 @@
  */
 
 // 유저 이미지 업로드
-export type UploadImageRequest = FormData;
+export interface UploadImageRequest {
+  path: 'users' | 'diaries';
+  imageFormData: FormData;
+}
 
 /*
  * Response Data Types


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #141

<br />

## 🗒 작업 목록

- [x] useQuery 추상화
- [x] 이미지 업로드 api 리팩토링
- [x] useMutation 추상화

<br />

## 🧐 PR Point

- 현재 사용 중인 api를 useQuery와 useMutation로 추상화 작업을 진행했습니다.
- 이미지 업로드 api는 기존에 사용자 프로필 이미지와 다이어리 이미지 api를 분리하여 사용했습니다. 두 api를 하나로 통합하여 path에 따라 이미지를 업로드 할 수 있도록 수정했습니다.
- 추상화 커밋을 한꺼번에 진행한 점 양해부탁드립니다🙏
- queryKeys 상수를 전체에 적용했습니다.

<br />

## 💥 Trouble Shooting
- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크

- 내용을 입력해주세요.

<br />

## 📚 참고

- [[React Query] 리액트 쿼리 useMutation 실용 편(custom hook 으로 사용해보자)](https://velog.io/@kimhyo_0218/React-Query-%EB%A6%AC%EC%95%A1%ED%8A%B8-%EC%BF%BC%EB%A6%AC-useMutation-%EC%8B%A4%EC%9A%A9-%ED%8E%B8custom-hook-%EC%9C%BC%EB%A1%9C-%EC%82%AC%EC%9A%A9%ED%95%B4%EB%B3%B4%EC%9E%90)
- [[트러블슈팅] react-query useMutation onSuccess 안 되는줄 알았던 바보 여기있어요!](https://velog.io/@jhy979/React-react-query-useMutation-onSuccess-%EC%95%88%EB%90%98%EB%8A%94%EC%A4%84-%EC%95%8C%EC%95%98%EB%8D%98-%ED%8A%B8%EB%9F%AC%EB%B8%94-%EC%8A%88%ED%8C%85)
- [sejulbook/src/hooks/services/mutations](https://github.com/KingDonggyu/sejulbook/tree/bd706df45dfa63ebbdbe350bbdd80cbc03edc688/src/hooks/services/mutations)

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다. 
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
