### PR TITLE
로그인 토큰 만료 기간 동기화

### DIFF
--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -11,7 +11,7 @@ import { errorResponseMessage } from 'utils';
 export const authOptions: NextAuthOptions = {
   session: {
     strategy: 'jwt',
-    maxAge: 30 * 24 * 60 * 60, // 30 days
+    maxAge: 24 * 60 * 60, // NOTE: 24 hours
   },
   providers: [
     // email, password를 이용한 인증 방식

--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -14,14 +14,12 @@ export const authOptions: NextAuthOptions = {
     maxAge: 24 * 60 * 60, // NOTE: 24 hours
   },
   providers: [
-    // email, password를 이용한 인증 방식
     CredentialsProvider({
       name: 'Credentials',
       credentials: {
         email: { type: 'text' },
         password: { type: 'password' },
       },
-      // 로그인 인증
       async authorize(credentials, _req) {
         const { email, password } = credentials as LoginRequest;
 
@@ -31,11 +29,13 @@ export const authOptions: NextAuthOptions = {
               data: { user, token },
             },
           } = await api.login({ email, password });
+
           return { ...user, accessToken: token };
         } catch (error) {
           if (isAxiosError<ErrorResponse>(error)) {
             throw new Error(errorResponseMessage(error.response?.data.message));
           }
+
           return null;
         }
       },
@@ -64,7 +64,6 @@ export const authOptions: NextAuthOptions = {
       const { email, id, imgUrl, isAdmin, username, accessToken } = token;
       // session.user에 token의 로그인 한 사용자 정보 전달
       session.user = { email, id, username, imgUrl, isAdmin, accessToken };
-      // session.accessToken = accessToken;
 
       return await Promise.resolve(session);
     },
@@ -73,7 +72,6 @@ export const authOptions: NextAuthOptions = {
     },
   },
   pages: {
-    // 커스텀 로그인 페이지로 라우팅 처리
     signIn: '/account/login',
   },
   secret: process.env.NEXTAUTH_SECRET,


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #175

<br />

## 🗒 작업 목록

- [x] next-auth session maxAge를 기존 30일에서 24시간으로 변경
- [x] next-auth option 내 불필요한 주석 제거

<br />

## 🧐 PR Point

- next-auth option의 session(token) 만료 기간의 초기 설정을 공식문서와 동일하게 30일로 지정해두었습니다.
- 이후 서버에서 전달해주는 토큰을 받아 next-auth session에 해당 토큰을 전달하여 로그인 상태를 유지합니다.
- 서버에서 전달해주는 토큰의 만료 기간은 24시간으로 클라이언트와 만료 기간의 차이가 생겨 실제 서버 토큰은 만료가 되어 유효하지 않은 토큰임을 나타내며 api 호출이 정상적으로 이루어지지 않으나 클라이언트에서는 유효한 토큰으로 인식하여 브라우저의 쿠키 정보를 삭제해줘야 하는 번거로움이 있었습니다.
- 이를 해소하기 위해 서버와 동일한 만료 기간을 적용했습니다.

> #### 24시간 이후 토큰이 정상적으로 만료되는지 확인하기 위해 잠시 draft로 PR을 올려둡니다.

<br />

## 💥 Trouble Shooting
- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크
- 로그인 시간과 만료 시간 확인
![Group 12](https://github.com/a-daily-diary/ADD.FE/assets/85009583/37d2dbe6-679a-4e98-98be-0c6ed95e8821)

<br />

## 📚 참고

- 참고한 내용 또는 링크를 입력해주세요.

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다. 
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
