### PR TITLE
공용 Button 컴포넌트 개선

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -65,6 +65,7 @@
         "html": true
       }
     ],
+    "react/no-unknown-property": ["error", { "ignore": ["css"] }],
     "import/order": [
       "error",
       {

--- a/src/components/account/CompleteRegister.tsx
+++ b/src/components/account/CompleteRegister.tsx
@@ -26,7 +26,7 @@ export const CompleteRegister = () => {
       <ButtonContainer>
         <Button
           type="button"
-          pattern="box"
+          shape="box"
           size="lg"
           fullWidth
           onClick={async () => await router.replace('/account/login')}

--- a/src/components/account/CompleteRegister.tsx
+++ b/src/components/account/CompleteRegister.tsx
@@ -26,13 +26,10 @@ export const CompleteRegister = () => {
       <ButtonContainer>
         <Button
           type="button"
-          shape="box"
-          size="lg"
           fullWidth
           onClick={async () => await router.replace('/account/login')}
-        >
-          로그인하기
-        </Button>
+          text="로그인하기"
+        />
       </ButtonContainer>
     </Section>
   );

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -1,39 +1,31 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
-import type { Theme } from '@emotion/react';
-import type { ReactNode } from 'react';
+import type { ButtonHTMLAttributes, ReactNode } from 'react';
+import { theme } from 'styles';
 
-interface ButtonProps {
-  type: 'button' | 'submit';
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   pattern: 'box' | 'round';
   size: 'sm' | 'md' | 'lg' | 'xl';
   variant?: 'active' | 'highlight' | 'line';
   fullWidth?: boolean;
-  theme?: Theme;
-  onClick?: () => void;
   children: ReactNode;
-  disabled?: boolean;
 }
 
 export const Button = ({
-  type,
   pattern,
   size,
   variant,
   fullWidth,
-  onClick,
   children,
-  disabled,
+  ...props
 }: ButtonProps) => {
   return (
     <ButtonLayout
-      type={type}
       pattern={pattern}
       size={size}
       variant={variant}
       fullWidth={fullWidth}
-      onClick={onClick}
-      disabled={disabled}
+      {...props}
     >
       {children}
     </ButtonLayout>
@@ -52,50 +44,50 @@ const patternStyles = ({ pattern }: ButtonProps) => css`
   `}
 `;
 
-const sizeStyles = ({ size, theme }: ButtonProps) => css`
+const sizeStyles = ({ size }: ButtonProps) => css`
   ${size === 'sm' &&
   css`
-    ${theme?.fonts.button_01}
+    ${theme.fonts.button_01}
     padding: 8px 10px;
   `}
 
   ${size === 'md' &&
   css`
-    ${theme?.fonts.button_01}
+    ${theme.fonts.button_01}
     padding: 12px 20px;
   `}
 
   ${size === 'lg' &&
   css`
-    ${theme?.fonts.button_02}
+    ${theme.fonts.button_02}
     padding: 17px 32px;
   `}
 
   ${size === 'xl' &&
   css`
-    ${theme?.fonts.button_03}
+    ${theme.fonts.button_03}
     padding: 20px 48px;
   `}
 `;
 
-const variantStyles = ({ variant, theme }: ButtonProps) => css`
+const variantStyles = ({ variant }: ButtonProps) => css`
   ${variant === 'active' &&
   css`
-    background: ${theme?.colors.primary_00};
-    color: ${theme?.colors.white};
+    background: ${theme.colors.primary_00};
+    color: ${theme.colors.white};
   `}
 
   ${variant === 'highlight' &&
   css`
-    background: ${theme?.colors.primary_03};
-    color: ${theme?.colors.primary_00};
+    background: ${theme.colors.primary_03};
+    color: ${theme.colors.primary_00};
   `}
 
   ${variant === 'line' &&
   css`
-    background: ${theme?.colors.white};
-    color: ${theme?.colors.gray_00};
-    border: 1px solid ${theme?.colors.gray_05};
+    background: ${theme.colors.white};
+    color: ${theme.colors.gray_00};
+    border: 1px solid ${theme.colors.gray_05};
     box-sizing: border-box;
   `}
 `;
@@ -116,7 +108,7 @@ const ButtonLayout = styled.button<ButtonProps>`
   ${sizeStyles}
   ${variantStyles}
 
-    &:disabled {
+  &:disabled {
     background: ${({ theme }) => theme.colors.gray_04};
     color: ${({ theme }) => theme.colors.white};
   }

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -88,20 +88,13 @@ const variantStyles = ({ variant }: ButtonProps) => css`
     background: ${theme.colors.white};
     color: ${theme.colors.gray_00};
     border: 1px solid ${theme.colors.gray_05};
-    box-sizing: border-box;
   `}
 `;
 
 const ButtonLayout = styled.button<ButtonProps>`
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  position: relative;
   width: ${({ fullWidth }) => (fullWidth === true ? '100%' : 'fit-content')};
   background: ${({ theme }) => theme.colors.primary_00};
   color: ${({ theme }) => theme.colors.white};
-  text-align: center;
-  vertical-align: middle;
   user-select: none;
 
   ${patternStyles}

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -1,108 +1,90 @@
 import { css } from '@emotion/react';
-import styled from '@emotion/styled';
-import type { ButtonHTMLAttributes, ReactNode } from 'react';
+import type { ButtonHTMLAttributes } from 'react';
 import { theme } from 'styles';
 
 interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
-  shape: 'box' | 'round';
-  size: 'sm' | 'md' | 'lg' | 'xl';
-  variant?: 'active' | 'highlight' | 'line';
   fullWidth?: boolean;
-  children: ReactNode;
+  shape?: 'box' | 'round';
+  size?: 'sm' | 'md' | 'lg' | 'xl';
+  text: string;
+  variant?: 'active' | 'highlight' | 'line' | 'disabled';
 }
 
 export const Button = ({
-  shape,
-  size,
-  variant,
-  fullWidth,
-  children,
+  fullWidth = false,
+  shape = 'box',
+  size = 'lg',
+  text,
+  variant = 'active',
   ...props
 }: ButtonProps) => {
   return (
-    <ButtonLayout
-      shape={shape}
-      size={size}
-      variant={variant}
-      fullWidth={fullWidth}
+    <button
+      css={css`
+        width: ${fullWidth ? '100%' : 'fit-content'};
+        background-color: ${theme.colors.primary_00};
+        color: ${theme.colors.white};
+        user-select: none;
+
+        ${SHAPE_STYLES[shape]}
+        ${SIZE_STYLES[size]}
+        ${VARIANT_STYLES[variant]}
+
+        &:disabled {
+          ${VARIANT_STYLES.disabled}
+        }
+      `}
       {...props}
     >
-      {children}
-    </ButtonLayout>
+      {text}
+    </button>
   );
 };
 
-const shapeStyles = ({ shape }: ButtonProps) => css`
-  ${shape === 'box' &&
-  css`
+const SHAPE_STYLES = {
+  box: css`
     border-radius: 6px;
-  `}
-
-  ${shape === 'round' &&
-  css`
+  `,
+  round: css`
     border-radius: 100px;
-  `}
-`;
+  `,
+};
 
-const sizeStyles = ({ size }: ButtonProps) => css`
-  ${size === 'sm' &&
-  css`
+const SIZE_STYLES = {
+  sm: css`
     ${theme.fonts.button_01}
     padding: 8px 10px;
-  `}
-
-  ${size === 'md' &&
-  css`
+  `,
+  md: css`
     ${theme.fonts.button_01}
     padding: 12px 20px;
-  `}
-
-  ${size === 'lg' &&
-  css`
+  `,
+  lg: css`
     ${theme.fonts.button_02}
     padding: 17px 32px;
-  `}
-
-  ${size === 'xl' &&
-  css`
+  `,
+  xl: css`
     ${theme.fonts.button_03}
     padding: 20px 48px;
-  `}
-`;
+  `,
+};
 
-const variantStyles = ({ variant }: ButtonProps) => css`
-  ${variant === 'active' &&
-  css`
-    background: ${theme.colors.primary_00};
+const VARIANT_STYLES = {
+  active: css`
+    background-color: ${theme.colors.primary_00};
     color: ${theme.colors.white};
-  `}
-
-  ${variant === 'highlight' &&
-  css`
-    background: ${theme.colors.primary_03};
+  `,
+  highlight: css`
+    background-color: ${theme.colors.primary_03};
     color: ${theme.colors.primary_00};
-  `}
-
-  ${variant === 'line' &&
-  css`
-    background: ${theme.colors.white};
+  `,
+  line: css`
+    background-color: ${theme.colors.white};
     color: ${theme.colors.gray_00};
     border: 1px solid ${theme.colors.gray_05};
-  `}
-`;
-
-const ButtonLayout = styled.button<ButtonProps>`
-  width: ${({ fullWidth }) => (fullWidth === true ? '100%' : 'fit-content')};
-  background: ${({ theme }) => theme.colors.primary_00};
-  color: ${({ theme }) => theme.colors.white};
-  user-select: none;
-
-  ${shapeStyles}
-  ${sizeStyles}
-  ${variantStyles}
-
-  &:disabled {
-    background: ${({ theme }) => theme.colors.gray_04};
-    color: ${({ theme }) => theme.colors.white};
-  }
-`;
+  `,
+  disabled: css`
+    background-color: ${theme.colors.gray_04};
+    color: ${theme.colors.white};
+  `,
+};

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -22,8 +22,6 @@ export const Button = ({
     <button
       css={css`
         width: ${fullWidth ? '100%' : 'fit-content'};
-        background-color: ${theme.colors.primary_00};
-        color: ${theme.colors.white};
         user-select: none;
 
         ${SHAPE_STYLES[shape]}

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -3,18 +3,18 @@ import type { ButtonHTMLAttributes } from 'react';
 import { theme } from 'styles';
 
 interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  text: string;
   fullWidth?: boolean;
   shape?: 'box' | 'round';
   size?: 'sm' | 'md' | 'lg' | 'xl';
-  text: string;
   variant?: 'active' | 'highlight' | 'line' | 'disabled';
 }
 
 export const Button = ({
+  text,
   fullWidth = false,
   shape = 'box',
   size = 'lg',
-  text,
   variant = 'active',
   ...props
 }: ButtonProps) => {

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -4,7 +4,7 @@ import type { ButtonHTMLAttributes, ReactNode } from 'react';
 import { theme } from 'styles';
 
 interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
-  pattern: 'box' | 'round';
+  shape: 'box' | 'round';
   size: 'sm' | 'md' | 'lg' | 'xl';
   variant?: 'active' | 'highlight' | 'line';
   fullWidth?: boolean;
@@ -12,7 +12,7 @@ interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
 }
 
 export const Button = ({
-  pattern,
+  shape,
   size,
   variant,
   fullWidth,
@@ -21,7 +21,7 @@ export const Button = ({
 }: ButtonProps) => {
   return (
     <ButtonLayout
-      pattern={pattern}
+      shape={shape}
       size={size}
       variant={variant}
       fullWidth={fullWidth}
@@ -32,13 +32,13 @@ export const Button = ({
   );
 };
 
-const patternStyles = ({ pattern }: ButtonProps) => css`
-  ${pattern === 'box' &&
+const shapeStyles = ({ shape }: ButtonProps) => css`
+  ${shape === 'box' &&
   css`
     border-radius: 6px;
   `}
 
-  ${pattern === 'round' &&
+  ${shape === 'round' &&
   css`
     border-radius: 100px;
   `}
@@ -97,7 +97,7 @@ const ButtonLayout = styled.button<ButtonProps>`
   color: ${({ theme }) => theme.colors.white};
   user-select: none;
 
-  ${patternStyles}
+  ${shapeStyles}
   ${sizeStyles}
   ${variantStyles}
 

--- a/src/components/matching/RecommendTopic.tsx
+++ b/src/components/matching/RecommendTopic.tsx
@@ -21,7 +21,7 @@ const RecommendTopic = ({ ...otherProps }: RecommendTopicProps) => {
         <SmallParagraph>취미가 무엇인가요?</SmallParagraph>
       </Card>
       {/* FIXME: 버튼 background color 변경 필요 */}
-      <Button type="button" pattern="round" size="md">
+      <Button type="button" shape="round" size="md">
         다음 질문
       </Button>
     </article>

--- a/src/components/matching/RecommendTopic.tsx
+++ b/src/components/matching/RecommendTopic.tsx
@@ -21,9 +21,7 @@ const RecommendTopic = ({ ...otherProps }: RecommendTopicProps) => {
         <SmallParagraph>취미가 무엇인가요?</SmallParagraph>
       </Card>
       {/* FIXME: 버튼 background color 변경 필요 */}
-      <Button type="button" shape="round" size="md">
-        다음 질문
-      </Button>
+      <Button type="button" shape="round" size="md" text="다음 질문" />
     </article>
   );
 };

--- a/src/pages/account/findPassword.tsx
+++ b/src/pages/account/findPassword.tsx
@@ -36,12 +36,9 @@ const FindPassword: NextPage = () => {
             <Button
               type="submit"
               disabled={!isValid}
-              shape="box"
-              size="lg"
               fullWidth
-            >
-              재설정 링크보내기
-            </Button>
+              text="재설정 링크보내기"
+            />
           </ButtonContainer>
         </FormProvider>
       </ContentWrapper>

--- a/src/pages/account/findPassword.tsx
+++ b/src/pages/account/findPassword.tsx
@@ -36,7 +36,7 @@ const FindPassword: NextPage = () => {
             <Button
               type="submit"
               disabled={!isValid}
-              pattern="box"
+              shape="box"
               size="lg"
               fullWidth
             >

--- a/src/pages/account/login.tsx
+++ b/src/pages/account/login.tsx
@@ -103,7 +103,7 @@ const Login: NextPage = () => {
         <Button
           type="submit"
           disabled={!isValid}
-          pattern="box"
+          shape="box"
           size="lg"
           fullWidth
         >
@@ -116,7 +116,7 @@ const Login: NextPage = () => {
       <ButtonContainer>
         <Button
           type="button"
-          pattern="box"
+          shape="box"
           size="lg"
           fullWidth
           variant="line"

--- a/src/pages/account/login.tsx
+++ b/src/pages/account/login.tsx
@@ -100,15 +100,7 @@ const Login: NextPage = () => {
           label="비밀번호"
           errors={errors.password}
         />
-        <Button
-          type="submit"
-          disabled={!isValid}
-          shape="box"
-          size="lg"
-          fullWidth
-        >
-          로그인
-        </Button>
+        <Button type="submit" disabled={!isValid} fullWidth text="로그인" />
       </Form>
       <StyledLink href={'/account/findPassword'}>
         비밀번호를 잊으셨나요?
@@ -116,14 +108,11 @@ const Login: NextPage = () => {
       <ButtonContainer>
         <Button
           type="button"
-          shape="box"
-          size="lg"
           fullWidth
           variant="line"
           onClick={async () => await router.push('/account/register')}
-        >
-          이메일로 가입하기
-        </Button>
+          text="이메일로 가입하기"
+        />
       </ButtonContainer>
     </Section>
   );

--- a/src/pages/account/register.tsx
+++ b/src/pages/account/register.tsx
@@ -112,15 +112,7 @@ const Register: NextPage = () => {
             )}
             {registerStep.termsAgreement && <RegisterTerms />}
             <ButtonContainer>
-              <Button
-                type="submit"
-                disabled={!isValid}
-                shape="box"
-                size="lg"
-                fullWidth
-              >
-                다음
-              </Button>
+              <Button type="submit" disabled={!isValid} fullWidth text="다음" />
             </ButtonContainer>
           </From>
         </FormProvider>

--- a/src/pages/account/register.tsx
+++ b/src/pages/account/register.tsx
@@ -115,7 +115,7 @@ const Register: NextPage = () => {
               <Button
                 type="submit"
                 disabled={!isValid}
-                pattern="box"
+                shape="box"
                 size="lg"
                 fullWidth
               >

--- a/src/pages/matching/index.tsx
+++ b/src/pages/matching/index.tsx
@@ -69,9 +69,8 @@ const MatchingRule: NextPage = () => {
             onClick={async () => {
               await router.push(PAGE_PATH.matching_loading);
             }}
-          >
-            랜덤매칭 시작
-          </Button>
+            text="랜덤매칭 시작"
+          />
         </Article>
       </Section>
     </>

--- a/src/pages/matching/index.tsx
+++ b/src/pages/matching/index.tsx
@@ -64,7 +64,7 @@ const MatchingRule: NextPage = () => {
           </RuleList>
           <Button
             type="button"
-            pattern="round"
+            shape="round"
             size="xl"
             onClick={async () => {
               await router.push(PAGE_PATH.matching_loading);

--- a/src/pages/matching/loading.tsx
+++ b/src/pages/matching/loading.tsx
@@ -56,10 +56,10 @@ const MatchingLoading: NextPage = () => {
             type="button"
             shape="round"
             size="xl"
+            variant="disabled"
             onClick={cancelMatching}
-          >
-            랜덤매칭 취소
-          </Button>
+            text="랜덤매칭 취소"
+          />
         </>
       )}
     </Section>

--- a/src/pages/matching/loading.tsx
+++ b/src/pages/matching/loading.tsx
@@ -54,7 +54,7 @@ const MatchingLoading: NextPage = () => {
           </ImageWrapper>
           <Button
             type="button"
-            pattern="round"
+            shape="round"
             size="xl"
             onClick={cancelMatching}
           >

--- a/src/styles/GlobalStyle.ts
+++ b/src/styles/GlobalStyle.ts
@@ -40,7 +40,6 @@ const GlobalStyle = css`
     background: transparent;
     color: inherit;
     font: inherit;
-    text-align: inherit;
     cursor: pointer;
 
     /* Normalize 'line-height'. Cannot be changed from 'normal' in Firefox 4+. */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -13,6 +17,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
+    "jsxImportSource": "@emotion/react",
     "incremental": true,
     "baseUrl": "src",
     "noImplicitAny": true,
@@ -21,6 +26,12 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #168 

<br />

## 🗒 작업 목록

- [x] Button props 확장 및 수정
- [x] 불필요한 스타일 코드 제거
- [x] css 속성을 사용하기 위한 ESLint 룰 및 tsconfig 컴파일 옵션 추가
- [x] Button 컴포넌트 리팩토링

<br />

## 🧐 PR Point

- 공용으로 사용하는 Button 컴포넌트 리팩토링을 통해 코드를 수정하고 확장성을 높입니다.
- Button props를 `ButtonHTMLAttributes<HTMLButtonElement>`로 확장하여 불필요한 타입 정의를 제거했습니다.
- props의 기본 값을 적용하여 불필요한 props 코드를 제거했습니다.
- `variant`에 `disabled` 스타일을 추가하여 `disabled` 상태가 아니더라도 해당 스타일을 적용할 수 있도록 했습니다.
- 예외적인 스타일이 필요한 경우 style props를 통해 스타일을 유연하게 적용할 수 있도록 수정했습니다.
  - css 속성 : Button 컴포넌트에 적용된 스타일을 사용하기 위해 적용
  - style 속성 : 예외적인 스타일을 위해 적용
- children ⇒ text props로 수정하여 타입을 좁혔습니다.
  - children을 text로 변경한 이유: 해당 컴포넌트를 문자열 버튼에만 사용하여 타입을 좁혔습니다.
  - 피그마 상에서 아이콘과 문자열이 함께 적용된 버튼 형태가 있으나 실제로 Link 컴포넌트로 구현되어 있으므로 문자열만 사용하는 것을 확인 후 변경했습니다.

### 추가 사항
- 다음과 같이 아이콘만 포함된 버튼이 있는데 이를 공용 컴포넌트로 생성하면 좋을 것 같습니다. 
<img width="366" alt="image" src="https://github.com/a-daily-diary/ADD.FE/assets/85009583/ac408956-ba6c-4d79-a68c-d35f1f5026b6">

- 제가 작업하겠습니다!

<br />

## 💥 Trouble Shooting

### 'DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement>' 형식에 'css' 속성이 없습니다.

#### 원인
- HTMLButtonElement에 css 속성이 존재하지 않아 발생한 타입 에러입니다.
- DetailedHTMLProps는 React의 HTML 속성과 이벤트를 모두 포함하는 인터페이스이고 HTMLButtonElement는 button 요소의 HTML 태그 인터페이스로, 기본적으로 css 속성이 존재하지 않습니다.
- 따라서, DetailedHTMLProps 인터페이스에 css 속성을 추가하여 React 기본 기능을 사용하면서 emotion의 css props를 사용할 수 있도록 해야합니다. 

#### 해결
- Emotion 공식문서를 통해 TypeScript 사용 시 설정을 적용합니다.
- tsconfig.json 의 compilerOptions에 다음 내용 추가
  ```json
  {
    "compilerOptions": {
      "jsx": "react-jsx",
      "jsxImportSource": "@emotion/react"
    }
  }
  ```
- `Unknown property 'css' found` 에러를 해결하기 위해 다음의 규칙을 eslint에 추가
  ```json
  {
    "rules": {
      "react/no-unknown-property": ["error", { "ignore": ["css"] }]
    }
  }
  ```

<br />

## 📸 스크린샷 / 피그마 링크

- 내용을 입력해주세요.

<br />

## 📚 참고

- [TypeScript - Emotion](https://emotion.sh/docs/typescript)
- [emotion 사용시 react/no-unknown-property 에러](https://uxicode.tistory.com/entry/emotion-%EC%82%AC%EC%9A%A9%EC%8B%9C-reactno-unknown-property-%EC%97%90%EB%9F%AC)
- [Emotion 사용 중 발생한 DetailedHTMLProps 이슈 해결하기
](https://velog.io/@adultlee/%EC%96%B8%EC%A0%9C%EA%B9%8C%EC%A7%80-%EA%B5%AC%EA%B8%80%EB%A7%81%EC%9C%BC%EB%A1%9C%EB%A7%8C-%ED%95%B4%EA%B2%B0%ED%95%A0%EA%B1%B0%EC%95%BC-emotion%ED%8E%B8)

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다. 
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
