### PR TITLE
로그인 > 비밀번호 찾기_재설정 링크보내기 API 연동

### DIFF
--- a/src/api/users.ts
+++ b/src/api/users.ts
@@ -1,4 +1,5 @@
 import type { LoginRequest, LoginResponse } from 'types/login';
+import type { PasswordResetLinkRequest } from 'types/password';
 import type { ExistsRequest, RegisterRequest } from 'types/register';
 import type { OnlyMessageResponse, SuccessResponse } from 'types/response';
 import { API_PATH } from 'constants/services';
@@ -45,5 +46,15 @@ export const login = async ({ email, password }: LoginRequest) => {
   return await axios.post<SuccessResponse<LoginResponse>>(
     API_PATH.users.login,
     { email, password },
+  );
+};
+
+export const passwordResetLink = async ({
+  email,
+  redirectUrl,
+}: PasswordResetLinkRequest) => {
+  return await axios.post<SuccessResponse<OnlyMessageResponse>>(
+    API_PATH.users.passwordResetLink,
+    { email, redirectUrl },
   );
 };

--- a/src/components/account/FindPasswordForm.tsx
+++ b/src/components/account/FindPasswordForm.tsx
@@ -3,7 +3,7 @@ import { isAxiosError } from 'axios';
 import { useForm } from 'react-hook-form';
 import type { Dispatch, SetStateAction } from 'react';
 import type { SubmitHandler } from 'react-hook-form';
-import type { RegisterForm } from 'types/register';
+import type { PasswordFindForm } from 'types/password';
 import type { ErrorResponse } from 'types/response';
 import { passwordResetLink } from 'api';
 import { Button } from 'components/common';
@@ -15,18 +15,14 @@ interface FindPasswordFormProps {
 }
 
 export const FindPasswordForm = ({ setIsSubmitted }: FindPasswordFormProps) => {
-  /**
-   * @todo
-   * RegisterForm 대신 PasswordFindForm 정의하여 사용
-   */
   const {
     register,
     handleSubmit,
     setError,
     formState: { errors, isValid },
-  } = useForm<RegisterForm>({ mode: 'onChange' });
+  } = useForm<PasswordFindForm>({ mode: 'onChange' });
 
-  const onSubmit: SubmitHandler<RegisterForm> = async (data) => {
+  const onSubmit: SubmitHandler<PasswordFindForm> = async (data) => {
     try {
       const { email } = data;
       await passwordResetLink({

--- a/src/components/account/FindPasswordForm.tsx
+++ b/src/components/account/FindPasswordForm.tsx
@@ -1,7 +1,11 @@
 import styled from '@emotion/styled';
+import { isAxiosError } from 'axios';
 import { useForm } from 'react-hook-form';
 import type { Dispatch, SetStateAction } from 'react';
+import type { SubmitHandler } from 'react-hook-form';
 import type { RegisterForm } from 'types/register';
+import type { ErrorResponse } from 'types/response';
+import { passwordResetLink } from 'api';
 import { Button } from 'components/common';
 import { FormInput } from 'components/form';
 import { ERROR_MESSAGE, VALID_VALUE } from 'constants/validation';
@@ -18,15 +22,37 @@ export const FindPasswordForm = ({ setIsSubmitted }: FindPasswordFormProps) => {
   const {
     register,
     handleSubmit,
-    formState: { isValid },
+    setError,
+    formState: { errors, isValid },
   } = useForm<RegisterForm>({ mode: 'onChange' });
 
-  /**
-   * @todo
-   * 서버로 이메일 전송 요청
-   */
-  const onSubmit = () => {
-    setIsSubmitted(true);
+  const onSubmit: SubmitHandler<RegisterForm> = async (data) => {
+    try {
+      const { email } = data;
+      await passwordResetLink({
+        email,
+        /**
+         * @todo
+         * redirectUrl을 비밀번호 재설정 페이지로 변경
+         */
+        redirectUrl: `${window.location.origin}`,
+      });
+      setIsSubmitted(true);
+    } catch (error) {
+      if (isAxiosError<ErrorResponse>(error)) {
+        if (error.response?.status === 404) {
+          setError('email', {
+            type: 'emailNotFound',
+            message: '이메일이 존재하지 않습니다.',
+          });
+        } else {
+          /**
+           * @todo
+           * 404 외 모든 에러 공통 처리 */
+          console.log(error.response?.status);
+        }
+      }
+    }
   };
 
   return (
@@ -49,6 +75,7 @@ export const FindPasswordForm = ({ setIsSubmitted }: FindPasswordFormProps) => {
           type="text"
           placeholder="이메일"
           label="이메일"
+          errors={errors.email}
         />
         <ButtonContainer>
           <Button

--- a/src/constants/services/path.ts
+++ b/src/constants/services/path.ts
@@ -6,6 +6,7 @@ export const API_PATH = {
     usernameExists: '/users/username-exists',
     register: '/users/register',
     login: '/users/login',
+    passwordResetLink: '/users/password-reset-link',
   },
   diaries: {
     index: '/diaries',

--- a/src/types/password.ts
+++ b/src/types/password.ts
@@ -1,4 +1,13 @@
+/**
+ * Request
+ */
 export interface PasswordResetLinkRequest {
   email: string;
   redirectUrl: string;
 }
+
+/**
+ * Others
+ */
+
+export type PasswordFindForm = Omit<PasswordResetLinkRequest, 'redirectUrl'>;

--- a/src/types/password.ts
+++ b/src/types/password.ts
@@ -1,0 +1,4 @@
+export interface PasswordResetLinkRequest {
+  email: string;
+  redirectUrl: string;
+}


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #204 

<br />

## 🗒 작업 목록

- [x] 비밀번호 재설정 링크보내기 API 연동을 위한 타입 정의, API 추가
- [x] API 에러 핸들링

<br />

## 🧐 PR Point
- 비밀번호 재설정 링크 보내기 API 연동 작업을 진행했습니다.
- 이메일이 존재하지 않아 404 에러가 내려지는 경우 '이메일이 존재하지 않습니다' 메시지를 표출합니다.
- 메일을 통해 받게 되는 재설정 링크 url은 '비밀번호 재설정' 페이지여야 하나 해당 페이지는 이 후 작업 예정으로 'todo'를 남겨놓았습니다. (현재는 `window.location.origin`으로 로그인 페이지를 연결해두었습니다)

<br />

## 💥 Trouble Shooting
- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크

결과 | 
-- | 
![Mar-24-2024 21-30-34](https://github.com/a-daily-diary/ADD.FE/assets/23066745/075917b0-7a39-4ab6-8741-257b22984c5d)


<br />

## 📚 참고

- 참고한 내용 또는 링크를 입력해주세요.

<br />

## ✅ PR Submit 전 체크리스트

- [] Merge 하는 브랜치는 `main` 브랜치가 아닙니다. 
- [] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [] 불필요한 `console`이 존재하지 않습니다.
