### PR TITLE
공용 IconButton 컴포넌트 구현

### DIFF
--- a/src/components/common/IconButton.tsx
+++ b/src/components/common/IconButton.tsx
@@ -1,0 +1,39 @@
+import type { ButtonHTMLAttributes, ReactNode } from 'react';
+
+interface IconButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  backgroundColor?: string;
+  icon: ReactNode;
+  size?: 'md' | 'lg';
+}
+
+export const IconButton = ({
+  backgroundColor = 'transparent',
+  icon,
+  size = 'lg',
+  ...props
+}: IconButtonProps) => {
+  return (
+    <button
+      type="button"
+      style={{
+        // TODO: #186 PR 머지 후 css 속성으로 수정
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        width: `${SIZE_STYLES[size]}px`,
+        height: `${SIZE_STYLES[size]}px`,
+        borderRadius: '50%',
+        backgroundColor,
+        userSelect: 'none',
+      }}
+      {...props}
+    >
+      {icon}
+    </button>
+  );
+};
+
+const SIZE_STYLES = {
+  md: 48,
+  lg: 60,
+};

--- a/src/components/common/IconButton.tsx
+++ b/src/components/common/IconButton.tsx
@@ -1,14 +1,14 @@
 import type { ButtonHTMLAttributes, ReactNode } from 'react';
 
 interface IconButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
-  backgroundColor?: string;
   icon: ReactNode;
+  backgroundColor?: string;
   size?: 'md' | 'lg';
 }
 
 export const IconButton = ({
-  backgroundColor = 'transparent',
   icon,
+  backgroundColor = 'transparent',
   size = 'lg',
   ...props
 }: IconButtonProps) => {

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -1,4 +1,5 @@
 export * from './Button';
+export * from './IconButton';
 export * from './FloatingMenu';
 export * from './FloatingMenuButton';
 export * from './ResponsiveImage';


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #188
- #186 

<br />

## 🗒 작업 목록

- [x] 공용 IconButton 컴포넌트 구현

<br />

## 🧐 PR Point

- 공용으로 사용할 IconButton 컴포넌트를 구현했습니다.
<img width="280" alt="image" src="https://github.com/a-daily-diary/ADD.FE/assets/85009583/19c4c66c-80e4-40af-90bc-0e50d4fad279">
<img width="374" alt="image" src="https://github.com/a-daily-diary/ADD.FE/assets/85009583/7695a34b-c656-40b8-9107-c8fb09f98da6">

- #186 PR이 머지 된 후 style 속성으로 적용된 스타일 코드를 css 속성으로 변경할 예정입니다.
  - 해당 부분에 주석으로 내용 남겨두었습니다. 
- 추후 버튼이 아닌 링크 형태가 필요하다면 필요한 시점에 컴포넌트 추가하겠습니다.

<br />

## 💥 Trouble Shooting
- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크

- 내용을 입력해주세요.

<br />

## 📚 참고

- 참고한 내용 또는 링크를 입력해주세요.

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다. 
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
