### PR TITLE
비밀번호 찾기 페이지 마크업 및 스타일링

### DIFF
--- a/src/components/account/FindPasswordForm.tsx
+++ b/src/components/account/FindPasswordForm.tsx
@@ -1,0 +1,34 @@
+import styled from '@emotion/styled';
+import { useFormContext } from 'react-hook-form';
+import type { RegisterForm } from 'types/register';
+import { FormInput } from 'components/form';
+import { ERROR_MESSAGE, VALID_VALUE } from 'constants/validation';
+
+export const FindPasswordForm = () => {
+  /**
+   * @todo
+   * RegisterForm 대신 PasswordFindForm 정의하여 사용
+   */
+  const { register } = useFormContext<RegisterForm>();
+
+  return (
+    <Form>
+      <FormInput
+        register={register('email', {
+          required: ERROR_MESSAGE.email.required,
+          pattern: {
+            value: VALID_VALUE.email,
+            message: ERROR_MESSAGE.email.pattern,
+          },
+        })}
+        type="text"
+        placeholder="이메일"
+        label="이메일"
+      />
+    </Form>
+  );
+};
+
+const Form = styled.form`
+  margin-top: 40px;
+`;

--- a/src/components/account/index.ts
+++ b/src/components/account/index.ts
@@ -2,3 +2,4 @@ export * from './CompleteRegister';
 export * from './RegisterInformation';
 export * from './RegisterProfileImage';
 export * from './RegisterTerms';
+export * from './FindPasswordForm';

--- a/src/pages/account/findPassword.tsx
+++ b/src/pages/account/findPassword.tsx
@@ -5,7 +5,6 @@ import type { RegisterForm } from 'types/register';
 import { FindPasswordForm } from 'components/account';
 import { Button, Seo } from 'components/common';
 import { Header, HeaderLeft, HeaderTitle } from 'components/layouts';
-import { Z_INDEX } from 'constants/styles';
 
 const FindPassword: NextPage = () => {
   /**
@@ -27,8 +26,9 @@ const FindPassword: NextPage = () => {
       <ContentWrapper>
         <Title>비밀번호를 잊으셨나요?</Title>
         <DescriptionText>
-          {`이메일 주소를 입력하면 암호를 재설정할 수 있는 
-            링크를 이메일로 보내드릴게요.`}
+          이메일 주소를 입력하면 암호를 재설정할 수 있는
+          <br />
+          링크를 이메일로 보내드릴게요.
         </DescriptionText>
         <FormProvider {...methods}>
           <FindPasswordForm />
@@ -62,13 +62,11 @@ const Title = styled.h1`
 
 const DescriptionText = styled.p`
   margin-top: 8px;
+
   color: ${({ theme }) => theme.colors.gray_02};
   ${({ theme }) => theme.fonts.body_07};
-
-  white-space: pre-line;
 `;
 
 const ButtonContainer = styled.div`
   margin-top: 28px;
-  z-index: ${Z_INDEX.dialog};
 `;

--- a/src/pages/account/findPassword.tsx
+++ b/src/pages/account/findPassword.tsx
@@ -1,0 +1,74 @@
+import styled from '@emotion/styled';
+import { FormProvider, useForm } from 'react-hook-form';
+import type { NextPage } from 'next/types';
+import type { RegisterForm } from 'types/register';
+import { FindPasswordForm } from 'components/account';
+import { Button, Seo } from 'components/common';
+import { Header, HeaderLeft, HeaderTitle } from 'components/layouts';
+import { Z_INDEX } from 'constants/styles';
+
+const FindPassword: NextPage = () => {
+  /**
+   * @todo
+   * RegisterForm 대신 PasswordFindForm 정의하여 사용
+   */
+  const methods = useForm<RegisterForm>({ mode: 'onChange' });
+  const {
+    formState: { isValid },
+  } = methods;
+
+  return (
+    <>
+      <Seo title={'비밀번호 찾기 | a daily diary'} />
+      <Header
+        left={<HeaderLeft type="이전" />}
+        title={<HeaderTitle title={'비밀번호 찾기'} position={'left'} />}
+      />
+      <ContentWrapper>
+        <Title>비밀번호를 잊으셨나요?</Title>
+        <DescriptionText>
+          {`이메일 주소를 입력하면 암호를 재설정할 수 있는 
+            링크를 이메일로 보내드릴게요.`}
+        </DescriptionText>
+        <FormProvider {...methods}>
+          <FindPasswordForm />
+          <ButtonContainer>
+            <Button
+              type="submit"
+              disabled={!isValid}
+              pattern="box"
+              size="lg"
+              fullWidth
+            >
+              재설정 링크보내기
+            </Button>
+          </ButtonContainer>
+        </FormProvider>
+      </ContentWrapper>
+    </>
+  );
+};
+
+export default FindPassword;
+
+const ContentWrapper = styled.section`
+  margin-top: 54px;
+  padding: 30px 20px;
+`;
+
+const Title = styled.h1`
+  ${({ theme }) => theme.fonts.headline_01};
+`;
+
+const DescriptionText = styled.p`
+  margin-top: 8px;
+  color: ${({ theme }) => theme.colors.gray_02};
+  ${({ theme }) => theme.fonts.body_07};
+
+  white-space: pre-line;
+`;
+
+const ButtonContainer = styled.div`
+  margin-top: 28px;
+  z-index: ${Z_INDEX.dialog};
+`;

--- a/src/pages/account/login.tsx
+++ b/src/pages/account/login.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import Image from 'next/image';
+import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { signIn } from 'next-auth/react';
 import { useForm } from 'react-hook-form';
@@ -109,12 +110,9 @@ const Login: NextPage = () => {
           로그인
         </Button>
       </Form>
-      <UnderlinedButton
-        type="button"
-        onClick={async () => await router.push('/account/findPassword')}
-      >
+      <StyledLink href={'/account/findPassword'}>
         비밀번호를 잊으셨나요?
-      </UnderlinedButton>
+      </StyledLink>
       <ButtonContainer>
         <Button
           type="button"
@@ -156,13 +154,11 @@ const ButtonContainer = styled.div`
   margin-top: 8px;
 `;
 
-const UnderlinedButton = styled.button`
-  width: 100%;
+const StyledLink = styled(Link)`
+  margin-top: 16px;
+  display: block;
 
   ${({ theme }) => theme.fonts.body_06};
-  color: ${({ theme }) => theme.colors.gray_00};
   text-decoration: underline;
   text-align: center;
-
-  margin-top: 16px;
 `;

--- a/src/pages/account/login.tsx
+++ b/src/pages/account/login.tsx
@@ -109,6 +109,7 @@ const Login: NextPage = () => {
           로그인
         </Button>
       </Form>
+      <UnderlinedButton type="button">비밀번호를 잊으셨나요?</UnderlinedButton>
       <ButtonContainer>
         <Button
           type="button"
@@ -148,4 +149,15 @@ const Form = styled.form`
 
 const ButtonContainer = styled.div`
   margin-top: 8px;
+`;
+
+const UnderlinedButton = styled.button`
+  width: 100%;
+
+  ${({ theme }) => theme.fonts.body_06};
+  color: ${({ theme }) => theme.colors.gray_00};
+  text-decoration: underline;
+  text-align: center;
+
+  margin-top: 16px;
 `;

--- a/src/pages/account/login.tsx
+++ b/src/pages/account/login.tsx
@@ -109,7 +109,12 @@ const Login: NextPage = () => {
           로그인
         </Button>
       </Form>
-      <UnderlinedButton type="button">비밀번호를 잊으셨나요?</UnderlinedButton>
+      <UnderlinedButton
+        type="button"
+        onClick={async () => await router.push('/account/findPassword')}
+      >
+        비밀번호를 잊으셨나요?
+      </UnderlinedButton>
       <ButtonContainer>
         <Button
           type="button"


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #179 

<br />

## 🗒 작업 목록

- [x] 로그인 > 비밀번호 찾기 버튼 UI
- [x] 로그인 > 비밀번호 찾기 버튼 클릭 시 비밀번호 찾기 페이지로 이동
- [x] 비밀번호 찾기 페이지 UI

<br />

## 🧐 PR Point

- 로그인 폼 하단 '비밀번호를 잊으셨나요?' 버튼 추가
- 비밀번호 찾기 페이지 마크업 및 스타일링 구현 (비밀번호 찾기 > 링크 전송, 비밀번호 재설정 UI 는 따로 작업할 예정입니다)

---

- 해당 PR 은 스타일링과 마크업만 진행되었습니다. 기능적인 부분(이메일 형식 검사 및 api 연동 등등) 은 따로 진행될 예정입니다. 
- 따라서, ui를 확인하기 위해 필요한 최소한의 react-form 을 연결했으며 register 컴포넌트를 참고하였기 때문에 RegisterForm type을 그대로 사용한 상태 입니다.  해당 부분은 기능 구현 시 교체될 예정입니다. (`@todo` 로 표시해두었습니다)

<br />

## 💥 Trouble Shooting
- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크
스크린샷 | 
-- |
![Feb-04-2024 17-26-04](https://github.com/a-daily-diary/ADD.FE/assets/23066745/77a0408a-2370-4843-a930-6390b7fe0417) |


<br />

## 📚 참고

- 참고한 내용 또는 링크를 입력해주세요.

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다. 
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
