### PR TITLE
다른 사용자 프로필 내 활동 탭 구현

### DIFF
--- a/src/components/layouts/Layout.tsx
+++ b/src/components/layouts/Layout.tsx
@@ -8,7 +8,7 @@ interface LayoutProps {
   children?: ReactNode;
 }
 
-const SHOW_NAVBAR_PAGES = ['/', '/profile'];
+const SHOW_NAVBAR_PAGES = ['/', '/profile', '/profile/[username]'];
 
 const Layout = ({ children }: LayoutProps): ReactJSXElement => {
   const { pathname } = useRouter();

--- a/src/components/profile/ActivitiesContainer.tsx
+++ b/src/components/profile/ActivitiesContainer.tsx
@@ -1,5 +1,4 @@
 import styled from '@emotion/styled';
-import { useSession } from 'next-auth/react';
 import { useState } from 'react';
 import { ActivitiesCalendar } from './ActivitiesCalendar';
 import { ActivitiesInformation } from './ActivitiesInformation';

--- a/src/components/profile/ActivitiesContainer.tsx
+++ b/src/components/profile/ActivitiesContainer.tsx
@@ -26,9 +26,13 @@ const initialCalendarDate = {
 
 interface ActivitiesContainerProps {
   title: string;
+  username: string;
 }
 
-export const ActivitiesContainer = ({ title }: ActivitiesContainerProps) => {
+export const ActivitiesContainer = ({
+  title,
+  username,
+}: ActivitiesContainerProps) => {
   const todayDateString = dateStringFormat(today.toDateString());
   const years = getYearsFromStartYearToNow();
 
@@ -39,13 +43,9 @@ export const ActivitiesContainer = ({ title }: ActivitiesContainerProps) => {
   }>(initialCalendarDate);
   const [selectedDate, setSelectedDate] = useState<string>(todayDateString);
 
-  const { data: session } = useSession({ required: true });
-
-  if (session === null) return <div>로그인이 필요합니다.</div>; // TODO: 로그인 페이지로 이동 모달 생성하여 적용하기
-
   const { ref, isVisible, setIsVisible } = useClickOutside();
   const { activitiesData } = useActivities({
-    username: session.user.username,
+    username,
     year: calendarDate.activeYear,
   });
 
@@ -119,7 +119,9 @@ export const ActivitiesContainer = ({ title }: ActivitiesContainerProps) => {
         onClick={handleClick}
       />
 
-      {isSelected && <ActivityDetail dateString={selectedDate} />}
+      {isSelected && (
+        <ActivityDetail dateString={selectedDate} username={username} />
+      )}
     </section>
   );
 };

--- a/src/components/profile/ActivityDetail.tsx
+++ b/src/components/profile/ActivityDetail.tsx
@@ -1,5 +1,4 @@
 import styled from '@emotion/styled';
-import { useSession } from 'next-auth/react';
 import { Loading } from 'components/common';
 import { ActivityDiariesContainer } from 'components/diary';
 import { EmptyActivitiesDiary } from 'components/diary/EmptyActivitiesDiary';

--- a/src/components/profile/ActivityDetail.tsx
+++ b/src/components/profile/ActivityDetail.tsx
@@ -8,15 +8,15 @@ import { dateWithDayFormat } from 'utils';
 
 interface ActivityDetailProps {
   dateString: string;
+  username: string;
 }
 
-export const ActivityDetail = ({ dateString }: ActivityDetailProps) => {
-  const { data: session } = useSession();
-
-  if (session === null) return <div>로그인이 필요합니다.</div>; // TODO: 로그인 페이지로 이동 모달 생성하여 적용하기
-
+export const ActivityDetail = ({
+  dateString,
+  username,
+}: ActivityDetailProps) => {
   const { activityDetailData } = useActivityDetail({
-    username: session.user.username,
+    username,
     dateString,
   });
 
@@ -47,6 +47,7 @@ export const ActivityDetail = ({ dateString }: ActivityDetailProps) => {
         </CountList>
       </DetailHeader>
 
+      {/* TODO: 날짜별, 사용자별 UI 수정 필요 */}
       <ActivityDiariesContainer
         title={`${dateString} 작성한 일기`}
         diariesData={diaries}

--- a/src/pages/profile/[username].tsx
+++ b/src/pages/profile/[username].tsx
@@ -11,7 +11,7 @@ import * as api from 'api';
 import { FullPageLoading, ObserverTarget, Seo, Tab } from 'components/common';
 import { DiariesContainer } from 'components/diary';
 import EmptyDiary from 'components/diary/EmptyDiary';
-import { ProfileContainer } from 'components/profile';
+import { ActivitiesContainer, ProfileContainer } from 'components/profile';
 import { PAGE_PATH } from 'constants/common';
 import { queryKeys } from 'constants/services';
 import { useIntersectionObserver, useTabIndicator } from 'hooks/common';
@@ -59,6 +59,12 @@ const YourProfile: NextPage<
           );
         })}
       </Tab>
+      {PROFILE_TAB_LIST[activeIndex].id === 'activities' && (
+        <ActivitiesContainer
+          title={PROFILE_TAB_LIST[activeIndex].title}
+          username={username}
+        />
+      )}
       {PROFILE_TAB_LIST[activeIndex].id === 'diaries' && (
         <>
           <DiariesContainer

--- a/src/pages/profile/[username].tsx
+++ b/src/pages/profile/[username].tsx
@@ -8,7 +8,7 @@ import type {
   NextPage,
 } from 'next';
 import * as api from 'api';
-import { Loading, ObserverTarget, Seo, Tab } from 'components/common';
+import { FullPageLoading, ObserverTarget, Seo, Tab } from 'components/common';
 import { DiariesContainer } from 'components/diary';
 import EmptyDiary from 'components/diary/EmptyDiary';
 import { ProfileContainer } from 'components/profile';
@@ -34,7 +34,7 @@ const YourProfile: NextPage<
     onIntersect: fetchNextPage,
   });
 
-  if (userDiariesData === undefined) return <Loading />;
+  if (userDiariesData === undefined) return <FullPageLoading />;
 
   return (
     <>

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -75,7 +75,10 @@ const MyProfile: NextPage = () => {
         })}
       </Tab>
       {PROFILE_TAB_LIST[activeIndex].id === 'activities' && (
-        <ActivitiesContainer title={PROFILE_TAB_LIST[activeIndex].title} />
+        <ActivitiesContainer
+          title={PROFILE_TAB_LIST[activeIndex].title}
+          username={session.user.username}
+        />
       )}
       {PROFILE_TAB_LIST[activeIndex].id === 'diaries' && (
         <>


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #212 

<br />

## 🗒 작업 목록

- [x] 다른 사용자 프로필 활동 탭 구현
- [x] 다른 사용자 프로필 페이지에서 나타나지 않았던 Navbar 나타나게 수정
- [x] 잘못 적용된 로딩 컴포넌트 수정

<br />

## 🧐 PR Point

- 다른 사용자 프로필 페이지 접근 시 활동 탭이 나타나도록 적용했습니다.
- 내 프로필 페이지와 동일하게 적용되어 있어 논의가 필요한 부분은 주석으로 남겨두었습니다.
- 다른 사용자 프로필 페이지에서 나타나지 않았던 Navbar 나타나도록 했습니다. 

<br />

## 💥 Trouble Shooting
- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크

https://github.com/a-daily-diary/ADD.FE/assets/85009583/159b8dfa-acbd-4215-88e2-2dc8d124eb0a

<br />

## 📚 참고

- 참고한 내용 또는 링크를 입력해주세요.

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다. 
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
