### PR TITLE
사용자 프로필 이미지 클릭 시 프로필 페이지로 이동

### DIFF
--- a/src/components/comment/DiaryComment.tsx
+++ b/src/components/comment/DiaryComment.tsx
@@ -1,11 +1,11 @@
 import styled from '@emotion/styled';
 import { isAxiosError } from 'axios';
-import Image from 'next/image';
 import { useSession } from 'next-auth/react';
 import type { Comment } from 'types/comment';
 import type { ErrorResponse } from 'types/response';
 import { MoreIcon, ReportIcon, TrashIcon } from 'assets/icons';
 import { FloatingMenu, Modal } from 'components/common';
+import { ProfileImage } from 'components/profile';
 import { MODAL_BUTTON, MODAL_MESSAGE } from 'constants/modal';
 import { useClickOutside, useModal } from 'hooks/common';
 import { useDeleteComment } from 'hooks/services';
@@ -41,14 +41,11 @@ export const DiaryComment = ({ diaryComment, diaryId }: DiaryCommentProps) => {
     <>
       <CommentItem>
         <CommentHead>
-          <ProfileImageBox>
-            <Image
-              src={commenter.imgUrl}
-              alt={commenter.username}
-              width={20}
-              height={20}
-            />
-          </ProfileImageBox>
+          <ProfileImage
+            size="sm"
+            src={commenter.imgUrl}
+            username={commenter.username}
+          />
           <UsernameSpan>{commenter.username}</UsernameSpan>
           <CreatedAtSpan>
             {timeFormat(createdAt) !== null
@@ -127,14 +124,6 @@ const CommentHead = styled.div`
   align-items: center;
   position: relative;
   margin-bottom: 8px;
-`;
-
-const ProfileImageBox = styled.div`
-  overflow: hidden;
-  border-radius: 50%;
-  width: 20px;
-  aspect-ratio: 1;
-  background-color: rgba(0, 0, 0, 0.2);
 `;
 
 const UsernameSpan = styled.span`

--- a/src/components/comment/DiaryComment.tsx
+++ b/src/components/comment/DiaryComment.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import { isAxiosError } from 'axios';
+import Link from 'next/link';
 import { useSession } from 'next-auth/react';
 import type { Comment } from 'types/comment';
 import type { ErrorResponse } from 'types/response';
@@ -46,7 +47,9 @@ export const DiaryComment = ({ diaryComment, diaryId }: DiaryCommentProps) => {
             src={commenter.imgUrl}
             username={commenter.username}
           />
-          <UsernameSpan>{commenter.username}</UsernameSpan>
+          <UsernameLink href={`/profile/${commenter.username}`}>
+            {commenter.username}
+          </UsernameLink>
           <CreatedAtSpan>
             {timeFormat(createdAt) !== null
               ? timeFormat(createdAt)
@@ -126,7 +129,7 @@ const CommentHead = styled.div`
   margin-bottom: 8px;
 `;
 
-const UsernameSpan = styled.span`
+const UsernameLink = styled(Link)`
   margin: 0 6px 0 8px;
   color: ${({ theme }) => theme.colors.gray_00};
   ${({ theme }) => theme.fonts.body_08};

--- a/src/components/diary/Diary.tsx
+++ b/src/components/diary/Diary.tsx
@@ -43,7 +43,7 @@ const Diary = ({
         )}
         <DateContainer>
           <span>
-            <span>{author.username}</span>
+            <Link href={`/profile/${author.username}`}>{author.username}</Link>
             <span>・</span>
             <span>{dateFormat(createdAt)}</span>
           </span>

--- a/src/components/diary/DiaryDetailContainer.tsx
+++ b/src/components/diary/DiaryDetailContainer.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import Link from 'next/link';
 import type { DiaryDetail } from 'types/diary';
 import {
   BookmarkOffIcon,
@@ -39,7 +40,9 @@ export const DiaryDetailContainer = ({
           src={author.imgUrl}
           username={author.username}
         />
-        <UsernameText>{author.username}</UsernameText>
+        <UsernameLink href={`/profile/${author.username}`}>
+          {author.username}
+        </UsernameLink>
         <CreatedAtText>{dateFormat(createdAt)}</CreatedAtText>
       </AuthorContainer>
       <ContentContainer>
@@ -89,7 +92,7 @@ const AuthorContainer = styled.div`
   padding: 18px 20px;
 `;
 
-const UsernameText = styled.span`
+const UsernameLink = styled(Link)`
   color: ${({ theme }) => theme.colors.gray_00};
   ${({ theme }) => theme.fonts.body_05};
 `;

--- a/src/components/diary/DiaryDetailContainer.tsx
+++ b/src/components/diary/DiaryDetailContainer.tsx
@@ -1,5 +1,4 @@
 import styled from '@emotion/styled';
-import Image from 'next/image';
 import type { DiaryDetail } from 'types/diary';
 import {
   BookmarkOffIcon,
@@ -9,6 +8,7 @@ import {
   HeartOnIcon,
 } from 'assets/icons';
 import { ResponsiveImage } from 'components/common';
+import { ProfileImage } from 'components/profile';
 import { useHandleFavorite, useHandleBookmark } from 'hooks/services/common';
 import { dateFormat, timeFormat } from 'utils';
 
@@ -34,17 +34,11 @@ export const DiaryDetailContainer = ({
   return (
     <Container>
       <AuthorContainer>
-        {/* TODO:
-        1. 유저 프로필 이미지 클릭 시 해당 프로필로 이동
-        2. 프로필 이미지 컴포넌트 분리 */}
-        <AuthorImageContainer>
-          <Image
-            src={author.imgUrl}
-            alt={author.username}
-            width={28}
-            height={28}
-          />
-        </AuthorImageContainer>
+        <ProfileImage
+          size="md"
+          src={author.imgUrl}
+          username={author.username}
+        />
         <UsernameText>{author.username}</UsernameText>
         <CreatedAtText>{dateFormat(createdAt)}</CreatedAtText>
       </AuthorContainer>
@@ -93,13 +87,6 @@ const AuthorContainer = styled.div`
   gap: 8px;
   align-items: center;
   padding: 18px 20px;
-`;
-
-const AuthorImageContainer = styled.div`
-  overflow: hidden;
-  border-radius: 50%;
-  width: 28px;
-  aspect-ratio: 1;
 `;
 
 const UsernameText = styled.span`

--- a/src/components/profile/ProfileContainer.tsx
+++ b/src/components/profile/ProfileContainer.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
-import Image from 'next/image';
 import Link from 'next/link';
+import { NoLinkProfileImage } from './ProfileImage';
 import { SettingIcon } from 'assets/icons';
 import { Loading } from 'components/common';
 import { useProfile } from 'hooks/services';
@@ -25,12 +25,10 @@ export const ProfileContainer = ({
           <SettingIcon />
         </SettingLink>
       )}
-      <ProfileImage
+      <NoLinkProfileImage
+        size="lg"
         src={profileData.imgUrl}
-        alt={profileData.username}
-        width={92}
-        height={92}
-        priority
+        username={profileData.username}
       />
       <UserName>{username}</UserName>
       {isMyProfile && <EditLink href={'/profile/edit'}>프로필 수정</EditLink>}
@@ -52,10 +50,6 @@ const SettingLink = styled(Link)`
   position: absolute;
   top: 32px;
   right: 20px;
-`;
-
-const ProfileImage = styled(Image)`
-  border-radius: 50%;
 `;
 
 const UserName = styled.h2`

--- a/src/components/profile/ProfileImage.tsx
+++ b/src/components/profile/ProfileImage.tsx
@@ -1,0 +1,33 @@
+import styled from '@emotion/styled';
+import Image from 'next/image';
+import Link from 'next/link';
+
+interface ProfileImageProps {
+  username: string;
+  src: string;
+  size: 'sm' | 'md';
+}
+
+export const ProfileImage = ({ username, src, size }: ProfileImageProps) => {
+  return (
+    <ImageLink href={`/profile/${username}`}>
+      <Image
+        src={src}
+        alt={username}
+        width={SIZE_STYLES[size]}
+        height={SIZE_STYLES[size]}
+      />
+    </ImageLink>
+  );
+};
+
+const SIZE_STYLES = {
+  sm: 22,
+  md: 28,
+};
+
+const ImageLink = styled(Link)`
+  overflow: hidden;
+  border-radius: 50%;
+  aspect-ratio: 1;
+`;

--- a/src/components/profile/ProfileImage.tsx
+++ b/src/components/profile/ProfileImage.tsx
@@ -1,3 +1,4 @@
+import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import Image from 'next/image';
 import Link from 'next/link';
@@ -5,7 +6,7 @@ import Link from 'next/link';
 interface ProfileImageProps {
   username: string;
   src: string;
-  size: 'sm' | 'md';
+  size: 'sm' | 'md' | 'lg' | 'xl';
 }
 
 export const ProfileImage = ({ username, src, size }: ProfileImageProps) => {
@@ -21,13 +22,43 @@ export const ProfileImage = ({ username, src, size }: ProfileImageProps) => {
   );
 };
 
+export const NoLinkProfileImage = ({
+  username,
+  src,
+  size,
+}: ProfileImageProps) => {
+  return (
+    <StyledImage
+      src={src}
+      alt={username}
+      width={SIZE_STYLES[size]}
+      height={SIZE_STYLES[size]}
+      priority
+    />
+  );
+};
+
 const SIZE_STYLES = {
   sm: 22,
   md: 28,
+  lg: 92,
+  xl: 160,
 };
 
-const ImageLink = styled(Link)`
+const ImageStyles = css`
   overflow: hidden;
   border-radius: 50%;
   aspect-ratio: 1;
+  object-fit: cover;
+`;
+
+const ImageLink = styled(Link)`
+  ${ImageStyles}
+`;
+
+const StyledImage = styled(Image)`
+  ${ImageStyles}
+
+  display: block;
+  margin: 0 auto;
 `;

--- a/src/components/profile/index.ts
+++ b/src/components/profile/index.ts
@@ -1,2 +1,3 @@
 export * from './ProfileContainer';
 export * from './SelectProfileImage';
+export * from './ProfileImage';

--- a/src/pages/profile/edit.tsx
+++ b/src/pages/profile/edit.tsx
@@ -22,7 +22,7 @@ import {
   HeaderRight,
   HeaderTitle,
 } from 'components/layouts';
-import { SelectProfileImage } from 'components/profile';
+import { NoLinkProfileImage, SelectProfileImage } from 'components/profile';
 import {
   ERROR_MESSAGE,
   INVALID_VALUE,
@@ -129,12 +129,10 @@ const ProfileEditPage: NextPage = () => {
               />
             }
           />
-          <ProfileImage
+          <NoLinkProfileImage
+            size="xl"
             src={previewImage}
-            alt={session.user.username}
-            width={160}
-            height={160}
-            priority
+            username={session.user.username}
           />
           <SelectProfileImage
             previewImage={previewImage}
@@ -206,13 +204,6 @@ const Title = styled.h1`
 
 const Form = styled.form`
   padding: 28px 20px;
-`;
-
-const ProfileImage = styled(Image)`
-  display: block;
-  margin: 0 auto;
-  border-radius: 50%;
-  object-fit: cover;
 `;
 
 const FormInputContainer = styled.div`

--- a/src/styles/GlobalStyle.ts
+++ b/src/styles/GlobalStyle.ts
@@ -26,6 +26,11 @@ const GlobalStyle = css`
     font-size: 1.6rem;
   }
 
+  a,
+  button {
+    -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  }
+
   a {
     color: inherit;
     text-decoration: none;


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #185

<br />

## 🗒 작업 목록

- [x] ProfileImage/NoLinkProfileImage 컴포넌트 생성 및 적용
- [x] 프로필 이미지, 일기/댓글 작성자 username 클릭 시 해당 사용자 프로필 페이지로 이동
- [x] `a`, `button` 태그 클릭 시 하이라이트 배경 제거

<br />

## 🧐 PR Point

- 일기/댓글 작성자의 프로필 이미지와 `username`을 클릭 시 해당 사용자의 프로필 페이지로 이동하는 기능을 구현했습니다.
- 프로필 이미지 클릭 시 프로필 페이지로 이동할 수 있는 컴포넌트(ProfileImage)와 이동할 필요가 없는 컴포넌트(NoLinkProfileImage)를 구현하고, 이를 적용했습니다.
- 추가로 `a`, `button` 태그 클릭 시 하이라이트 배경색이 나타나는데 이를 글로벌 스타일에서 하이라이트 배경색을 없애는 코드를 적용했습니다.

<br />

## 💥 Trouble Shooting
- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크

https://github.com/a-daily-diary/ADD.FE/assets/85009583/a7091aba-0840-4564-980d-328c91ecc7d1

<br />

## 📚 참고

- [-webkit-tap-highlight-color](https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-tap-highlight-color)
- [[Web / CSS] WebView 버튼 클릭 시 생기는 파란색 박스 해결 ](https://kbwplace.tistory.com/153)

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다. 
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
