### PR TITLE
로그인 > 비밀번호 재설정 UI 구현

### DIFF
--- a/src/components/account/FindPasswordForm.tsx
+++ b/src/components/account/FindPasswordForm.tsx
@@ -19,7 +19,7 @@ export const FindPasswordForm = ({ setIsSubmitted }: FindPasswordFormProps) => {
     register,
     handleSubmit,
     setError,
-    formState: { errors, isValid },
+    formState: { errors, isValid, isSubmitting },
   } = useForm<PasswordFindForm>({ mode: 'onChange' });
 
   const onSubmit: SubmitHandler<PasswordFindForm> = async (data) => {
@@ -72,7 +72,7 @@ export const FindPasswordForm = ({ setIsSubmitted }: FindPasswordFormProps) => {
         <ButtonContainer>
           <Button
             type="submit"
-            disabled={!isValid}
+            disabled={!isValid || isSubmitting}
             fullWidth
             text="재설정 링크보내기"
           />

--- a/src/components/account/FindPasswordForm.tsx
+++ b/src/components/account/FindPasswordForm.tsx
@@ -27,11 +27,7 @@ export const FindPasswordForm = ({ setIsSubmitted }: FindPasswordFormProps) => {
       const { email } = data;
       await passwordResetLink({
         email,
-        /**
-         * @todo
-         * redirectUrl을 비밀번호 재설정 페이지로 변경
-         */
-        redirectUrl: `${window.location.origin}`,
+        redirectUrl: `${window.location.origin}/account/resetPassword`,
       });
       setIsSubmitted(true);
     } catch (error) {

--- a/src/components/account/ResetPasswordForm.tsx
+++ b/src/components/account/ResetPasswordForm.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import router from 'next/router';
 import { useForm } from 'react-hook-form';
 import type { PasswordResetForm } from 'types/password';
 import { Button } from 'components/common';
@@ -13,13 +14,22 @@ export const ResetPasswordForm = () => {
   const {
     register,
     getValues,
+    handleSubmit,
     formState: { isValid, errors },
   } = useForm<PasswordResetForm>({ mode: 'onChange' });
+
+  const onSubmit = async () => {
+    /**
+     * @todo
+     * 비밀번호 재설정 API 요청
+     */
+    await router.push('/account/login');
+  };
 
   return (
     <>
       <Title>비밀번호를 재설정해주세요.</Title>
-      <Form>
+      <Form onSubmit={handleSubmit(onSubmit)}>
         <FormInput
           register={register('password', {
             required: ERROR_MESSAGE.password.required,

--- a/src/components/account/ResetPasswordForm.tsx
+++ b/src/components/account/ResetPasswordForm.tsx
@@ -3,27 +3,70 @@ import { useForm } from 'react-hook-form';
 import type { PasswordResetForm } from 'types/password';
 import { Button } from 'components/common';
 import { FormInput } from 'components/form';
+import {
+  ERROR_MESSAGE,
+  INVALID_VALUE,
+  VALID_VALUE,
+} from 'constants/validation';
 
 export const ResetPasswordForm = () => {
-  const { register } = useForm<PasswordResetForm>({ mode: 'onChange' });
+  const {
+    register,
+    getValues,
+    formState: { isValid, errors },
+  } = useForm<PasswordResetForm>({ mode: 'onChange' });
 
   return (
     <>
       <Title>비밀번호를 재설정해주세요.</Title>
       <Form>
         <FormInput
-          register={register('password', {})}
+          register={register('password', {
+            required: ERROR_MESSAGE.password.required,
+            minLength: {
+              value: VALID_VALUE.password.min,
+              message: ERROR_MESSAGE.password.length,
+            },
+            maxLength: {
+              value: VALID_VALUE.password.max,
+              message: ERROR_MESSAGE.password.length,
+            },
+            pattern: {
+              value: VALID_VALUE.password.pattern,
+              message: ERROR_MESSAGE.password.pattern,
+            },
+            validate: (value) =>
+              !INVALID_VALUE.password.test(value) ||
+              ERROR_MESSAGE.password.invalidPattern,
+          })}
           type="password"
           placeholder="비밀번호"
           label="비밀번호"
+          errors={errors.password}
         />
         <FormInput
-          register={register('passwordCheck', {})}
+          register={register('passwordCheck', {
+            required: ERROR_MESSAGE.passwordCheck.required,
+            validate: {
+              matchesPreviousPassword: (value) => {
+                const { password } = getValues();
+                return (
+                  password === value || ERROR_MESSAGE.passwordCheck.pattern
+                );
+              },
+            },
+          })}
           type="password"
           placeholder="비밀번호 확인"
           label="비밀번호 확인"
+          errors={errors.passwordCheck}
         />
-        <StyledButton type="submit" text="비밀번호 재설정" fullWidth />
+        <StyledButton
+          type="submit"
+          disabled={!isValid}
+          text="비밀번호 재설정"
+          fullWidth
+        />
       </Form>
     </>
   );

--- a/src/components/account/ResetPasswordForm.tsx
+++ b/src/components/account/ResetPasswordForm.tsx
@@ -15,7 +15,7 @@ export const ResetPasswordForm = () => {
     register,
     getValues,
     handleSubmit,
-    formState: { isValid, errors },
+    formState: { isValid, errors, isSubmitting },
   } = useForm<PasswordResetForm>({ mode: 'onChange' });
 
   const onSubmit = async () => {
@@ -73,7 +73,7 @@ export const ResetPasswordForm = () => {
         />
         <StyledButton
           type="submit"
-          disabled={!isValid}
+          disabled={!isValid || isSubmitting}
           text="비밀번호 재설정"
           fullWidth
         />

--- a/src/components/account/ResetPasswordForm.tsx
+++ b/src/components/account/ResetPasswordForm.tsx
@@ -4,6 +4,7 @@ import { useForm } from 'react-hook-form';
 import type { PasswordResetForm } from 'types/password';
 import { Button } from 'components/common';
 import { FormInput } from 'components/form';
+import { PAGE_PATH } from 'constants/common';
 import {
   ERROR_MESSAGE,
   INVALID_VALUE,
@@ -23,7 +24,7 @@ export const ResetPasswordForm = () => {
      * @todo
      * 비밀번호 재설정 API 요청
      */
-    await router.push('/account/login');
+    await router.replace(PAGE_PATH.account.login);
   };
 
   return (

--- a/src/components/account/ResetPasswordForm.tsx
+++ b/src/components/account/ResetPasswordForm.tsx
@@ -1,0 +1,45 @@
+import styled from '@emotion/styled';
+import { useForm } from 'react-hook-form';
+import type { PasswordResetForm } from 'types/password';
+import { Button } from 'components/common';
+import { FormInput } from 'components/form';
+
+export const ResetPasswordForm = () => {
+  const { register } = useForm<PasswordResetForm>({ mode: 'onChange' });
+
+  return (
+    <>
+      <Title>비밀번호를 재설정해주세요.</Title>
+      <Form>
+        <FormInput
+          register={register('password', {})}
+          type="password"
+          placeholder="비밀번호"
+          label="비밀번호"
+        />
+        <FormInput
+          register={register('passwordCheck', {})}
+          type="password"
+          placeholder="비밀번호 확인"
+          label="비밀번호 확인"
+        />
+        <StyledButton type="submit" text="비밀번호 재설정" fullWidth />
+      </Form>
+    </>
+  );
+};
+
+const Title = styled.h1`
+  ${({ theme }) => theme.fonts.headline_01};
+`;
+
+const Form = styled.form`
+  margin-top: 40px;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+`;
+
+const StyledButton = styled(Button)`
+  margin-top: -4px;
+`;

--- a/src/components/account/index.ts
+++ b/src/components/account/index.ts
@@ -4,3 +4,4 @@ export * from './RegisterProfileImage';
 export * from './RegisterTerms';
 export * from './FindPasswordForm';
 export * from './CompleteFindPassword';
+export * from './ResetPasswordForm';

--- a/src/pages/account/resetPassword.tsx
+++ b/src/pages/account/resetPassword.tsx
@@ -1,0 +1,17 @@
+import styled from '@emotion/styled';
+import type { NextPage } from 'next/types';
+
+const ResetPassword: NextPage = () => {
+  return (
+    <>
+      <ContentWrapper />
+    </>
+  );
+};
+
+export default ResetPassword;
+
+const ContentWrapper = styled.section`
+  margin-top: 54px;
+  padding: 30px 20px;
+`;

--- a/src/pages/account/resetPassword.tsx
+++ b/src/pages/account/resetPassword.tsx
@@ -1,10 +1,13 @@
 import styled from '@emotion/styled';
 import type { NextPage } from 'next/types';
+import { ResetPasswordForm } from 'components/account';
 
 const ResetPassword: NextPage = () => {
   return (
     <>
-      <ContentWrapper />
+      <ContentWrapper>
+        <ResetPasswordForm />
+      </ContentWrapper>
     </>
   );
 };

--- a/src/pages/account/resetPassword.tsx
+++ b/src/pages/account/resetPassword.tsx
@@ -1,10 +1,12 @@
 import styled from '@emotion/styled';
 import type { NextPage } from 'next/types';
 import { ResetPasswordForm } from 'components/account';
+import { Seo } from 'components/common';
 
 const ResetPassword: NextPage = () => {
   return (
     <>
+      <Seo title={'비밀번호 재성정 | a daily diary'} />
       <ContentWrapper>
         <ResetPasswordForm />
       </ContentWrapper>

--- a/src/types/password.ts
+++ b/src/types/password.ts
@@ -11,6 +11,7 @@ export interface PasswordResetLinkRequest {
  */
 
 export type PasswordFindForm = Omit<PasswordResetLinkRequest, 'redirectUrl'>;
+
 export interface PasswordResetForm {
   password: string;
   passwordCheck: string;

--- a/src/types/password.ts
+++ b/src/types/password.ts
@@ -11,3 +11,7 @@ export interface PasswordResetLinkRequest {
  */
 
 export type PasswordFindForm = Omit<PasswordResetLinkRequest, 'redirectUrl'>;
+export interface PasswordResetForm {
+  password: string;
+  passwordCheck: string;
+}


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #221 

<br />

## 🗒 작업 목록

- [x] 재설정할 비밀번호 입력 폼
- [x] 비밀번호 유효성 검사
- [x] 비밀번호 hide/show
- [x] [비밀번호 재설정] 버튼

<br />

## 🧐 PR Point

**Feature**
- 비밀번호 재설정 페이지 UI 작업을 진행했습니다.
- 비밀번호 재설정 페이지 링크는 `/account/resetPassword` 로 설정했습니다.
- 비밀번호 유효성 검사는 회원가입 폼에 있는 password 부분을 동일하게 가져왔습니다.
- 비밀번호 재설정 링크 보내기 시 redirectUrl 을 `/account/resetPassword` 로 수정했습니다. (이전 [PR](https://github.com/a-daily-diary/ADD.FE/pull/220)에서 todo로 표시한 부분)

**Refactor**
- react-hook-form 의 isSubmitting 값을 사용하여 폼을 제출하는 동안 버튼이 disabled 되도록 하였습니다. 

<br />

## 💥 Trouble Shooting
- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크

결과 | 
-- | 
![Mar-31-2024 15-28-50](https://github.com/a-daily-diary/ADD.FE/assets/23066745/d8f95cea-7fcd-4341-a969-c718aba0b777)


<br />

## 📚 참고

- 참고한 내용 또는 링크를 입력해주세요.

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다. 
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
