### PR TITLE
일기 목록 무한스크롤 구현

### DIFF
--- a/src/api/diaries.ts
+++ b/src/api/diaries.ts
@@ -7,19 +7,64 @@ import type {
   DeleteDiaryRequest,
   GetDiariesRequest,
   GetDiaryRequest,
+  GetDiariesByUsernameRequest,
 } from 'types/diary';
 import type { OnlyMessageResponse, SuccessResponse } from 'types/response';
-import { API_PATH } from 'constants/api/path';
+import { API_PATH, PAGE_SIZE } from 'constants/api/path';
 import axios from 'lib/axios';
 
-export const getDiaries = async ({ config }: GetDiariesRequest) => {
+export const getDiaries = async ({ page, config }: GetDiariesRequest) => {
   const {
     data: { data },
   } = await axios.get<SuccessResponse<Diaries>>(
-    `${API_PATH.diaries.index}`,
+    `${API_PATH.diaries.index}?skip=${PAGE_SIZE * page}&take=${PAGE_SIZE}`,
     config,
   );
-  return data;
+
+  const nextPage: number | undefined =
+    data.diaries.length >= PAGE_SIZE ? page + 1 : undefined;
+
+  return { ...data, nextPage };
+};
+
+export const getDiariesByUsername = async ({
+  page,
+  username,
+  config,
+}: GetDiariesByUsernameRequest) => {
+  const {
+    data: { data },
+  } = await axios.get<SuccessResponse<Diaries>>(
+    `${API_PATH.diaries.index}?username=${username}&skip=${
+      PAGE_SIZE * page
+    }&take=${PAGE_SIZE}`,
+    config,
+  );
+
+  const nextPage: number | undefined =
+    data.diaries.length >= PAGE_SIZE ? page + 1 : undefined;
+
+  return { ...data, nextPage };
+};
+
+export const getBookmarkedDiariesByUsername = async ({
+  page,
+  username,
+  config,
+}: GetDiariesByUsernameRequest) => {
+  const {
+    data: { data },
+  } = await axios.get<SuccessResponse<Diaries>>(
+    `${API_PATH.diaries.bookmark}/${username}?skip=${
+      PAGE_SIZE * page
+    }&take=${PAGE_SIZE}`,
+    config,
+  );
+
+  const nextPage: number | undefined =
+    data.diaries.length >= PAGE_SIZE ? page + 1 : undefined;
+
+  return { ...data, nextPage };
 };
 
 export const writeDiary = async ({
@@ -77,30 +122,4 @@ export const deleteDiaryDetail = async ({ id }: DeleteDiaryRequest) => {
     `${API_PATH.diaries.index}/${id}`,
   );
   return message;
-};
-
-export const getDiariesByUsername = async ({
-  username,
-  config,
-}: GetDiariesRequest & { username: string }) => {
-  const {
-    data: { data },
-  } = await axios.get<SuccessResponse<Diaries>>(
-    `${API_PATH.diaries.index}?username=${username}`,
-    config,
-  );
-  return data;
-};
-
-export const getBookmarkedDiariesByUsername = async ({
-  username,
-  config,
-}: GetDiariesRequest & { username: string }) => {
-  const {
-    data: { data },
-  } = await axios.get<SuccessResponse<Diaries>>(
-    `${API_PATH.diaries.bookmark}/${username}`,
-    config,
-  );
-  return data;
 };

--- a/src/api/diaries.ts
+++ b/src/api/diaries.ts
@@ -13,13 +13,15 @@ import type { OnlyMessageResponse, SuccessResponse } from 'types/response';
 import { API_PATH, PAGE_SIZE } from 'constants/api/path';
 import axios from 'lib/axios';
 
-export const getDiaries = async ({ page, config }: GetDiariesRequest) => {
+export const getDiaries = async ({ page }: GetDiariesRequest) => {
   const {
     data: { data },
-  } = await axios.get<SuccessResponse<Diaries>>(
-    `${API_PATH.diaries.index}?skip=${PAGE_SIZE * page}&take=${PAGE_SIZE}`,
-    config,
-  );
+  } = await axios.get<SuccessResponse<Diaries>>(`${API_PATH.diaries.index}`, {
+    params: {
+      skip: PAGE_SIZE * page,
+      take: PAGE_SIZE,
+    },
+  });
 
   const nextPage: number | undefined =
     data.diaries.length >= PAGE_SIZE ? page + 1 : undefined;
@@ -30,16 +32,16 @@ export const getDiaries = async ({ page, config }: GetDiariesRequest) => {
 export const getDiariesByUsername = async ({
   page,
   username,
-  config,
 }: GetDiariesByUsernameRequest) => {
   const {
     data: { data },
-  } = await axios.get<SuccessResponse<Diaries>>(
-    `${API_PATH.diaries.index}?username=${username}&skip=${
-      PAGE_SIZE * page
-    }&take=${PAGE_SIZE}`,
-    config,
-  );
+  } = await axios.get<SuccessResponse<Diaries>>(`${API_PATH.diaries.index}`, {
+    params: {
+      username,
+      skip: PAGE_SIZE * page,
+      take: PAGE_SIZE,
+    },
+  });
 
   const nextPage: number | undefined =
     data.diaries.length >= PAGE_SIZE ? page + 1 : undefined;
@@ -50,15 +52,17 @@ export const getDiariesByUsername = async ({
 export const getBookmarkedDiariesByUsername = async ({
   page,
   username,
-  config,
 }: GetDiariesByUsernameRequest) => {
   const {
     data: { data },
   } = await axios.get<SuccessResponse<Diaries>>(
-    `${API_PATH.diaries.bookmark}/${username}?skip=${
-      PAGE_SIZE * page
-    }&take=${PAGE_SIZE}`,
-    config,
+    `${API_PATH.diaries.bookmark}/${username}`,
+    {
+      params: {
+        skip: PAGE_SIZE * page,
+        take: PAGE_SIZE,
+      },
+    },
   );
 
   const nextPage: number | undefined =

--- a/src/api/diaries.ts
+++ b/src/api/diaries.ts
@@ -13,60 +13,63 @@ import type { OnlyMessageResponse, SuccessResponse } from 'types/response';
 import { API_PATH, PAGE_SIZE } from 'constants/api/path';
 import axios from 'lib/axios';
 
-export const getDiaries = async ({ page }: GetDiariesRequest) => {
+export const getDiaries = async ({ currentPage }: GetDiariesRequest) => {
+  const currentPageIndex = currentPage - 1;
   const {
     data: { data },
   } = await axios.get<SuccessResponse<Diaries>>(`${API_PATH.diaries.index}`, {
     params: {
-      skip: PAGE_SIZE * page,
+      skip: PAGE_SIZE * currentPageIndex,
       take: PAGE_SIZE,
     },
   });
 
   const nextPage: number | undefined =
-    data.diaries.length >= PAGE_SIZE ? page + 1 : undefined;
+    data.totalPage > currentPage ? currentPage + 1 : undefined;
 
   return { ...data, nextPage };
 };
 
 export const getDiariesByUsername = async ({
-  page,
+  currentPage,
   username,
 }: GetDiariesByUsernameRequest) => {
+  const currentPageIndex = currentPage - 1;
   const {
     data: { data },
   } = await axios.get<SuccessResponse<Diaries>>(`${API_PATH.diaries.index}`, {
     params: {
       username,
-      skip: PAGE_SIZE * page,
+      skip: PAGE_SIZE * currentPageIndex,
       take: PAGE_SIZE,
     },
   });
 
   const nextPage: number | undefined =
-    data.diaries.length >= PAGE_SIZE ? page + 1 : undefined;
+    data.totalPage > currentPage ? currentPage + 1 : undefined;
 
   return { ...data, nextPage };
 };
 
 export const getBookmarkedDiariesByUsername = async ({
-  page,
+  currentPage,
   username,
 }: GetDiariesByUsernameRequest) => {
+  const currentPageIndex = currentPage - 1;
   const {
     data: { data },
   } = await axios.get<SuccessResponse<Diaries>>(
     `${API_PATH.diaries.bookmark}/${username}`,
     {
       params: {
-        skip: PAGE_SIZE * page,
+        skip: PAGE_SIZE * currentPageIndex,
         take: PAGE_SIZE,
       },
     },
   );
 
   const nextPage: number | undefined =
-    data.diaries.length >= PAGE_SIZE ? page + 1 : undefined;
+    data.totalPage > currentPage ? currentPage + 1 : undefined;
 
   return { ...data, nextPage };
 };

--- a/src/components/common/ObserverTarget.tsx
+++ b/src/components/common/ObserverTarget.tsx
@@ -1,0 +1,21 @@
+import type { Dispatch, SetStateAction } from 'react';
+
+interface ObserverTargetProps {
+  isLoading: boolean;
+  isError: boolean;
+  targetRef: Dispatch<SetStateAction<HTMLElement | null>>;
+}
+
+export const ObserverTarget = ({
+  isLoading,
+  isError,
+  targetRef,
+}: ObserverTargetProps) => {
+  return (
+    <div ref={targetRef}>
+      {/* TODO: 로딩/에러 시 UI 수정 */}
+      {isLoading && <p>데이터를 불러오는 중입니다.</p>}
+      {isError && <p>데이터를 불러오는데 실패했습니다.</p>}
+    </div>
+  );
+};

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -7,3 +7,4 @@ export * from './Seo';
 export * from './Tab';
 export * from './Modal';
 export * from './Loading';
+export * from './ObserverTarget';

--- a/src/components/diary/DiariesContainer.tsx
+++ b/src/components/diary/DiariesContainer.tsx
@@ -5,7 +5,7 @@ import { ScreenReaderOnly } from 'styles';
 
 interface DiariesContainerProps {
   title: string;
-  diariesData: Diaries;
+  diariesData: Diaries[];
   empty: JSX.Element;
 }
 
@@ -14,23 +14,25 @@ export const DiariesContainer = ({
   diariesData,
   empty,
 }: DiariesContainerProps) => {
-  const { diaries } = diariesData;
-  const isEmptyDiaries = diaries === undefined || diaries.length === 0;
+  const isEmptyDiaries = diariesData.length === 0;
 
   // TODO: 북마크한 일기 리스트 조회 데이터 구조 변경 완료 후 수정
   // diaries의 값이 null일 경우가 있는지 확인
   if (isEmptyDiaries) return empty;
 
   return (
-    <article>
+    <section>
       <Title>{title}</Title>
       <List>
-        {diaries.map((diary) => {
-          const { id } = diary;
-          return <Diary key={`diary-list-${id}`} {...diary} />;
+        {diariesData.map((data) => {
+          const { diaries } = data;
+          return diaries.map((diary) => {
+            const { id } = diary;
+            return <Diary key={`diary-list-${id}`} {...diary} />;
+          });
         })}
       </List>
-    </article>
+    </section>
   );
 };
 

--- a/src/components/diary/DiariesContainer.tsx
+++ b/src/components/diary/DiariesContainer.tsx
@@ -16,8 +16,6 @@ export const DiariesContainer = ({
 }: DiariesContainerProps) => {
   const isEmptyDiaries = diariesData.length === 0;
 
-  // TODO: 북마크한 일기 리스트 조회 데이터 구조 변경 완료 후 수정
-  // diaries의 값이 null일 경우가 있는지 확인
   if (isEmptyDiaries) return empty;
 
   return (

--- a/src/constants/api/path.ts
+++ b/src/constants/api/path.ts
@@ -16,3 +16,5 @@ export const API_PATH = {
     index: '/terms-agreements',
   },
 } as const;
+
+export const PAGE_SIZE = 10;

--- a/src/hooks/common/index.ts
+++ b/src/hooks/common/index.ts
@@ -2,3 +2,4 @@ export * from './useBeforeLeave';
 export * from './useClickOutside';
 export * from './useTabIndicator';
 export * from './useModal';
+export * from './useIntersectionObserver';

--- a/src/hooks/common/useIntersectionObserver.ts
+++ b/src/hooks/common/useIntersectionObserver.ts
@@ -1,0 +1,36 @@
+import { useEffect, useState } from 'react';
+
+interface UseIntersectionObserverProps {
+  threshold?: number;
+  onIntersect: () => void;
+}
+
+export const useIntersectionObserver = ({
+  onIntersect,
+  threshold = 0.5,
+}: UseIntersectionObserverProps) => {
+  const [targetRef, setTargetRef] = useState<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (targetRef === null) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          onIntersect();
+        }
+      },
+      { threshold },
+    );
+
+    observer.observe(targetRef);
+
+    return () => {
+      if (observer !== null) {
+        observer.disconnect();
+      }
+    };
+  }, [targetRef]);
+
+  return { setTargetRef };
+};

--- a/src/hooks/services/queries/useBookmarkedDiaries.ts
+++ b/src/hooks/services/queries/useBookmarkedDiaries.ts
@@ -3,7 +3,7 @@ import * as api from 'api';
 import { queryKeys } from 'constants/queryKeys';
 
 export const useBookmarkedDiaries = (username: string) => {
-  const { data, isFetching, isFetchingNextPage, fetchNextPage } =
+  const { data, isFetching, isFetchingNextPage, isError, fetchNextPage } =
     useInfiniteQuery({
       queryKey: [queryKeys.bookmark, username],
       queryFn: async ({ pageParam = 0 }) =>
@@ -19,6 +19,7 @@ export const useBookmarkedDiaries = (username: string) => {
   return {
     bookmarkedDiariesData: data?.pages,
     isLoading,
+    isError,
     fetchNextPage,
   };
 };

--- a/src/hooks/services/queries/useBookmarkedDiaries.ts
+++ b/src/hooks/services/queries/useBookmarkedDiaries.ts
@@ -1,11 +1,24 @@
-import { useQuery } from '@tanstack/react-query';
+import { useInfiniteQuery } from '@tanstack/react-query';
 import * as api from 'api';
 import { queryKeys } from 'constants/queryKeys';
 
 export const useBookmarkedDiaries = (username: string) => {
-  const { data: bookmarkedDiariesData, isLoading } = useQuery(
-    [queryKeys.bookmark, username], // TODO: 북마트한 다이어리 queryKeys 확인
-    async () => await api.getBookmarkedDiariesByUsername({ username }),
-  );
-  return { bookmarkedDiariesData, isLoading };
+  const { data, isFetching, isFetchingNextPage, fetchNextPage } =
+    useInfiniteQuery({
+      queryKey: [queryKeys.bookmark, username],
+      queryFn: async ({ pageParam = 0 }) =>
+        await api.getBookmarkedDiariesByUsername({
+          username,
+          page: pageParam as number,
+        }),
+      getNextPageParam: (lastPage) => lastPage.nextPage,
+    });
+
+  const isLoading = isFetching && !isFetchingNextPage;
+
+  return {
+    bookmarkedDiariesData: data?.pages,
+    isLoading,
+    fetchNextPage,
+  };
 };

--- a/src/hooks/services/queries/useBookmarkedDiaries.ts
+++ b/src/hooks/services/queries/useBookmarkedDiaries.ts
@@ -6,10 +6,10 @@ export const useBookmarkedDiaries = (username: string) => {
   const { data, isFetching, isFetchingNextPage, isError, fetchNextPage } =
     useInfiniteQuery({
       queryKey: [queryKeys.bookmark, username],
-      queryFn: async ({ pageParam = 0 }) =>
+      queryFn: async ({ pageParam = 1 }) =>
         await api.getBookmarkedDiariesByUsername({
           username,
-          page: pageParam as number,
+          currentPage: pageParam as number,
         }),
       getNextPageParam: (lastPage) => lastPage.nextPage,
     });

--- a/src/hooks/services/queries/useDiaries.ts
+++ b/src/hooks/services/queries/useDiaries.ts
@@ -3,7 +3,7 @@ import * as api from 'api';
 import { queryKeys } from 'constants/queryKeys';
 
 export const useDiaries = () => {
-  const { data, isFetching, isFetchingNextPage, fetchNextPage } =
+  const { data, isFetching, isFetchingNextPage, isError, fetchNextPage } =
     useInfiniteQuery({
       queryKey: [queryKeys.diaries],
       queryFn: async ({ pageParam = 0 }) =>
@@ -13,5 +13,5 @@ export const useDiaries = () => {
 
   const isLoading = isFetching && !isFetchingNextPage;
 
-  return { diariesData: data?.pages, isLoading, fetchNextPage };
+  return { diariesData: data?.pages, isLoading, isError, fetchNextPage };
 };

--- a/src/hooks/services/queries/useDiaries.ts
+++ b/src/hooks/services/queries/useDiaries.ts
@@ -6,8 +6,8 @@ export const useDiaries = () => {
   const { data, isFetching, isFetchingNextPage, isError, fetchNextPage } =
     useInfiniteQuery({
       queryKey: [queryKeys.diaries],
-      queryFn: async ({ pageParam = 0 }) =>
-        await api.getDiaries({ page: pageParam as number }),
+      queryFn: async ({ pageParam = 1 }) =>
+        await api.getDiaries({ currentPage: pageParam as number }),
       getNextPageParam: (lastPage) => lastPage.nextPage,
     });
 

--- a/src/hooks/services/queries/useDiaries.ts
+++ b/src/hooks/services/queries/useDiaries.ts
@@ -1,11 +1,17 @@
-import { useQuery } from '@tanstack/react-query';
+import { useInfiniteQuery } from '@tanstack/react-query';
 import * as api from 'api';
 import { queryKeys } from 'constants/queryKeys';
 
 export const useDiaries = () => {
-  const { data: diariesData, isLoading } = useQuery(
-    [queryKeys.diaries],
-    async () => await api.getDiaries({}),
-  );
-  return { diariesData, isLoading };
+  const { data, isFetching, isFetchingNextPage, fetchNextPage } =
+    useInfiniteQuery({
+      queryKey: [queryKeys.diaries],
+      queryFn: async ({ pageParam = 0 }) =>
+        await api.getDiaries({ page: pageParam as number }),
+      getNextPageParam: (lastPage) => lastPage.nextPage,
+    });
+
+  const isLoading = isFetching && !isFetchingNextPage;
+
+  return { diariesData: data?.pages, isLoading, fetchNextPage };
 };

--- a/src/hooks/services/queries/useUserDiaries.ts
+++ b/src/hooks/services/queries/useUserDiaries.ts
@@ -6,8 +6,11 @@ export const useUserDiaries = (username: string) => {
   const { data, isFetching, isFetchingNextPage, isError, fetchNextPage } =
     useInfiniteQuery({
       queryKey: [queryKeys.diaries, username],
-      queryFn: async ({ pageParam = 0 }) =>
-        await api.getDiariesByUsername({ username, page: pageParam as number }),
+      queryFn: async ({ pageParam = 1 }) =>
+        await api.getDiariesByUsername({
+          username,
+          currentPage: pageParam as number,
+        }),
       getNextPageParam: (lastPage) => lastPage.nextPage,
     });
 

--- a/src/hooks/services/queries/useUserDiaries.ts
+++ b/src/hooks/services/queries/useUserDiaries.ts
@@ -1,11 +1,21 @@
-import { useQuery } from '@tanstack/react-query';
+import { useInfiniteQuery } from '@tanstack/react-query';
 import * as api from 'api';
 import { queryKeys } from 'constants/queryKeys';
 
 export const useUserDiaries = (username: string) => {
-  const { data: userDiariesData, isLoading } = useQuery(
-    [queryKeys.diaries, username],
-    async () => await api.getDiariesByUsername({ username }),
-  );
-  return { userDiariesData, isLoading };
+  const { data, isFetching, isFetchingNextPage, fetchNextPage } =
+    useInfiniteQuery({
+      queryKey: [queryKeys.diaries, username],
+      queryFn: async ({ pageParam = 0 }) =>
+        await api.getDiariesByUsername({ username, page: pageParam as number }),
+      getNextPageParam: (lastPage) => lastPage.nextPage,
+    });
+
+  const isLoading = isFetching && !isFetchingNextPage;
+
+  return {
+    userDiariesData: data?.pages,
+    isLoading,
+    fetchNextPage,
+  };
 };

--- a/src/hooks/services/queries/useUserDiaries.ts
+++ b/src/hooks/services/queries/useUserDiaries.ts
@@ -3,7 +3,7 @@ import * as api from 'api';
 import { queryKeys } from 'constants/queryKeys';
 
 export const useUserDiaries = (username: string) => {
-  const { data, isFetching, isFetchingNextPage, fetchNextPage } =
+  const { data, isFetching, isFetchingNextPage, isError, fetchNextPage } =
     useInfiniteQuery({
       queryKey: [queryKeys.diaries, username],
       queryFn: async ({ pageParam = 0 }) =>
@@ -16,6 +16,7 @@ export const useUserDiaries = (username: string) => {
   return {
     userDiariesData: data?.pages,
     isLoading,
+    isError,
     fetchNextPage,
   };
 };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,21 +1,18 @@
 import styled from '@emotion/styled';
-import { QueryClient, dehydrate } from '@tanstack/react-query';
 import Link from 'next/link';
 import { getServerSession } from 'next-auth';
 import { authOptions } from './api/auth/[...nextauth]';
 import type { GetServerSideProps, NextPage } from 'next';
-import * as api from 'api';
 import { Loading, ResponsiveImage, Seo } from 'components/common';
 import { DiariesContainer } from 'components/diary';
 import EmptyDiary from 'components/diary/EmptyDiary';
 import { Header, HeaderLeft, HeaderRight } from 'components/layouts';
-import { queryKeys } from 'constants/queryKeys';
 import { useDiaries } from 'hooks/services';
 
 const Home: NextPage = () => {
-  const { diariesData, isLoading } = useDiaries();
+  const { diariesData, isLoading, fetchNextPage } = useDiaries();
 
-  if (diariesData === undefined || isLoading) return <Loading />;
+  if (diariesData === undefined) return <Loading />;
 
   return (
     <>
@@ -34,7 +31,7 @@ const Home: NextPage = () => {
         </Link>
       </BannerContainer>
       <DiariesContainer
-        title="일기"
+        title="홈 일기 목록"
         diariesData={diariesData}
         empty={<EmptyDiary text="일기가 없습니다." />}
       />
@@ -55,19 +52,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     };
   }
 
-  const queryClient = new QueryClient();
-  await queryClient.prefetchQuery(
-    [queryKeys.diaries],
-    async () =>
-      await api.getDiaries({
-        config: {
-          headers: {
-            Authorization: `Bearer ${session.user.accessToken}`,
-          },
-        },
-      }),
-  );
-  return { props: { dehydratedState: dehydrate(queryClient) } };
+  return { props: { session } };
 };
 
 export default Home;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -3,14 +3,23 @@ import Link from 'next/link';
 import { getServerSession } from 'next-auth';
 import { authOptions } from './api/auth/[...nextauth]';
 import type { GetServerSideProps, NextPage } from 'next';
-import { Loading, ResponsiveImage, Seo } from 'components/common';
+import {
+  Loading,
+  ObserverTarget,
+  ResponsiveImage,
+  Seo,
+} from 'components/common';
 import { DiariesContainer } from 'components/diary';
 import EmptyDiary from 'components/diary/EmptyDiary';
 import { Header, HeaderLeft, HeaderRight } from 'components/layouts';
+import { useIntersectionObserver } from 'hooks/common';
 import { useDiaries } from 'hooks/services';
 
 const Home: NextPage = () => {
-  const { diariesData, isLoading, fetchNextPage } = useDiaries();
+  const { diariesData, isLoading, isError, fetchNextPage } = useDiaries();
+  const { setTargetRef } = useIntersectionObserver({
+    onIntersect: fetchNextPage,
+  });
 
   if (diariesData === undefined) return <Loading />;
 
@@ -34,6 +43,11 @@ const Home: NextPage = () => {
         title="홈 일기 목록"
         diariesData={diariesData}
         empty={<EmptyDiary text="일기가 없습니다." />}
+      />
+      <ObserverTarget
+        targetRef={setTargetRef}
+        isLoading={isLoading}
+        isError={isError}
       />
     </>
   );

--- a/src/pages/profile/[username].tsx
+++ b/src/pages/profile/[username].tsx
@@ -8,12 +8,12 @@ import type {
   NextPage,
 } from 'next';
 import * as api from 'api';
-import { Loading, Seo, Tab } from 'components/common';
+import { Loading, ObserverTarget, Seo, Tab } from 'components/common';
 import { DiariesContainer } from 'components/diary';
 import EmptyDiary from 'components/diary/EmptyDiary';
 import { ProfileContainer } from 'components/profile';
 import { queryKeys } from 'constants/queryKeys';
-import { useTabIndicator } from 'hooks/common';
+import { useIntersectionObserver, useTabIndicator } from 'hooks/common';
 import { useUserDiaries } from 'hooks/services';
 import { authOptions } from 'pages/api/auth/[...nextauth]';
 
@@ -27,8 +27,11 @@ const YourProfile: NextPage<
 > = ({ username }) => {
   const { tabsRef, indicator, activeIndex, setActiveIndex } = useTabIndicator();
 
-  const { userDiariesData, isLoading, fetchNextPage } =
+  const { userDiariesData, isLoading, isError, fetchNextPage } =
     useUserDiaries(username);
+  const { setTargetRef } = useIntersectionObserver({
+    onIntersect: fetchNextPage,
+  });
 
   if (userDiariesData === undefined) return <Loading />;
 
@@ -56,11 +59,18 @@ const YourProfile: NextPage<
         })}
       </Tab>
       {PROFILE_TAB_LIST[activeIndex].id === 'diaries' && (
-        <DiariesContainer
-          title={PROFILE_TAB_LIST[activeIndex].title}
-          diariesData={userDiariesData}
-          empty={<EmptyDiary text="일기가 없습니다." />}
-        />
+        <>
+          <DiariesContainer
+            title={PROFILE_TAB_LIST[activeIndex].title}
+            diariesData={userDiariesData}
+            empty={<EmptyDiary text="일기가 없습니다." />}
+          />
+          <ObserverTarget
+            targetRef={setTargetRef}
+            isLoading={isLoading}
+            isError={isError}
+          />
+        </>
       )}
     </>
   );

--- a/src/types/diary.ts
+++ b/src/types/diary.ts
@@ -31,7 +31,7 @@ export type DiaryForm = Pick<
 /* Request */
 
 export interface GetDiariesRequest {
-  page: number;
+  currentPage: number;
 }
 
 export interface GetDiariesByUsernameRequest extends GetDiariesRequest {

--- a/src/types/diary.ts
+++ b/src/types/diary.ts
@@ -31,7 +31,6 @@ export type DiaryForm = Pick<
 /* Request */
 
 export interface GetDiariesRequest {
-  config?: AxiosRequestConfig;
   page: number;
 }
 

--- a/src/types/diary.ts
+++ b/src/types/diary.ts
@@ -20,6 +20,7 @@ export interface Diaries {
   diaries: DiaryDetail[];
   totalCount: number;
   totalPage: number;
+  nextPage: number | undefined;
 }
 
 export type DiaryForm = Pick<
@@ -31,6 +32,11 @@ export type DiaryForm = Pick<
 
 export interface GetDiariesRequest {
   config?: AxiosRequestConfig;
+  page: number;
+}
+
+export interface GetDiariesByUsernameRequest extends GetDiariesRequest {
+  username: string;
 }
 
 export interface GetDiaryRequest {


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #190 

<br />

## 🗒 작업 목록

- [x] 일기 목록 조회 커스텀 훅에서 사용된 useQuery를 useInfiniteQuery로 변경 
- [x] useInfiniteQuery 로 인해 변경된 데이터 구조에 맞게 DiariesContainer 컴포넌트 수정
- [x] useIntersectionObserver 커스텀 훅 및 ObserverTarget 컴포넌트 생성
- [x] 홈 일기 목록, 사용자가 작성한 일기 목록, 사용자가 북마크한 일기 목록 조회시 무한스크롤 적용

<br />

## 🧐 PR Point

- 일기 목록 조회시 무한스크롤을 적용하여 사용자 경험을 높입니다.
- 일기 목록 조회시 useQuery를 이용한 데이터 페칭을 useInfiniteQuery로 변경하여 적용했습니다.
  - useQuery 사용 시 데이터 구조
  ```json
  {
    "success": true,
    "data": {
      "diaries": [
        {
          "id": "8ade21fa-58cc-4b48-a56b-5c6e405281f6",
          "createdAt": "2024-02-12T07:50:33.145Z",
          "updatedAt": "2024-02-12T07:50:33.145Z",
          "title": "no. 11",
          "content": "test no.11",
          "imgUrl": "http://add.bucket.s3.amazonaws.com/diaries/1707724226944",
          "isPublic": true,
          "favoriteCount": 0,
          "commentCount": 0,
          "isFavorite": false,
          "isBookmark": false,
          "author": {
            "id": "6a4abdbc-5ac5-43ab-9e60-7d30765ce20d",
            "email": "qhfl@qhfl.com",
            "username": "qhfl_test",
            "imgUrl": "http://add.bucket.s3.amazonaws.com/users/1703344786638",
            "isAdmin": false
          }
        },
        // ... 
      ],
      "totalCount": 16,
      "totalPage": 2
    }
  }
  ```
  - useQuery 사용 시 데이터 구조
    - `nextPage`가 `undefined`인 경우 마지막 페이지를 의미합니다.
  <img width="427" alt="image" src="https://github.com/a-daily-diary/ADD.FE/assets/85009583/06a397d3-99de-4898-ac4f-fa191ffd3e68">
- 무한스크롤을 적용하면서 서버사이드 렌더링으로 데이터 페칭하던 방식을 클라이언트사이드 렌더링으로 변경했습니다.
- 캐싱으로 인해 페이지 이동을 하더라도 다시 해당 페이지로 돌아오면 이 전에 렌더링 되었던 데이터들이 함께 나타납니다.
  - `캐시 비우기 및 강력 새로고침` 시 다시 첫 페이지 사이즈만큼 데이터가 렌더링 됩니다. 

<br />

## 💥 Trouble Shooting
- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크

#### 홈 일기 목록 조회 시 무한스크롤
![Feb-25-2024 00-51-54](https://github.com/a-daily-diary/ADD.FE/assets/85009583/d89e4217-3dfa-4aef-86dc-287798702400)

<br />

## 📚 참고

- [useInfiniteQuery | TanStack Query](https://tanstack.com/query/v4/docs/framework/react/reference/useInfiniteQuery)
- [React Query: Infinite Scroll](https://dev.to/kevin-uehara/2-react-query-infinite-scroll-1mg8)
- [[React] infinite scroll을 구현해보자](https://velog.io/@ohsg97/React-infinite-scroll)
- [React Query와 함께하는 Next.js 무한 스크롤](https://velog.io/@hdpark/React-Query%EC%99%80-%ED%95%A8%EA%BB%98%ED%95%98%EB%8A%94-Next.js-%EB%AC%B4%ED%95%9C-%EC%8A%A4%ED%81%AC%EB%A1%A4)
- [React-query 사용하는 이유, useInfiniteQuery 로 무한 스크롤 구현하기 (+ react-infinite-scroller)
](https://velog.io/@leemember/React-query-%EC%82%AC%EC%9A%A9%ED%95%98%EB%8A%94-%EC%9D%B4%EC%9C%A0-useInfiniteQuery-%EB%A1%9C-%EB%AC%B4%ED%95%9C-%EC%8A%A4%ED%81%AC%EB%A1%A4-%EA%B5%AC%ED%98%84%ED%95%98%EA%B8%B0-react-infinite-scroller#3-infinite-scroll-%EB%AC%B4%ED%95%9C%EC%8A%A4%ED%81%AC%EB%A1%A4)

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다. 
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
