### PR TITLE
프로필 페이지에 필요한 데이터 패칭

### DIFF
--- a/src/api/diaries.ts
+++ b/src/api/diaries.ts
@@ -78,3 +78,16 @@ export const deleteDiaryDetail = async ({ id }: DeleteDiaryRequest) => {
   );
   return message;
 };
+
+export const getDiariesByUsername = async ({
+  username,
+  config,
+}: GetDiariesRequest & { username: string }) => {
+  const {
+    data: { data },
+  } = await axios.get<SuccessResponse<Diaries>>(
+    `${API_PATH.diaries.index}?username=${username}`,
+    config,
+  );
+  return data;
+};

--- a/src/api/diaries.ts
+++ b/src/api/diaries.ts
@@ -91,3 +91,16 @@ export const getDiariesByUsername = async ({
   );
   return data;
 };
+
+export const getBookmarkedDiariesByUsername = async ({
+  username,
+  config,
+}: GetDiariesRequest & { username: string }) => {
+  const {
+    data: { data },
+  } = await axios.get<SuccessResponse<Diaries>>(
+    `${API_PATH.diaries.bookmark}/${username}`,
+    config,
+  );
+  return data;
+};

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -5,3 +5,4 @@ export * from './diaries';
 export * from './comments';
 export * from './favorite';
 export * from './bookmark';
+export * from './profile';

--- a/src/api/profile.ts
+++ b/src/api/profile.ts
@@ -1,0 +1,18 @@
+import type { User } from 'next-auth';
+import type { GetProfileByUsernameRequest } from 'types/profile';
+import type { SuccessResponse } from 'types/response';
+import { API_PATH } from 'constants/api/path';
+import axios from 'lib/axios';
+
+export const getProfileByUsername = async ({
+  username,
+  config,
+}: GetProfileByUsernameRequest) => {
+  const {
+    data: { data },
+  } = await axios.get<SuccessResponse<User>>(
+    `${API_PATH.users.index}/${username}`,
+    config,
+  );
+  return data;
+};

--- a/src/components/diary/Diary.tsx
+++ b/src/components/diary/Diary.tsx
@@ -27,7 +27,11 @@ const Diary = ({
   author,
 }: DiaryDetail) => {
   const handleFavorite = useHandleFavorite({ isFavorite, id });
-  const handleBookmark = useHandleBookmark({ isBookmark, id });
+  const handleBookmark = useHandleBookmark({
+    isBookmark,
+    id,
+    username: author.username,
+  });
 
   return (
     <Container>

--- a/src/constants/api/path.ts
+++ b/src/constants/api/path.ts
@@ -10,6 +10,7 @@ export const API_PATH = {
   diaries: {
     index: '/diaries',
     image: '/diaries/upload-image',
+    bookmark: '/diaries/bookmark',
   },
   terms: {
     index: '/terms-agreements',

--- a/src/containers/profile/ProfileContainer.tsx
+++ b/src/containers/profile/ProfileContainer.tsx
@@ -1,0 +1,65 @@
+import styled from '@emotion/styled';
+import Image from 'next/image';
+import Link from 'next/link';
+import { SettingIcon } from 'assets/icons';
+import { useProfile } from 'hooks/services';
+
+interface ProfileContainerProps {
+  username: string;
+}
+
+export const ProfileContainer = ({ username }: ProfileContainerProps) => {
+  const { profileData, isLoading } = useProfile(username);
+
+  if (profileData === undefined) return <div />;
+  if (isLoading) return <div>Loading</div>;
+
+  return (
+    <Container>
+      <SettingLink href={'/setting'}>
+        <SettingIcon />
+      </SettingLink>
+      <ProfileImage
+        src={profileData.imgUrl}
+        alt={profileData.username}
+        width={92}
+        height={92}
+        priority
+      />
+      <UserName>{username}</UserName>
+      <EditLink href={'/profile/edit'}>프로필 수정</EditLink>
+    </Container>
+  );
+};
+
+const Container = styled.section`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  position: relative;
+  padding: 32px 20px;
+  border-bottom: 12px solid ${({ theme }) => theme.colors.gray_06};
+  background-color: ${({ theme }) => theme.colors.white};
+`;
+
+const SettingLink = styled(Link)`
+  position: absolute;
+  top: 32px;
+  right: 20px;
+`;
+
+const ProfileImage = styled(Image)`
+  border-radius: 50%;
+`;
+
+const UserName = styled.h2`
+  margin: 8px 0 6px;
+  ${({ theme }) => theme.fonts.headline_01};
+`;
+
+const EditLink = styled(Link)`
+  padding: 12px 20px;
+  border-radius: 120px;
+  background: #f4f4f4;
+  ${({ theme }) => theme.fonts.caption_01};
+`;

--- a/src/containers/users/UserDiariesContainer.tsx
+++ b/src/containers/users/UserDiariesContainer.tsx
@@ -1,21 +1,18 @@
 import styled from '@emotion/styled';
 import Diary from '../../components/diary/Diary';
+import type { Diaries } from 'types/diary';
 import Empty from 'components/profile/Empty';
-import { useUserDiaries } from 'hooks/services';
 
 interface UserDiariesContainerProps {
-  username: string;
+  diariesData: Diaries;
 }
 
-const UserDiariesContainer = ({ username }: UserDiariesContainerProps) => {
-  const { userDiariesData, isLoading } = useUserDiaries(username);
+const UserDiariesContainer = ({ diariesData }: UserDiariesContainerProps) => {
+  const { diaries } = diariesData;
 
-  if (userDiariesData === undefined) return <div />;
-  if (isLoading) return <div>Loading</div>;
-
-  const { diaries } = userDiariesData;
-
-  if (diaries.length === 0) return <Empty text={'일기가 없습니다.'} />;
+  // TODO: 북마크한 일기 리스트 조회 데이터 구조 변경 완료 후 수정
+  if (diaries === undefined || diaries.length === 0)
+    return <Empty text={'일기가 없습니다.'} />;
 
   return (
     <List>

--- a/src/containers/users/UserDiariesContainer.tsx
+++ b/src/containers/users/UserDiariesContainer.tsx
@@ -1,0 +1,36 @@
+import styled from '@emotion/styled';
+import Diary from '../../components/diary/Diary';
+import Empty from 'components/profile/Empty';
+import { useUserDiaries } from 'hooks/services';
+
+interface UserDiariesContainerProps {
+  username: string;
+}
+
+const UserDiariesContainer = ({ username }: UserDiariesContainerProps) => {
+  const { userDiariesData, isLoading } = useUserDiaries(username);
+
+  if (userDiariesData === undefined) return <div />;
+  if (isLoading) return <div>Loading</div>;
+
+  const { diaries } = userDiariesData;
+
+  if (diaries.length === 0) return <Empty text={'일기가 없습니다.'} />;
+
+  return (
+    <List>
+      {diaries.map((diary) => {
+        const { id } = diary;
+        return <Diary key={`diary-list-${id}`} {...diary} />;
+      })}
+    </List>
+  );
+};
+
+export default UserDiariesContainer;
+
+const List = styled.ul`
+  display: grid;
+  gap: 6px;
+  background-color: ${({ theme }) => theme.colors.gray_06};
+`;

--- a/src/hooks/common/useHandleBookmark.ts
+++ b/src/hooks/common/useHandleBookmark.ts
@@ -1,13 +1,15 @@
 import { useBookmarkDiary, useCancelBookmarkDiary } from '../services';
+import type { User } from 'next-auth';
 import type { MouseEventHandler } from 'react';
 import type { DiaryDetail } from 'types/diary';
 
 export const useHandleBookmark = ({
   isBookmark,
   id,
-}: Pick<DiaryDetail, 'id' | 'isBookmark'>) => {
-  const bookmarkMutation = useBookmarkDiary(id);
-  const cancelBookmarkMutation = useCancelBookmarkDiary(id);
+  username,
+}: Pick<DiaryDetail, 'id' | 'isBookmark'> & Pick<User, 'username'>) => {
+  const bookmarkMutation = useBookmarkDiary(id, username);
+  const cancelBookmarkMutation = useCancelBookmarkDiary(id, username);
 
   const handleBookmark: MouseEventHandler<HTMLButtonElement> = () => {
     if (isBookmark) {

--- a/src/hooks/services/index.ts
+++ b/src/hooks/services/index.ts
@@ -12,3 +12,4 @@ export * from './queries/useDiaries';
 export * from './queries/useDiary';
 export * from './queries/useComments';
 export * from './queries/useTermsAgreements';
+export * from './queries/useProfile';

--- a/src/hooks/services/index.ts
+++ b/src/hooks/services/index.ts
@@ -14,3 +14,4 @@ export * from './queries/useComments';
 export * from './queries/useTermsAgreements';
 export * from './queries/useProfile';
 export * from './queries/useUserDiaries';
+export * from './queries/useBookmarkedDiaries';

--- a/src/hooks/services/index.ts
+++ b/src/hooks/services/index.ts
@@ -13,3 +13,4 @@ export * from './queries/useDiary';
 export * from './queries/useComments';
 export * from './queries/useTermsAgreements';
 export * from './queries/useProfile';
+export * from './queries/useUserDiaries';

--- a/src/hooks/services/mutations/useBookmarkDiary.ts
+++ b/src/hooks/services/mutations/useBookmarkDiary.ts
@@ -2,12 +2,13 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import * as api from 'api';
 import { queryKeys } from 'constants/queryKeys';
 
-export const useBookmarkDiary = (diaryId: string) => {
+export const useBookmarkDiary = (diaryId: string, username: string) => {
   const queryClient = useQueryClient();
   const { mutate } = useMutation(async () => await api.bookmarkDiary(diaryId), {
     onSuccess: async () => {
       await queryClient.invalidateQueries([queryKeys.diaries]);
       await queryClient.invalidateQueries([queryKeys.diaries, diaryId]);
+      await queryClient.invalidateQueries([queryKeys.bookmark, username]);
     },
   });
 

--- a/src/hooks/services/mutations/useCancelBookmarkDiary.ts
+++ b/src/hooks/services/mutations/useCancelBookmarkDiary.ts
@@ -2,7 +2,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import * as api from 'api';
 import { queryKeys } from 'constants/queryKeys';
 
-export const useCancelBookmarkDiary = (diaryId: string) => {
+export const useCancelBookmarkDiary = (diaryId: string, username: string) => {
   const queryClient = useQueryClient();
   const { mutate } = useMutation(
     async () => await api.cancelBookmarkDiary(diaryId),
@@ -10,6 +10,7 @@ export const useCancelBookmarkDiary = (diaryId: string) => {
       onSuccess: async () => {
         await queryClient.invalidateQueries([queryKeys.diaries]);
         await queryClient.invalidateQueries([queryKeys.diaries, diaryId]);
+        await queryClient.invalidateQueries([queryKeys.bookmark, username]);
       },
     },
   );

--- a/src/hooks/services/mutations/useWriteDiary.ts
+++ b/src/hooks/services/mutations/useWriteDiary.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/router';
-import type { DiaryRequest } from 'types/diary';
+import type { WriteDiaryRequest } from 'types/diary';
 import * as api from 'api';
 import { queryKeys } from 'constants/queryKeys';
 
@@ -8,7 +8,7 @@ export const useWriteDiary = () => {
   const router = useRouter();
   const queryClient = useQueryClient();
   const { mutate } = useMutation(
-    async ({ title, content, imgUrl, isPublic }: DiaryRequest) => {
+    async ({ title, content, imgUrl, isPublic }: WriteDiaryRequest) => {
       const {
         data: { diary },
       } = await api.writeDiary({

--- a/src/hooks/services/queries/useBookmarkedDiaries.ts
+++ b/src/hooks/services/queries/useBookmarkedDiaries.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+import * as api from 'api';
+import { queryKeys } from 'constants/queryKeys';
+
+export const useBookmarkedDiaries = (username: string) => {
+  const { data: bookmarkedDiariesData, isLoading } = useQuery(
+    [queryKeys.bookmark, username], // TODO: 북마트한 다이어리 queryKeys 확인
+    async () => await api.getBookmarkedDiariesByUsername({ username }),
+  );
+  return { bookmarkedDiariesData, isLoading };
+};

--- a/src/hooks/services/queries/useProfile.ts
+++ b/src/hooks/services/queries/useProfile.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+import * as api from 'api';
+import { queryKeys } from 'constants/queryKeys';
+
+export const useProfile = (username: string) => {
+  const { data: profileData, isLoading } = useQuery(
+    [queryKeys.users, username],
+    async () => await api.getProfileByUsername({ username }),
+  );
+  return { profileData, isLoading };
+};

--- a/src/hooks/services/queries/useUserDiaries.ts
+++ b/src/hooks/services/queries/useUserDiaries.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+import * as api from 'api';
+import { queryKeys } from 'constants/queryKeys';
+
+export const useUserDiaries = (username: string) => {
+  const { data: userDiariesData, isLoading } = useQuery(
+    [queryKeys.diaries, username],
+    async () => await api.getDiariesByUsername({ username }),
+  );
+  return { userDiariesData, isLoading };
+};

--- a/src/hooks/useTabIndicator.ts
+++ b/src/hooks/useTabIndicator.ts
@@ -1,21 +1,17 @@
-import { useEffect, useState } from 'react';
-import type { MutableRefObject } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
-interface IndicatorProps {
+interface Indicator {
   width: number;
   offsetLeft: number;
 }
 
-interface UseTabIndicatorProps {
-  tabsRef: MutableRefObject<Array<HTMLButtonElement | null>>;
-  activeIndex: number;
-}
-
-const useTabIndicator = ({ tabsRef, activeIndex }: UseTabIndicatorProps) => {
-  const [indicator, setIndicator] = useState<IndicatorProps>({
+const useTabIndicator = () => {
+  const [activeIndex, setActiveIndex] = useState<number>(0);
+  const [indicator, setIndicator] = useState<Indicator>({
     width: 0,
     offsetLeft: 0,
   });
+  const tabsRef = useRef<Array<HTMLElement | null>>([]);
 
   useEffect(() => {
     const setIndicatorPosition = () => {
@@ -34,7 +30,7 @@ const useTabIndicator = ({ tabsRef, activeIndex }: UseTabIndicatorProps) => {
     };
   }, [activeIndex]);
 
-  return indicator;
+  return { tabsRef, indicator, activeIndex, setActiveIndex };
 };
 
 export default useTabIndicator;

--- a/src/pages/diary/[id]/edit.tsx
+++ b/src/pages/diary/[id]/edit.tsx
@@ -251,9 +251,12 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
   await queryClient.prefetchQuery(
     [queryKeys.diaries, id],
     async () =>
-      await api.getDiaryDetail(id as string, {
-        headers: {
-          Authorization: `Bearer ${session.user.accessToken}`,
+      await api.getDiaryDetail({
+        id: id as string,
+        config: {
+          headers: {
+            Authorization: `Bearer ${session.user.accessToken}`,
+          },
         },
       }),
   );

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -1,11 +1,16 @@
 import styled from '@emotion/styled';
-import Link from 'next/link';
-import type { NextPage } from 'next';
-import { SettingIcon } from 'assets/icons';
+import { QueryClient, dehydrate } from '@tanstack/react-query';
+import { getServerSession } from 'next-auth';
+import { useSession } from 'next-auth/react';
+import type { GetServerSideProps, NextPage } from 'next';
+import * as api from 'api';
 import Seo from 'components/common/Seo';
 import Tab from 'components/common/Tab';
 import Empty from 'components/profile/Empty';
+import { queryKeys } from 'constants/queryKeys';
+import { ProfileContainer } from 'containers/profile/ProfileContainer';
 import { useTabIndicator } from 'hooks';
+import { authOptions } from 'pages/api/auth/[...nextauth]';
 
 const PROFILE_TAB_LIST = [
   { id: 'activities', title: '활동' },
@@ -16,17 +21,14 @@ const PROFILE_TAB_LIST = [
 const Profile: NextPage = () => {
   const { tabsRef, indicator, activeIndex, setActiveIndex } = useTabIndicator();
 
+  const { data: session } = useSession();
+
+  if (session === null) return <div>로그인이 필요합니다.</div>; // TODO: 로그인 페이지로 이동 모달 생성하여 적용하기
+
   return (
     <>
       <Seo title="프로필 | a daily diary" />
-      <UserInfoContainer>
-        <SettingLink href={'/setting'}>
-          <SettingIcon />
-        </SettingLink>
-        <UserProfileImage />
-        <UserName>userid1234</UserName>
-        <ProfileEditLink href={'/profile/edit'}>프로필 수정</ProfileEditLink>
-      </UserInfoContainer>
+      <ProfileContainer username={session.user.username} />
       <section>
         <Tab indicator={indicator}>
           {PROFILE_TAB_LIST.map((tab, index) => {
@@ -66,42 +68,35 @@ const Profile: NextPage = () => {
   );
 };
 
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const { req, res } = context;
+  const session = await getServerSession(req, res, authOptions);
+
+  if (session === null) {
+    return {
+      redirect: {
+        destination: '/account/login',
+        permanent: false,
+      },
+    };
+  }
+
+  const { username, accessToken } = session.user;
+
+  const headers = {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  };
+
+  const queryClient = new QueryClient();
+  await queryClient.prefetchQuery([queryKeys.users, username], async () => {
+    return await api.getProfileByUsername({ username, config: headers });
+  });
+  return { props: { dehydratedState: dehydrate(queryClient), session } };
+};
+
 export default Profile;
-
-const UserInfoContainer = styled.section`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  position: relative;
-  padding: 32px 20px;
-  border-bottom: 12px solid ${({ theme }) => theme.colors.gray_06};
-  background-color: ${({ theme }) => theme.colors.white};
-`;
-
-const SettingLink = styled(Link)`
-  position: absolute;
-  top: 32px;
-  right: 20px;
-`;
-
-const UserProfileImage = styled.div`
-  width: 92px;
-  height: 92px;
-  border-radius: 50%;
-  background-color: #d9d9d9;
-`;
-
-const UserName = styled.h2`
-  margin: 8px 0 6px;
-  ${({ theme }) => theme.fonts.headline_01};
-`;
-
-const ProfileEditLink = styled(Link)`
-  padding: 12px 20px;
-  border-radius: 120px;
-  background: #f4f4f4;
-  ${({ theme }) => theme.fonts.caption_01};
-`;
 
 const TabButton = styled.button<{ active: boolean }>`
   ${({ theme }) => theme.fonts.headline_04};

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -12,6 +12,7 @@ import UserDiariesContainer from 'containers/users/UserDiariesContainer';
 import { useTabIndicator } from 'hooks';
 import { useBookmarkedDiaries, useUserDiaries } from 'hooks/services';
 import { authOptions } from 'pages/api/auth/[...nextauth]';
+import { ScreenReaderOnly } from 'styles';
 
 const PROFILE_TAB_LIST = [
   { id: 'activities', title: '활동' },
@@ -63,10 +64,16 @@ const Profile: NextPage = () => {
         </Tab>
         <article>
           {PROFILE_TAB_LIST[activeIndex].id === 'diaries' && (
-            <UserDiariesContainer diariesData={userDiariesData} />
+            <>
+              <Title>{PROFILE_TAB_LIST[activeIndex].title}</Title>
+              <UserDiariesContainer diariesData={userDiariesData} />
+            </>
           )}
           {PROFILE_TAB_LIST[activeIndex].id === 'bookmarks' && (
-            <UserDiariesContainer diariesData={bookmarkedDiariesData} />
+            <>
+              <Title>{PROFILE_TAB_LIST[activeIndex].title}</Title>
+              <UserDiariesContainer diariesData={bookmarkedDiariesData} />
+            </>
           )}
         </article>
       </section>
@@ -115,4 +122,8 @@ export default Profile;
 
 const TabButton = styled.button<{ active: boolean }>`
   ${({ theme }) => theme.fonts.headline_04};
+`;
+
+const Title = styled.h2`
+  ${ScreenReaderOnly}
 `;

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -1,6 +1,5 @@
 import styled from '@emotion/styled';
 import Link from 'next/link';
-import { useRef, useState } from 'react';
 import type { NextPage } from 'next';
 import { SettingIcon } from 'assets/icons';
 import Seo from 'components/common/Seo';
@@ -15,9 +14,7 @@ const PROFILE_TAB_LIST = [
 ];
 
 const Profile: NextPage = () => {
-  const [activeIndex, setActiveIndex] = useState<number>(0);
-  const tabsRef = useRef<Array<HTMLButtonElement | null>>([]);
-  const indicator = useTabIndicator({ tabsRef, activeIndex });
+  const { tabsRef, indicator, activeIndex, setActiveIndex } = useTabIndicator();
 
   return (
     <>

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -9,6 +9,7 @@ import Tab from 'components/common/Tab';
 import Empty from 'components/profile/Empty';
 import { queryKeys } from 'constants/queryKeys';
 import { ProfileContainer } from 'containers/profile/ProfileContainer';
+import UserDiariesContainer from 'containers/users/UserDiariesContainer';
 import { useTabIndicator } from 'hooks';
 import { authOptions } from 'pages/api/auth/[...nextauth]';
 
@@ -50,12 +51,9 @@ const Profile: NextPage = () => {
           })}
         </Tab>
         <article>
-          {PROFILE_TAB_LIST[activeIndex].id === 'diaries' &&
-            (PROFILE_TAB_LIST[activeIndex].content !== null ? (
-              <div>일기</div>
-            ) : (
-              <Empty text={'일기가 없습니다.'} />
-            ))}
+          {PROFILE_TAB_LIST[activeIndex].id === 'diaries' && (
+            <UserDiariesContainer username={session.user.username} />
+          )}
           {PROFILE_TAB_LIST[activeIndex].id === 'bookmarks' &&
             (PROFILE_TAB_LIST[activeIndex].content !== null ? (
               <div>북마크</div>
@@ -93,6 +91,10 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
   await queryClient.prefetchQuery([queryKeys.users, username], async () => {
     return await api.getProfileByUsername({ username, config: headers });
   });
+  await queryClient.prefetchQuery(
+    [queryKeys.diaries, username],
+    async () => await api.getDiariesByUsername({ username, config: headers }),
+  );
   return { props: { dehydratedState: dehydrate(queryClient), session } };
 };
 

--- a/src/types/profile.ts
+++ b/src/types/profile.ts
@@ -1,0 +1,8 @@
+import type { AxiosRequestConfig } from 'axios';
+
+/* Request */
+
+export interface GetProfileByUsernameRequest {
+  username: string;
+  config?: AxiosRequestConfig;
+}


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #149

<br />

## 🗒 작업 목록

- [x] 사용자 프로필 정보 조회, 사용자 작성한 일기 조회, 사용자가 북마크한 일기 조회 api 구현
- [x] 각 api의 queries 커스텀 훅 생성 및 적용
  - useProfile : 사용자 프로필 정보 조회
  - useUserDiaries : 사용자 작성한 일기 조회
  - useBookmarkedDiaries : 사용자가 북마크한 일기 조회
- [x] 프로필 페이지 > 일기 탭, 북마크 탭에 heading 태그 적용
- [x] useTabIndicator 리팩토링

<br />

## 🧐 PR Point

- 프로필 페이지에서 보여줘야 할 데이터 패칭 작업을 진행했습니다.
- useTabIndicator 커스컴 훅을 리팩토링 하여 훅 내부로 state와 ref를 넣어 모두 한 번에 관리할 수 있도록 했습니다.
  - 이를 통해 사용하는 페이지에서 복잡했던 코드를 간결하게 사용할 수 있도록 했습니다.
- 일기 탭, 북마크 탭의 컨텐츠가 article 태그로 감싸져 있습니다.
  - 따라서 적절한 heading 태그를 넣고 ScreenReaderOnly 스타일을 적용하여 웹 표준 준수 및 웹 접근성 향상시켰습니다.

<br />

## 💥 Trouble Shooting
#### 북마크 탭에서 북마크 해제 후 실시간 갱신이 되지 않는 문제
- 북마크 탭에서 북마크 된 일기의 북마크를 해제 후 새로고침을 해야 해당 내용이 갱신되었습니다.
- 북마크/ 북마크 해제 mutaition에서 `queryClient.invalidateQueries([queryKeys.bookmark, username]);`에 해당하는 데이터를 무효화 하여 해결했습니다.

<br />

## 📸 스크린샷 / 피그마 링크

- 내용을 입력해주세요.

<br />

## 📚 참고

- 참고한 내용 또는 링크를 입력해주세요.

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다. 
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
