### PR TITLE
댓글 목록 무한스크롤 구현

### DIFF
--- a/src/api/comments.ts
+++ b/src/api/comments.ts
@@ -11,20 +11,23 @@ import axios from 'lib/axios';
 
 export const getComments = async ({
   diaryId,
-  page,
-  config,
+  currentPage,
 }: GetCommentRequest) => {
+  const currentPageIndex = currentPage - 1;
   const {
     data: { data },
   } = await axios.get<SuccessResponse<Comments>>(
-    `${API_PATH.diaries.index}/${diaryId}/comment?skip=${
-      PAGE_SIZE * page
-    }&take=${PAGE_SIZE}`,
-    config,
+    `${API_PATH.diaries.index}/${diaryId}/comment`,
+    {
+      params: {
+        skip: PAGE_SIZE * currentPageIndex,
+        take: PAGE_SIZE,
+      },
+    },
   );
 
   const nextPage: number | undefined =
-    data.comments.length >= PAGE_SIZE ? page + 1 : undefined;
+    data.totalPage > currentPage ? currentPage + 1 : undefined;
 
   return { ...data, nextPage };
 };

--- a/src/api/comments.ts
+++ b/src/api/comments.ts
@@ -6,17 +6,27 @@ import type {
   GetCommentRequest,
 } from 'types/comment';
 import type { OnlyMessageResponse, SuccessResponse } from 'types/response';
-import { API_PATH } from 'constants/api/path';
+import { API_PATH, PAGE_SIZE } from 'constants/api/path';
 import axios from 'lib/axios';
 
-export const getComments = async ({ diaryId, config }: GetCommentRequest) => {
+export const getComments = async ({
+  diaryId,
+  page,
+  config,
+}: GetCommentRequest) => {
   const {
     data: { data },
   } = await axios.get<SuccessResponse<Comments>>(
-    `${API_PATH.diaries.index}/${diaryId}/comment`,
+    `${API_PATH.diaries.index}/${diaryId}/comment?skip=${
+      PAGE_SIZE * page
+    }&take=${PAGE_SIZE}`,
     config,
   );
-  return data;
+
+  const nextPage: number | undefined =
+    data.comments.length >= PAGE_SIZE ? page + 1 : undefined;
+
+  return { ...data, nextPage };
 };
 
 export const writeComment = async ({

--- a/src/components/comment/DiaryComments.tsx
+++ b/src/components/comment/DiaryComments.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import { DiaryComment } from './DiaryComment';
+import EmptyComment from './EmptyComment';
 import type { Comments } from 'types/comment';
 import { ScreenReaderOnly } from 'styles';
 
@@ -16,13 +17,7 @@ export const DiaryComments = ({
   const isEmptyComments = totalCount === 0;
 
   if (isEmptyComments) {
-    return (
-      <NoCommentTitle>
-        아직 댓글이 없어요.
-        <br />
-        가장 먼저 댓글을 남겨보세요.
-      </NoCommentTitle>
-    );
+    return <EmptyComment />;
   }
 
   return (
@@ -48,11 +43,4 @@ export const DiaryComments = ({
 
 const CommentTitle = styled.h3`
   ${ScreenReaderOnly}
-`;
-
-const NoCommentTitle = styled.h3`
-  margin: 40px 0 20px;
-  color: ${({ theme }) => theme.colors.gray_02};
-  ${({ theme }) => theme.fonts.body_09};
-  text-align: center;
 `;

--- a/src/components/comment/DiaryComments.tsx
+++ b/src/components/comment/DiaryComments.tsx
@@ -13,7 +13,7 @@ export const DiaryComments = ({
   diaryId,
 }: DiaryCommentsProps) => {
   const { totalCount } = diaryComments[0];
-  const isEmptyComments = diaryComments.length === 0;
+  const isEmptyComments = totalCount === 0;
 
   if (isEmptyComments) {
     return (

--- a/src/components/comment/DiaryComments.tsx
+++ b/src/components/comment/DiaryComments.tsx
@@ -4,7 +4,7 @@ import type { Comments } from 'types/comment';
 import { ScreenReaderOnly } from 'styles';
 
 interface DiaryCommentsProps {
-  diaryComments: Comments;
+  diaryComments: Comments[];
   diaryId: string;
 }
 
@@ -12,31 +12,36 @@ export const DiaryComments = ({
   diaryComments,
   diaryId,
 }: DiaryCommentsProps) => {
-  const { comments, totalCount } = diaryComments;
+  const { totalCount } = diaryComments[0];
+  const isEmptyComments = diaryComments.length === 0;
+
+  if (isEmptyComments) {
+    return (
+      <NoCommentTitle>
+        아직 댓글이 없어요.
+        <br />
+        가장 먼저 댓글을 남겨보세요.
+      </NoCommentTitle>
+    );
+  }
+
   return (
     <>
-      {totalCount > 0 ? (
-        <>
-          <CommentTitle>{totalCount}개의 댓글</CommentTitle>
-          <ul>
-            {comments.map((comment) => {
-              return (
-                <DiaryComment
-                  key={`diary-comment-${comment.id}`}
-                  diaryComment={comment}
-                  diaryId={diaryId}
-                />
-              );
-            })}
-          </ul>
-        </>
-      ) : (
-        <NoCommentTitle>
-          아직 댓글이 없어요.
-          <br />
-          가장 먼저 댓글을 남겨보세요.
-        </NoCommentTitle>
-      )}
+      <CommentTitle>{totalCount}개의 댓글</CommentTitle>
+      <ul>
+        {diaryComments.map((data) => {
+          const { comments } = data;
+          return comments.map((comment) => {
+            return (
+              <DiaryComment
+                key={`diary-comment-${comment.id}`}
+                diaryComment={comment}
+                diaryId={diaryId}
+              />
+            );
+          });
+        })}
+      </ul>
     </>
   );
 };

--- a/src/components/comment/DiaryCommentsContainer.tsx
+++ b/src/components/comment/DiaryCommentsContainer.tsx
@@ -1,7 +1,8 @@
 import styled from '@emotion/styled';
 import { WriteCommentIcon } from 'assets/icons';
 import { DiaryCommentInput, DiaryComments } from 'components/comment';
-import { FullPageLoading } from 'components/common';
+import { FullPageLoading, ObserverTarget } from 'components/common';
+import { useIntersectionObserver } from 'hooks/common';
 import { useComments } from 'hooks/services';
 
 interface DiaryCommentsContainerProps {
@@ -11,13 +12,22 @@ interface DiaryCommentsContainerProps {
 export const DiaryCommentsContainer = ({
   diaryId,
 }: DiaryCommentsContainerProps) => {
-  const { commentsData, isLoading } = useComments(diaryId);
+  const { commentsData, isLoading, isError, fetchNextPage } =
+    useComments(diaryId);
+  const { setTargetRef } = useIntersectionObserver({
+    onIntersect: fetchNextPage,
+  });
 
   if (commentsData === undefined) return <FullPageLoading />;
 
   return (
     <DiaryCommentSection>
       <DiaryComments diaryComments={commentsData} diaryId={diaryId} />
+      <ObserverTarget
+        targetRef={setTargetRef}
+        isLoading={isLoading}
+        isError={isError}
+      />
       <WriteCommentLabel htmlFor="diaryCommentTextarea">
         <WriteCommentIcon />
         <WriteCommentSpan>댓글쓰기</WriteCommentSpan>

--- a/src/components/comment/DiaryCommentsContainer.tsx
+++ b/src/components/comment/DiaryCommentsContainer.tsx
@@ -13,7 +13,7 @@ export const DiaryCommentsContainer = ({
 }: DiaryCommentsContainerProps) => {
   const { commentsData, isLoading } = useComments(diaryId);
 
-  if (commentsData === undefined || isLoading) return <FullPageLoading />;
+  if (commentsData === undefined) return <FullPageLoading />;
 
   return (
     <DiaryCommentSection>

--- a/src/components/comment/EmptyComment.tsx
+++ b/src/components/comment/EmptyComment.tsx
@@ -1,0 +1,26 @@
+import styled from '@emotion/styled';
+
+const EmptyComment = () => {
+  return (
+    <EmptyContainer>
+      <EmptyParagraph>
+        아직 댓글이 없어요.
+        <br />
+        가장 먼저 댓글을 남겨보세요.
+      </EmptyParagraph>
+    </EmptyContainer>
+  );
+};
+
+export default EmptyComment;
+
+const EmptyContainer = styled.div`
+  padding-top: 40px;
+  text-align: center;
+`;
+
+const EmptyParagraph = styled.p`
+  color: ${({ theme }) => theme.colors.gray_02};
+  ${({ theme }) => theme.fonts.body_09};
+  text-align: center;
+`;

--- a/src/components/comment/EmptyComment.tsx
+++ b/src/components/comment/EmptyComment.tsx
@@ -2,24 +2,18 @@ import styled from '@emotion/styled';
 
 const EmptyComment = () => {
   return (
-    <EmptyContainer>
-      <EmptyParagraph>
-        아직 댓글이 없어요.
-        <br />
-        가장 먼저 댓글을 남겨보세요.
-      </EmptyParagraph>
-    </EmptyContainer>
+    <Title>
+      아직 댓글이 없어요.
+      <br />
+      가장 먼저 댓글을 남겨보세요.
+    </Title>
   );
 };
 
 export default EmptyComment;
 
-const EmptyContainer = styled.div`
+const Title = styled.h3`
   padding-top: 40px;
-  text-align: center;
-`;
-
-const EmptyParagraph = styled.p`
   color: ${({ theme }) => theme.colors.gray_02};
   ${({ theme }) => theme.fonts.body_09};
   text-align: center;

--- a/src/components/diary/DiariesContainer.tsx
+++ b/src/components/diary/DiariesContainer.tsx
@@ -14,7 +14,8 @@ export const DiariesContainer = ({
   diariesData,
   empty,
 }: DiariesContainerProps) => {
-  const isEmptyDiaries = diariesData.length === 0;
+  const { totalCount } = diariesData[0];
+  const isEmptyDiaries = totalCount === 0;
 
   if (isEmptyDiaries) return empty;
 

--- a/src/hooks/services/queries/useComments.ts
+++ b/src/hooks/services/queries/useComments.ts
@@ -6,8 +6,8 @@ export const useComments = (diaryId: string) => {
   const { data, isFetching, isFetchingNextPage, isError, fetchNextPage } =
     useInfiniteQuery({
       queryKey: [queryKeys.comments, diaryId],
-      queryFn: async ({ pageParam = 0 }) =>
-        await api.getComments({ diaryId, page: pageParam as number }),
+      queryFn: async ({ pageParam = 1 }) =>
+        await api.getComments({ diaryId, currentPage: pageParam as number }),
       getNextPageParam: (lastPage) => lastPage.nextPage,
     });
 

--- a/src/hooks/services/queries/useComments.ts
+++ b/src/hooks/services/queries/useComments.ts
@@ -1,11 +1,22 @@
-import { useQuery } from '@tanstack/react-query';
+import { useInfiniteQuery } from '@tanstack/react-query';
 import * as api from 'api';
 import { queryKeys } from 'constants/queryKeys';
 
 export const useComments = (diaryId: string) => {
-  const { data: commentsData, isLoading } = useQuery(
-    [queryKeys.comments, diaryId],
-    async () => await api.getComments({ diaryId }),
-  );
-  return { commentsData, isLoading };
+  const { data, isFetching, isFetchingNextPage, isError, fetchNextPage } =
+    useInfiniteQuery({
+      queryKey: [queryKeys.comments, diaryId],
+      queryFn: async ({ pageParam = 0 }) =>
+        await api.getComments({ diaryId, page: pageParam as number }),
+      getNextPageParam: (lastPage) => lastPage.nextPage,
+    });
+
+  const isLoading = isFetching && !isFetchingNextPage;
+
+  return {
+    commentsData: data?.pages,
+    isLoading,
+    isError,
+    fetchNextPage,
+  };
 };

--- a/src/pages/diary/[id]/index.tsx
+++ b/src/pages/diary/[id]/index.tsx
@@ -132,11 +132,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     [queryKeys.diaries, id],
     async () => await api.getDiaryDetail({ id: id as string, config: headers }),
   );
-  await queryClient.prefetchQuery(
-    [queryKeys.comments, id],
-    async () =>
-      await api.getComments({ diaryId: id as string, config: headers }),
-  );
+
   return { props: { dehydratedState: dehydrate(queryClient) } };
 };
 

--- a/src/types/comment.ts
+++ b/src/types/comment.ts
@@ -15,6 +15,7 @@ export interface Comments {
   comments: Comment[];
   totalCount: number;
   totalPage: number;
+  nextPage: number | undefined;
 }
 
 export type CommentForm = Pick<Comment, 'comment'>;
@@ -23,6 +24,7 @@ export type CommentForm = Pick<Comment, 'comment'>;
 
 export interface GetCommentRequest {
   diaryId: Pick<DiaryDetail, 'id'>['id'];
+  page: number;
   config?: AxiosRequestConfig;
 }
 

--- a/src/types/comment.ts
+++ b/src/types/comment.ts
@@ -24,8 +24,7 @@ export type CommentForm = Pick<Comment, 'comment'>;
 
 export interface GetCommentRequest {
   diaryId: Pick<DiaryDetail, 'id'>['id'];
-  page: number;
-  config?: AxiosRequestConfig;
+  currentPage: number;
 }
 
 export interface WriteCommentRequest extends CommentForm {


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #199 
- #190 
  - 해당 브랜치는 #190 을 기준으로 생성되었습니다.
  - 따라서 머지 방향이 #190 입니다. 

<br />

## 🗒 작업 목록

- [x] 댓글 목록 조회 커스텀 훅에서 사용된 useQuery를 useInfiniteQuery로 변경 
- [x] useInfiniteQuery 로 인해 변경된 데이터 구조에 맞게 DiaryComments 컴포넌트 수정
- [x] useIntersectionObserver 적용하여 무한스크롤 구현

<br />

## 🧐 PR Point

> 일기 목록 무한스크롤과 동일한 작업을 적용했습니다.

- 댓글 목록 조회시 무한스크롤을 적용하여 사용자 경험을 높입니다.
- PAGE_SIZE(take)를 일기 목록과 동일하게 적용했습니다.
  - 댓글 목록의 경우 take의 기본값이 5입니다. 
  - 댓글 스크롤 시 PAGE_SIZE가 5라면 댓글 특성 상 글의 길이가 길지 않으므로 API 호출 빈도가 높을 것 같아 10으로 적용했습니다.

<br />

## 💥 Trouble Shooting
- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크

https://github.com/a-daily-diary/ADD.FE/assets/85009583/c7f3a1f5-1f9b-4fb9-8028-9d46c8cf52c2

<br />

## 📚 참고

- 참고한 내용 또는 링크를 입력해주세요.

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다. 
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
