### PR TITLE
FloatingMenu 리팩토링

### DIFF
--- a/src/components/comment/DiaryComment.tsx
+++ b/src/components/comment/DiaryComment.tsx
@@ -70,7 +70,6 @@ export const DiaryComment = ({ diaryComment, diaryId }: DiaryCommentProps) => {
         <CommentContent>{comment}</CommentContent>
         {isVisible && (
           <FloatingMenu
-            position="absolute"
             items={
               isCommenter
                 ? [

--- a/src/components/common/FloatingMenu.tsx
+++ b/src/components/common/FloatingMenu.tsx
@@ -1,40 +1,26 @@
-import styled from '@emotion/styled';
 import {
   FloatingMenuButton,
   type FloatingMenuButtonProps,
 } from './FloatingMenuButton';
-import { Z_INDEX } from 'constants/styles';
+import { PopOver } from './PopOver';
 
-interface FloatingMenuStyleProps {
-  position: 'absolute' | 'fixed';
-}
-interface FloatingMenuProps extends FloatingMenuStyleProps {
+interface FloatingMenuProps {
   items: FloatingMenuButtonProps[];
 }
 
-export const FloatingMenu = ({ items, position }: FloatingMenuProps) => {
+export const FloatingMenu = ({ items }: FloatingMenuProps) => {
   return (
-    <List position={position}>
-      {items.map((item, index) => {
-        const { label, icon, onClick } = item;
-        return (
-          <li key={`floating-item-${index}`}>
-            <FloatingMenuButton icon={icon} label={label} onClick={onClick} />
-          </li>
-        );
-      })}
-    </List>
+    <PopOver top={40} right={20}>
+      <ul>
+        {items.map((item, index) => {
+          const { label, icon, onClick } = item;
+          return (
+            <li key={`floating-item-${index}`}>
+              <FloatingMenuButton icon={icon} label={label} onClick={onClick} />
+            </li>
+          );
+        })}
+      </ul>
+    </PopOver>
   );
 };
-
-const List = styled.ul<FloatingMenuStyleProps>`
-  position: ${({ position }) => position};
-  top: 40px;
-  right: 20px;
-  z-index: ${Z_INDEX.dialog};
-  padding: 6px 0;
-  border: 1px solid ${({ theme }) => theme.colors.gray_06};
-  border-radius: 10px;
-  background-color: ${({ theme }) => theme.colors.white};
-  filter: drop-shadow(4px 4px 10px rgba(0, 0, 0, 0.08));
-`;

--- a/src/components/common/FloatingMenu.tsx
+++ b/src/components/common/FloatingMenu.tsx
@@ -2,7 +2,7 @@ import {
   FloatingMenuButton,
   type FloatingMenuButtonProps,
 } from './FloatingMenuButton';
-import { PopOver } from './PopOver';
+import { Popover } from './Popover';
 
 interface FloatingMenuProps {
   items: FloatingMenuButtonProps[];
@@ -10,7 +10,7 @@ interface FloatingMenuProps {
 
 export const FloatingMenu = ({ items }: FloatingMenuProps) => {
   return (
-    <PopOver top={40} right={20}>
+    <Popover top={40} right={20}>
       <ul>
         {items.map((item, index) => {
           const { label, icon, onClick } = item;
@@ -21,6 +21,6 @@ export const FloatingMenu = ({ items }: FloatingMenuProps) => {
           );
         })}
       </ul>
-    </PopOver>
+    </Popover>
   );
 };

--- a/src/components/common/Popover.tsx
+++ b/src/components/common/Popover.tsx
@@ -4,7 +4,6 @@ import { Z_INDEX } from 'constants/styles';
 import { theme } from 'styles';
 
 interface PopoverProps extends PropsWithChildren {
-  position?: 'absolute' | 'fixed';
   positionBase?: 'top' | 'bottom';
   top?: number;
   right?: number;
@@ -13,7 +12,6 @@ interface PopoverProps extends PropsWithChildren {
 // NOTE: Popover의 부모에 position: relative 필요
 export const Popover = ({
   children,
-  position = 'absolute',
   positionBase = 'top',
   top = 10,
   right = 0,
@@ -21,7 +19,7 @@ export const Popover = ({
   return (
     <div
       css={css`
-        position: ${position};
+        position: absolute;
         top: ${positionBase === 'top' ? `${top}px` : 'auto'};
         bottom: ${positionBase === 'bottom' ? 0 : 'auto'};
         right: ${right}px;

--- a/src/components/common/Popover.tsx
+++ b/src/components/common/Popover.tsx
@@ -5,6 +5,7 @@ import { theme } from 'styles';
 
 interface PopoverProps extends PropsWithChildren {
   position?: 'absolute' | 'fixed';
+  positionBase?: 'top' | 'bottom';
   top?: number;
   right?: number;
 }
@@ -13,6 +14,7 @@ interface PopoverProps extends PropsWithChildren {
 export const Popover = ({
   children,
   position = 'absolute',
+  positionBase = 'top',
   top = 10,
   right = 0,
 }: PopoverProps) => {
@@ -20,15 +22,18 @@ export const Popover = ({
     <div
       css={css`
         position: ${position};
+        top: ${positionBase === 'top' ? `${top}px` : 'auto'};
+        bottom: ${positionBase === 'bottom' ? 0 : 'auto'};
         right: ${right}px;
-        bottom: 0;
         z-index: ${Z_INDEX.dialog};
         padding: 6px 0;
         border: 1px solid ${theme.colors.gray_06};
         border-radius: 10px;
         background-color: ${theme.colors.white};
         filter: drop-shadow(4px 4px 10px rgba(0, 0, 0, 0.08));
-        transform: translateY(calc(100% + ${top}px));
+        transform: ${positionBase === 'bottom'
+          ? `translateY(calc(100% + ${top}px))`
+          : 'none'};
       `}
     >
       {children}

--- a/src/components/profile/ActivitiesContainer.tsx
+++ b/src/components/profile/ActivitiesContainer.tsx
@@ -104,7 +104,7 @@ export const ActivitiesContainer = ({
             <QuestionIcon />
           </QuestionButton>
           {isVisible && (
-            <Popover>
+            <Popover positionBase="bottom">
               <ActivitiesInformation />
             </Popover>
           )}

--- a/src/pages/diary/[id]/index.tsx
+++ b/src/pages/diary/[id]/index.tsx
@@ -59,44 +59,46 @@ const DiaryDetailPage: NextPage = () => {
       <Header
         left={<HeaderLeft type="이전" />}
         right={
-          <HeaderRight
-            buttonRef={ref}
-            type="더보기"
-            onClick={() => {
-              setIsVisible((state) => !state);
-            }}
-          />
+          <>
+            <HeaderRight
+              buttonRef={ref}
+              type="더보기"
+              onClick={() => {
+                setIsVisible((state) => !state);
+              }}
+            />
+            {isVisible && (
+              <FloatingMenu
+                items={
+                  isAuthor
+                    ? [
+                        {
+                          icon: <EditIcon />,
+                          label: '수정하기',
+                          onClick: async () =>
+                            await router.push(`/diary/${id as string}/edit`),
+                        },
+                        {
+                          icon: <TrashIcon />,
+                          label: '삭제하기',
+                          onClick: handleDeleteModal.open,
+                        },
+                      ]
+                    : [
+                        {
+                          icon: <ReportIcon />,
+                          label: '신고하기',
+                          onClick: () => {
+                            confirm('신고하시겠습니까?'); // TODO: 신고하기 기능
+                          },
+                        },
+                      ]
+                }
+              />
+            )}
+          </>
         }
       />
-      {isVisible && (
-        <FloatingMenu
-          position="fixed"
-          items={
-            isAuthor
-              ? [
-                  {
-                    icon: <EditIcon />,
-                    label: '수정하기',
-                    onClick: handleGoToEdit,
-                  },
-                  {
-                    icon: <TrashIcon />,
-                    label: '삭제하기',
-                    onClick: handleDeleteModal.open,
-                  },
-                ]
-              : [
-                  {
-                    icon: <ReportIcon />,
-                    label: '신고하기',
-                    onClick: () => {
-                      confirm('신고하시겠습니까?'); // TODO: 신고하기 기능
-                    },
-                  },
-                ]
-          }
-        />
-      )}
       <Section>
         <DiaryDetailContainer {...diaryData} />
         <DiaryCommentsContainer diaryId={id as string} />

--- a/src/pages/diary/[id]/index.tsx
+++ b/src/pages/diary/[id]/index.tsx
@@ -75,8 +75,7 @@ const DiaryDetailPage: NextPage = () => {
                         {
                           icon: <EditIcon />,
                           label: '수정하기',
-                          onClick: async () =>
-                            await router.push(`/diary/${id as string}/edit`),
+                          onClick: handleGoToEdit,
                         },
                         {
                           icon: <TrashIcon />,


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #210 

<br />

## 🗒 작업 목록

- [x] PopOver positionBase prop 추가하여 position 기준점에 따라 위치 설정 구현
- [x] FloatingMenu에 PopOver 적용 및 불필요한 코드 제거

<br />

## 🧐 PR Point

- 활동 탭 잔디 정보를 나타내는 툴팁 구현 시 UI가 비슷한 FloatingMenu 컴포넌트를 사용하려고 했으나 적합하지 않다고 생각하여 PopOver 컴포넌트를 새로 생성하여 구현했습니다.
- PopOver 컴포넌트를 동일한 UI에 공통적으로 사용할 수 있도록 `positionBase` props를 추가하여 FloatingMenu에 적용 후 불필요한 코드를 제거했습니다.
  -  `positionBase`: position의 기준점을 top 또는 bottom으로 선택하기 위한 prop
- `positionBase="top" top={0}`
  - 기존 `top:0`을 적용하는 것과 동일하게 위치함
- **`positionBase="bottom" top={0}`**
  - `bottom:0`과 `translateY(calc(100% + ${top}px))`으로 인해 부모 요소의 bottom을 기준으로 위치를 지정할 수 있도록 적용했습니다.

|  `positionBase="top" top={0}` | `positionBase="bottom" top={0}` |
|:-------------------------------:|:-------------------------------:|
| ![](https://github.com/a-daily-diary/ADD.FE/assets/85009583/50d4adfa-2a63-43ab-ae0f-f88eff70a39f) | ![](https://github.com/a-daily-diary/ADD.FE/assets/85009583/065bd26a-158f-47b7-90cb-a2634ddb9cba) |


<br />

## 💥 Trouble Shooting
- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크

#### 수정 후 정상적으로 나타나는 지 확인
| 다른 사용자 작성글 더보기 | 내 작성글 더보기 | 다른 사용자 댓글 더보기 |
|:----------------:|:----------------:|:----------------:|
| ![](https://github.com/a-daily-diary/ADD.FE/assets/85009583/8e82a629-773a-4e64-ba49-c9ae4c41a66c) | ![](https://github.com/a-daily-diary/ADD.FE/assets/85009583/e302415e-2145-4396-82c5-3ef10a8a6381) | ![](https://github.com/a-daily-diary/ADD.FE/assets/85009583/9f5cf402-59c7-419d-976a-4dad878262fa) | 
| 내 댓글 더보기 | 잔디 정보 툴팁 |  |
| ![](https://github.com/a-daily-diary/ADD.FE/assets/85009583/65120176-7daa-41fa-8d48-b8cecd45bf3d) | ![](https://github.com/a-daily-diary/ADD.FE/assets/85009583/b6286a55-59a3-489b-a622-19af62c152bf) |  |
 

<br />

## 📚 참고

- 참고한 내용 또는 링크를 입력해주세요.

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다. 
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
