### PR TITLE
다른 사용자 프로필 페이지 구현 

### DIFF
--- a/src/components/diary/DiariesContainer.tsx
+++ b/src/components/diary/DiariesContainer.tsx
@@ -2,13 +2,16 @@ import styled from '@emotion/styled';
 import Diary from './Diary';
 import type { ReactNode } from 'react';
 import type { Diaries } from 'types/diary';
+import { ScreenReaderOnly } from 'styles';
 
 interface DiariesContainerProps {
+  title: string;
   diariesData: Diaries;
   empty?: ReactNode;
 }
 
 export const DiariesContainer = ({
+  title,
   diariesData,
   empty,
 }: DiariesContainerProps) => {
@@ -21,14 +24,21 @@ export const DiariesContainer = ({
   }
 
   return (
-    <List>
-      {diaries.map((diary) => {
-        const { id } = diary;
-        return <Diary key={`diary-list-${id}`} {...diary} />;
-      })}
-    </List>
+    <article>
+      <Title>{title}</Title>
+      <List>
+        {diaries.map((diary) => {
+          const { id } = diary;
+          return <Diary key={`diary-list-${id}`} {...diary} />;
+        })}
+      </List>
+    </article>
   );
 };
+
+const Title = styled.h2`
+  ${ScreenReaderOnly}
+`;
 
 const List = styled.ul`
   display: grid;

--- a/src/components/diary/DiariesContainer.tsx
+++ b/src/components/diary/DiariesContainer.tsx
@@ -1,13 +1,12 @@
 import styled from '@emotion/styled';
 import Diary from './Diary';
-import type { ReactNode } from 'react';
 import type { Diaries } from 'types/diary';
 import { ScreenReaderOnly } from 'styles';
 
 interface DiariesContainerProps {
   title: string;
   diariesData: Diaries;
-  empty?: ReactNode;
+  empty: JSX.Element;
 }
 
 export const DiariesContainer = ({
@@ -16,12 +15,11 @@ export const DiariesContainer = ({
   empty,
 }: DiariesContainerProps) => {
   const { diaries } = diariesData;
+  const isEmptyDiaries = diaries === undefined || diaries.length === 0;
 
   // TODO: 북마크한 일기 리스트 조회 데이터 구조 변경 완료 후 수정
   // diaries의 값이 null일 경우가 있는지 확인
-  if (diaries === undefined || diaries.length === 0) {
-    return <>{empty}</>;
-  }
+  if (isEmptyDiaries) return empty;
 
   return (
     <article>

--- a/src/components/profile/ProfileContainer.tsx
+++ b/src/components/profile/ProfileContainer.tsx
@@ -6,9 +6,13 @@ import { useProfile } from 'hooks/services';
 
 interface ProfileContainerProps {
   username: string;
+  isMyProfile?: boolean;
 }
 
-export const ProfileContainer = ({ username }: ProfileContainerProps) => {
+export const ProfileContainer = ({
+  username,
+  isMyProfile = true,
+}: ProfileContainerProps) => {
   const { profileData, isLoading } = useProfile(username);
 
   if (profileData === undefined) return <div />;
@@ -16,9 +20,11 @@ export const ProfileContainer = ({ username }: ProfileContainerProps) => {
 
   return (
     <Container>
-      <SettingLink href={'/setting'}>
-        <SettingIcon />
-      </SettingLink>
+      {isMyProfile && (
+        <SettingLink href={'/setting'}>
+          <SettingIcon />
+        </SettingLink>
+      )}
       <ProfileImage
         src={profileData.imgUrl}
         alt={profileData.username}
@@ -27,7 +33,7 @@ export const ProfileContainer = ({ username }: ProfileContainerProps) => {
         priority
       />
       <UserName>{username}</UserName>
-      <EditLink href={'/profile/edit'}>프로필 수정</EditLink>
+      {isMyProfile && <EditLink href={'/profile/edit'}>프로필 수정</EditLink>}
     </Container>
   );
 };
@@ -60,6 +66,6 @@ const UserName = styled.h2`
 const EditLink = styled(Link)`
   padding: 12px 20px;
   border-radius: 120px;
-  background: #f4f4f4;
+  background: ${({ theme }) => theme.colors.bg_02};
   ${({ theme }) => theme.fonts.caption_01};
 `;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -7,6 +7,7 @@ import type { GetServerSideProps, NextPage } from 'next';
 import * as api from 'api';
 import { ResponsiveImage, Seo } from 'components/common';
 import { DiariesContainer } from 'components/diary';
+import EmptyDiary from 'components/diary/EmptyDiary';
 import { Header, HeaderLeft, HeaderRight } from 'components/layouts';
 import { queryKeys } from 'constants/queryKeys';
 import { useDiaries } from 'hooks/services';
@@ -33,7 +34,11 @@ const Home: NextPage = () => {
           />
         </Link>
       </BannerContainer>
-      <DiariesContainer diariesData={diariesData} />
+      <DiariesContainer
+        title="일기"
+        diariesData={diariesData}
+        empty={<EmptyDiary text="일기가 없습니다." />}
+      />
     </>
   );
 };

--- a/src/pages/profile/[username].tsx
+++ b/src/pages/profile/[username].tsx
@@ -17,7 +17,6 @@ import { queryKeys } from 'constants/queryKeys';
 import { useTabIndicator } from 'hooks/common';
 import { useBookmarkedDiaries, useUserDiaries } from 'hooks/services';
 import { authOptions } from 'pages/api/auth/[...nextauth]';
-import { ScreenReaderOnly } from 'styles';
 
 const PROFILE_TAB_LIST = [
   { id: 'activities', title: '활동' },
@@ -67,17 +66,13 @@ const YourProfile: NextPage<
             );
           })}
         </Tab>
-        <article>
-          {PROFILE_TAB_LIST[activeIndex].id === 'diaries' && (
-            <>
-              <Title>{PROFILE_TAB_LIST[activeIndex].title}</Title>
-              <DiariesContainer
-                diariesData={userDiariesData}
-                empty={<EmptyDiary text="일기가 없습니다." />}
-              />
-            </>
-          )}
-        </article>
+        {PROFILE_TAB_LIST[activeIndex].id === 'diaries' && (
+          <DiariesContainer
+            title={PROFILE_TAB_LIST[activeIndex].title}
+            diariesData={userDiariesData}
+            empty={<EmptyDiary text="일기가 없습니다." />}
+          />
+        )}
       </section>
     </>
   );
@@ -142,8 +137,4 @@ export default YourProfile;
 
 const TabButton = styled.button<{ active: boolean }>`
   ${({ theme }) => theme.fonts.headline_04};
-`;
-
-const Title = styled.h2`
-  ${ScreenReaderOnly}
 `;

--- a/src/pages/profile/[username].tsx
+++ b/src/pages/profile/[username].tsx
@@ -4,7 +4,6 @@ import { isAxiosError } from 'axios';
 import { getServerSession } from 'next-auth';
 import type {
   GetServerSideProps,
-  GetServerSidePropsContext,
   InferGetServerSidePropsType,
   NextPage,
 } from 'next';
@@ -78,9 +77,7 @@ const YourProfile: NextPage<
   );
 };
 
-export const getServerSideProps = (async (
-  context: GetServerSidePropsContext,
-) => {
+export const getServerSideProps = (async (context) => {
   const { req, res, params } = context;
   const username = params?.username as string;
 

--- a/src/pages/profile/[username].tsx
+++ b/src/pages/profile/[username].tsx
@@ -1,0 +1,149 @@
+import styled from '@emotion/styled';
+import { QueryClient, dehydrate } from '@tanstack/react-query';
+import { isAxiosError } from 'axios';
+import { getServerSession } from 'next-auth';
+import type {
+  GetServerSideProps,
+  GetServerSidePropsContext,
+  InferGetServerSidePropsType,
+  NextPage,
+} from 'next';
+import * as api from 'api';
+import { Seo, Tab } from 'components/common';
+import { DiariesContainer } from 'components/diary';
+import EmptyDiary from 'components/diary/EmptyDiary';
+import { ProfileContainer } from 'components/profile';
+import { queryKeys } from 'constants/queryKeys';
+import { useTabIndicator } from 'hooks/common';
+import { useBookmarkedDiaries, useUserDiaries } from 'hooks/services';
+import { authOptions } from 'pages/api/auth/[...nextauth]';
+import { ScreenReaderOnly } from 'styles';
+
+const PROFILE_TAB_LIST = [
+  { id: 'activities', title: '활동' },
+  { id: 'diaries', title: '일기' },
+];
+
+const YourProfile: NextPage<
+  InferGetServerSidePropsType<typeof getServerSideProps>
+> = ({ username }) => {
+  const { tabsRef, indicator, activeIndex, setActiveIndex } = useTabIndicator();
+
+  const { userDiariesData, isLoading: isUserDiariesLoading } =
+    useUserDiaries(username);
+  const { bookmarkedDiariesData, isLoading: isBookmarkedDiariesLoading } =
+    useBookmarkedDiaries(username);
+
+  // TODO: Loading 컴포넌트 적용
+  if (
+    userDiariesData === undefined ||
+    bookmarkedDiariesData === undefined ||
+    isUserDiariesLoading ||
+    isBookmarkedDiariesLoading
+  )
+    return <div>Loading</div>;
+
+  return (
+    <>
+      <Seo title="프로필 | a daily diary" />
+      <ProfileContainer username={username} isMyProfile={false} />
+      <section>
+        <Tab indicator={indicator}>
+          {PROFILE_TAB_LIST.map((tab, index) => {
+            const { id, title } = tab;
+            return (
+              <li key={`tab-list-${id}`}>
+                <TabButton
+                  type="button"
+                  ref={(el) => (tabsRef.current[index] = el)}
+                  onClick={() => {
+                    setActiveIndex(index);
+                  }}
+                  active={activeIndex === index}
+                >
+                  {title}
+                </TabButton>
+              </li>
+            );
+          })}
+        </Tab>
+        <article>
+          {PROFILE_TAB_LIST[activeIndex].id === 'diaries' && (
+            <>
+              <Title>{PROFILE_TAB_LIST[activeIndex].title}</Title>
+              <DiariesContainer
+                diariesData={userDiariesData}
+                empty={<EmptyDiary text="일기가 없습니다." />}
+              />
+            </>
+          )}
+        </article>
+      </section>
+    </>
+  );
+};
+
+export const getServerSideProps = (async (
+  context: GetServerSidePropsContext,
+) => {
+  const { req, res, params } = context;
+  const username = params?.username as string;
+
+  const session = await getServerSession(req, res, authOptions);
+
+  if (session === null) {
+    return {
+      redirect: {
+        destination: '/account/login',
+        permanent: false,
+      },
+    };
+  }
+
+  const { accessToken, username: loggedInUsername } = session.user;
+
+  if (loggedInUsername === username) {
+    return {
+      redirect: {
+        destination: '/profile',
+        permanent: false,
+      },
+    };
+  }
+
+  const headers = {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  };
+
+  const queryClient = new QueryClient();
+
+  try {
+    await queryClient.fetchQuery([queryKeys.users, username], async () => {
+      return await api.getProfileByUsername({ username, config: headers });
+    });
+    await queryClient.fetchQuery(
+      [queryKeys.diaries, username],
+      async () => await api.getDiariesByUsername({ username, config: headers }),
+    );
+  } catch (error) {
+    if (isAxiosError(error)) {
+      return {
+        notFound: true,
+      };
+    }
+  }
+
+  return { props: { dehydratedState: dehydrate(queryClient), username } };
+}) satisfies GetServerSideProps;
+
+export default YourProfile;
+
+const TabButton = styled.button<{ active: boolean }>`
+  ${({ theme }) => theme.fonts.headline_04};
+`;
+
+const Title = styled.h2`
+  ${ScreenReaderOnly}
+`;

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -20,7 +20,7 @@ const PROFILE_TAB_LIST = [
   { id: 'bookmarks', title: '북마크' },
 ];
 
-const Profile: NextPage = () => {
+const MyProfile: NextPage = () => {
   const { tabsRef, indicator, activeIndex, setActiveIndex } = useTabIndicator();
 
   const { data: session } = useSession();
@@ -124,7 +124,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
   return { props: { dehydratedState: dehydrate(queryClient), session } };
 };
 
-export default Profile;
+export default MyProfile;
 
 const TabButton = styled.button<{ active: boolean }>`
   ${({ theme }) => theme.fonts.headline_04};

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -12,7 +12,6 @@ import { queryKeys } from 'constants/queryKeys';
 import { useTabIndicator } from 'hooks/common';
 import { useBookmarkedDiaries, useUserDiaries } from 'hooks/services';
 import { authOptions } from 'pages/api/auth/[...nextauth]';
-import { ScreenReaderOnly } from 'styles';
 
 const PROFILE_TAB_LIST = [
   { id: 'activities', title: '활동' },
@@ -62,26 +61,20 @@ const MyProfile: NextPage = () => {
             );
           })}
         </Tab>
-        <article>
-          {PROFILE_TAB_LIST[activeIndex].id === 'diaries' && (
-            <>
-              <Title>{PROFILE_TAB_LIST[activeIndex].title}</Title>
-              <DiariesContainer
-                diariesData={userDiariesData}
-                empty={<EmptyDiary text="일기가 없습니다." />}
-              />
-            </>
-          )}
-          {PROFILE_TAB_LIST[activeIndex].id === 'bookmarks' && (
-            <>
-              <Title>{PROFILE_TAB_LIST[activeIndex].title}</Title>
-              <DiariesContainer
-                diariesData={bookmarkedDiariesData}
-                empty={<EmptyDiary text="북마크한 일기가 없습니다." />}
-              />
-            </>
-          )}
-        </article>
+        {PROFILE_TAB_LIST[activeIndex].id === 'diaries' && (
+          <DiariesContainer
+            title={PROFILE_TAB_LIST[activeIndex].title}
+            diariesData={userDiariesData}
+            empty={<EmptyDiary text="일기가 없습니다." />}
+          />
+        )}
+        {PROFILE_TAB_LIST[activeIndex].id === 'bookmarks' && (
+          <DiariesContainer
+            title={PROFILE_TAB_LIST[activeIndex].title}
+            diariesData={bookmarkedDiariesData}
+            empty={<EmptyDiary text="북마크한 일기가 없습니다." />}
+          />
+        )}
       </section>
     </>
   );
@@ -128,8 +121,4 @@ export default MyProfile;
 
 const TabButton = styled.button<{ active: boolean }>`
   ${({ theme }) => theme.fonts.headline_04};
-`;
-
-const Title = styled.h2`
-  ${ScreenReaderOnly}
 `;


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #178

<br />

## 🗒 작업 목록

- [x] 나의 프로필과 다른 사용자의 프로필에 `ProfileContainer`를 사용하기 위해 `isMyProfile` props 추가하여 분기처리
- [x] 다른 사용자 프로필 페이지(YourProfile) 구현 및 나의 프로필 페이지 컴포넌트 명 수정(Profile ⇒ MyProfile)
- [x] `DiariesContainer` 컴포넌트 리팩토링

<br />

## 🧐 PR Point

- 다른 사용자의 프로필에 접근할 때 나의 프로필과 구분될 수 있도록 구현했습니다.
- URL로 접근 시 `/profile` 로 접근하면 나의 프로필, `/profile/[username]`으로 접근하면 해당 닉네임의 사용자 프로필에 접근할 수 있습니다.
- `/profile/[username]` 경로를 통해 로그인된 사용자의 프로필에 접근할 경우 `/profile`로 라우팅 처리했습니다.
- 입력한 username을 사용하는 사용자가 없는 경우 404 페이지로 이동합니다.
- `ProfileContainer`에 `isMyProfile` props를 추가하여 나의 프로필과 다른 사용자의 프로필에 나타날 UI 분기처리를 했습니다.
- `DiariesContainer` 리팩토링을 했습니다.
  - `title` props 추가하여 `DiariesContainer`를 사용하는 곳에서 코드가 간략해지도록 수정
  - `diariesData`가 비어있는 경우, 전달한 empty 컴포넌트가 불필요한 프래그먼트 없이 반환될 수 있도록 수정 

<br />

## 💥 Trouble Shooting
- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크

https://github.com/a-daily-diary/ADD.FE/assets/85009583/0b3922e7-aa38-4aa2-a4af-d6d58e385da1

<br />

## 📚 참고

- 참고한 내용 또는 링크를 입력해주세요.

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다. 
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
