### PR TITLE
검색 > 최근 검색어 기능 구현

### DIFF
--- a/src/components/search/RecentSearchContainer.tsx
+++ b/src/components/search/RecentSearchContainer.tsx
@@ -4,14 +4,15 @@ import { CloseIcon } from 'assets/icons';
 import { theme } from 'styles';
 
 interface RecentSearchContainerProps {
-  recentSearchList: string[];
+  recentSearchKeywords: string[];
+  onDeleteSearchKeyword: (value: string) => void;
 }
 
 export const RecentSearchContainer = ({
-  recentSearchList,
+  recentSearchKeywords,
+  onDeleteSearchKeyword,
 }: RecentSearchContainerProps) => {
-  const isEmptyRecentSearches =
-    recentSearchList === null || recentSearchList.length === 0;
+  const isEmptyRecentSearches = recentSearchKeywords.length === 0;
 
   return (
     <Container>
@@ -20,11 +21,16 @@ export const RecentSearchContainer = ({
         <NoSearchResults description="최근 검색어 내역이 없습니다." />
       ) : (
         <RecentSearchList>
-          {recentSearchList.map((recentSearch) => {
+          {recentSearchKeywords.map((recentSearchKeyword) => {
             return (
-              <li key={recentSearch}>
-                <RecentSearchButton type="button">
-                  {recentSearch}
+              <li key={recentSearchKeyword}>
+                <RecentSearchButton
+                  type="button"
+                  onClick={() => {
+                    onDeleteSearchKeyword(recentSearchKeyword);
+                  }}
+                >
+                  {recentSearchKeyword}
                   <CloseIcon
                     width={16}
                     height={16}

--- a/src/components/search/RecentSearchContainer.tsx
+++ b/src/components/search/RecentSearchContainer.tsx
@@ -6,17 +6,26 @@ import { theme } from 'styles';
 interface RecentSearchContainerProps {
   recentSearchKeywords: string[];
   onDeleteSearchKeyword: (value: string) => void;
+  onDeleteAllSearchKeyword: () => void;
 }
 
 export const RecentSearchContainer = ({
   recentSearchKeywords,
   onDeleteSearchKeyword,
+  onDeleteAllSearchKeyword,
 }: RecentSearchContainerProps) => {
   const isEmptyRecentSearches = recentSearchKeywords.length === 0;
 
   return (
     <Container>
-      <Title>최근 검색어</Title>
+      <TitleContainer>
+        <Title>최근 검색어</Title>
+        {!isEmptyRecentSearches && (
+          <DeleteAllButton type="button" onClick={onDeleteAllSearchKeyword}>
+            전체 삭제
+          </DeleteAllButton>
+        )}
+      </TitleContainer>
       {isEmptyRecentSearches ? (
         <NoSearchResults description="최근 검색어 내역이 없습니다." />
       ) : (
@@ -50,8 +59,19 @@ const Container = styled.div`
   padding: 20px;
 `;
 
+const TitleContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;
+
 const Title = styled.h2`
   ${({ theme }) => theme.fonts.headline_02}
+`;
+
+const DeleteAllButton = styled.button`
+  color: ${({ theme }) => theme.colors.gray_04};
+  ${({ theme }) => theme.fonts.body_06}
 `;
 
 const RecentSearchList = styled.ul`

--- a/src/components/search/RecentSearchContainer.tsx
+++ b/src/components/search/RecentSearchContainer.tsx
@@ -3,21 +3,15 @@ import { NoSearchResults } from './NoSearchResults';
 import { CloseIcon } from 'assets/icons';
 import { theme } from 'styles';
 
-// TODO: 목데이터 제거
-const RECENT_SEARCHES_MOCKS = [
-  'hello',
-  'daily routine',
-  'dance',
-  'morning',
-  'movies',
-  'cakes',
-  'happy',
-  'computer',
-];
+interface RecentSearchContainerProps {
+  recentSearchList: string[];
+}
 
-export const RecentSearchContainer = () => {
-  // TODO: localStorage 최근 검색어 목록으로 변경
-  const isEmptyRecentSearches = RECENT_SEARCHES_MOCKS.length === 0;
+export const RecentSearchContainer = ({
+  recentSearchList,
+}: RecentSearchContainerProps) => {
+  const isEmptyRecentSearches =
+    recentSearchList === null || recentSearchList.length === 0;
 
   return (
     <Container>
@@ -26,7 +20,7 @@ export const RecentSearchContainer = () => {
         <NoSearchResults description="최근 검색어 내역이 없습니다." />
       ) : (
         <RecentSearchList>
-          {RECENT_SEARCHES_MOCKS.map((recentSearch) => {
+          {recentSearchList.map((recentSearch) => {
             return (
               <li key={recentSearch}>
                 <RecentSearchButton type="button">

--- a/src/components/search/SearchHeader.tsx
+++ b/src/components/search/SearchHeader.tsx
@@ -41,6 +41,7 @@ export const SearchHeader = ({ onSaveSearchKeyword }: SearchHeaderProps) => {
         <SearchInput
           {...register('searchKeyword', {
             required: true,
+            setValueAs: (value: string) => value.trim(),
             // onChange: handleChangeSearch,
           })}
           type="search"

--- a/src/components/search/SearchHeader.tsx
+++ b/src/components/search/SearchHeader.tsx
@@ -1,34 +1,47 @@
 import styled from '@emotion/styled';
 import Link from 'next/link';
 import { useFormContext } from 'react-hook-form';
+import type { SubmitHandler } from 'react-hook-form';
 import type { SearchForm } from 'types/search';
 import { DeleteIcon, SearchIcon } from 'assets/icons';
 import { PAGE_PATH } from 'constants/common';
 import { SVGVerticalAlignStyle, theme } from 'styles';
 
-export const SearchHeader = () => {
-  const { register, setValue, watch } = useFormContext<SearchForm>();
-  const { searchKeyword } = watch();
+interface SearchHeaderProps {
+  onSaveSearchKeyword: (keywordValue: string) => void;
+}
+
+export const SearchHeader = ({ onSaveSearchKeyword }: SearchHeaderProps) => {
+  const { register, watch, setValue, handleSubmit } =
+    useFormContext<SearchForm>();
+  const { searchKeyword: watchSearchKeyword } = watch();
 
   const handleDeleteSearchKeyword = () => {
     setValue('searchKeyword', '');
   };
 
-  const handleChangeSearch = () => {
+  const onSubmit: SubmitHandler<SearchForm> = (data) => {
     // TODO: 검색 기능 구현
-    console.log(searchKeyword);
+    const { searchKeyword } = data;
+    onSaveSearchKeyword(searchKeyword);
   };
 
   return (
     <HeaderLayout>
-      <SearchContainer>
+      <SearchKeywordForm onSubmit={handleSubmit(onSubmit)}>
         <SearchLabel htmlFor="searchKeyword">
-          <SearchIcon width={20} height={20} stroke={theme.colors.primary_00} />
+          <button type="submit">
+            <SearchIcon
+              width={20}
+              height={20}
+              stroke={theme.colors.primary_00}
+            />
+          </button>
         </SearchLabel>
         <SearchInput
           {...register('searchKeyword', {
             required: true,
-            onChange: handleChangeSearch,
+            // onChange: handleChangeSearch,
           })}
           type="search"
           id="searchKeyword"
@@ -36,12 +49,12 @@ export const SearchHeader = () => {
         />
         <DeleteButton
           type="button"
-          isVisible={searchKeyword?.length > 0}
+          isVisible={watchSearchKeyword?.length > 0}
           onClick={handleDeleteSearchKeyword}
         >
           <DeleteIcon />
         </DeleteButton>
-      </SearchContainer>
+      </SearchKeywordForm>
       <CancelLink href={PAGE_PATH.main}>취소</CancelLink>
     </HeaderLayout>
   );
@@ -62,7 +75,7 @@ const HeaderLayout = styled.header`
   background: ${({ theme }) => theme.colors.white};
 `;
 
-const SearchContainer = styled.div`
+const SearchKeywordForm = styled.form`
   flex: 1;
   display: flex;
   align-items: center;
@@ -94,6 +107,8 @@ const SearchInput = styled.input`
 
 const DeleteButton = styled.button<{ isVisible: boolean }>`
   opacity: ${({ isVisible }) => (isVisible ? 1 : 0)};
+
+  ${SVGVerticalAlignStyle}
 `;
 
 const CancelLink = styled(Link)`

--- a/src/components/search/SearchHeader.tsx
+++ b/src/components/search/SearchHeader.tsx
@@ -42,7 +42,6 @@ export const SearchHeader = ({ onSaveSearchKeyword }: SearchHeaderProps) => {
           {...register('searchKeyword', {
             required: true,
             setValueAs: (value: string) => value.trim(),
-            // onChange: handleChangeSearch,
           })}
           type="search"
           id="searchKeyword"

--- a/src/constants/common/index.ts
+++ b/src/constants/common/index.ts
@@ -1,2 +1,3 @@
 export * from './page';
 export * from './date';
+export * from './localStorage';

--- a/src/constants/common/localStorage.ts
+++ b/src/constants/common/localStorage.ts
@@ -1,0 +1,3 @@
+export const LOCAL_STORAGE_KEYS = {
+  searchKeyword: 'a_daily_diary_search_keyword',
+};

--- a/src/constants/validation/value.ts
+++ b/src/constants/validation/value.ts
@@ -14,6 +14,7 @@ export const VALID_VALUE = {
     pattern:
       /(?!((?:[A-Za-z]+)|(?:[`~!@#$%^&*()-_=+[\]{}\\|;:'",<.>/?]+)|(?:[0-9]+))$)[A-Za-z\d`~!@#$%^&*()-_=+[\]{}\\|;:'",<.>/?]{6,30}$/,
   },
+  searchKeywordsMexLength: 8,
 };
 
 export const INVALID_VALUE = {

--- a/src/constants/validation/value.ts
+++ b/src/constants/validation/value.ts
@@ -14,7 +14,7 @@ export const VALID_VALUE = {
     pattern:
       /(?!((?:[A-Za-z]+)|(?:[`~!@#$%^&*()-_=+[\]{}\\|;:'",<.>/?]+)|(?:[0-9]+))$)[A-Za-z\d`~!@#$%^&*()-_=+[\]{}\\|;:'",<.>/?]{6,30}$/,
   },
-  searchKeywordsMexLength: 8,
+  searchKeywordsMaxLength: 8,
 };
 
 export const INVALID_VALUE = {

--- a/src/hooks/common/index.ts
+++ b/src/hooks/common/index.ts
@@ -3,3 +3,4 @@ export * from './useClickOutside';
 export * from './useTabIndicator';
 export * from './useModal';
 export * from './useIntersectionObserver';
+export * from './useSearchKeywordStorage';

--- a/src/hooks/common/useSearchKeywordStorage.ts
+++ b/src/hooks/common/useSearchKeywordStorage.ts
@@ -2,7 +2,8 @@ import { useEffect, useState } from 'react';
 import { LOCAL_STORAGE_KEYS } from 'constants/common';
 
 export function useSearchKeywordStorage() {
-  const [keywordList, setKeywordList] = useState<string[]>([]);
+  const [keywords, setKeywords] = useState<string[]>([]);
+  const [isLastKeyword, setIsLastKeyword] = useState<boolean>(false);
 
   const handleSaveSearchKeyword = (value: string) => {
     const keywordValue = value.trim();
@@ -10,49 +11,66 @@ export function useSearchKeywordStorage() {
 
     if (!isValidKeyword) return;
 
-    setKeywordList((prevState) => {
+    setKeywords((prevState) => {
       if (prevState.includes(keywordValue)) {
         return prevState;
       }
+
       if (prevState.length === 8) {
         return [...prevState.slice(1), keywordValue];
       }
+
       return [...prevState, keywordValue];
     });
   };
 
-  // TODO: 필요 시 주석 해제
-  // const handleDeleteSearchKeyword = (value: string) => {
-  //   setKeywordList((prevState) => prevState.filter((key) => key !== value));
-  // };
+  const handleDeleteSearchKeyword = (value: string) => {
+    setKeywords((prevState) => {
+      const result = prevState.filter((key) => key !== value);
 
+      if (result.length === 0) {
+        setIsLastKeyword(true);
+      }
+
+      return result;
+    });
+  };
+
+  // TODO: 필요 시 주석 해제
   // const handleDeleteAllSearchKeyword = () => {
   //   localStorage.removeItem(LOCAL_STORAGE_KEYS.searchKeyword);
-  //   setKeywordList([]);
+  //   setKeywords([]);
   // };
 
   useEffect(() => {
-    if (keywordList.length > 0) {
+    if (isLastKeyword && keywords.length === 0) {
+      localStorage.removeItem(LOCAL_STORAGE_KEYS.searchKeyword);
+      setIsLastKeyword(false);
+    }
+  }, [isLastKeyword]);
+
+  useEffect(() => {
+    if (keywords.length > 0) {
       localStorage.setItem(
         LOCAL_STORAGE_KEYS.searchKeyword,
-        JSON.stringify(keywordList),
+        JSON.stringify(keywords),
       );
     }
-  }, [keywordList]);
+  }, [keywords]);
 
   useEffect(() => {
     const localStorageKeyword =
       localStorage.getItem(LOCAL_STORAGE_KEYS.searchKeyword) ?? '[]';
 
     if (localStorageKeyword !== 'undefined') {
-      setKeywordList(JSON.parse(localStorageKeyword) as string[]);
+      setKeywords(JSON.parse(localStorageKeyword) as string[]);
     }
   }, []);
 
   return {
-    keywordList,
+    keywords,
     handleSaveSearchKeyword,
-    // handleDeleteSearchKeyword,
+    handleDeleteSearchKeyword,
     // handleDeleteAllSearchKeyword,
   };
 }

--- a/src/hooks/common/useSearchKeywordStorage.ts
+++ b/src/hooks/common/useSearchKeywordStorage.ts
@@ -61,9 +61,7 @@ export const useSearchKeywordStorage = () => {
     const localStorageKeyword =
       localStorage.getItem(LOCAL_STORAGE_KEYS.searchKeyword) ?? '[]';
 
-    if (localStorageKeyword !== 'undefined') {
-      setKeywords(JSON.parse(localStorageKeyword) as string[]);
-    }
+    setKeywords(JSON.parse(localStorageKeyword) as string[]);
   }, []);
 
   return {

--- a/src/hooks/common/useSearchKeywordStorage.ts
+++ b/src/hooks/common/useSearchKeywordStorage.ts
@@ -6,22 +6,21 @@ export function useSearchKeywordStorage() {
   const [keywords, setKeywords] = useState<string[]>([]);
   const [isLastKeyword, setIsLastKeyword] = useState<boolean>(false);
 
-  const handleSaveSearchKeyword = (value: string) => {
-    const keywordValue = value.trim();
-    const isValidKeyword = keywordValue.length > 0;
+  const handleSaveSearchKeyword = (keyword: string) => {
+    const isValidKeyword = keyword.length > 0;
 
     if (!isValidKeyword) return;
 
     setKeywords((prevState) => {
-      if (prevState.includes(keywordValue)) {
+      if (prevState.includes(keyword)) {
         return prevState;
       }
 
       if (prevState.length === VALID_VALUE.searchKeywordsMexLength) {
-        return [...prevState.slice(1), keywordValue];
+        return [...prevState.slice(1), keyword];
       }
 
-      return [...prevState, keywordValue];
+      return [...prevState, keyword];
     });
   };
 

--- a/src/hooks/common/useSearchKeywordStorage.ts
+++ b/src/hooks/common/useSearchKeywordStorage.ts
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { LOCAL_STORAGE_KEYS } from 'constants/common';
 import { VALID_VALUE } from 'constants/validation';
 
-export function useSearchKeywordStorage() {
+export const useSearchKeywordStorage = () => {
   const [keywords, setKeywords] = useState<string[]>([]);
   const [isLastKeyword, setIsLastKeyword] = useState<boolean>(false);
 
@@ -72,4 +72,4 @@ export function useSearchKeywordStorage() {
     handleDeleteSearchKeyword,
     handleDeleteAllSearchKeyword,
   };
-}
+};

--- a/src/hooks/common/useSearchKeywordStorage.ts
+++ b/src/hooks/common/useSearchKeywordStorage.ts
@@ -16,7 +16,7 @@ export function useSearchKeywordStorage() {
         return prevState;
       }
 
-      if (prevState.length === VALID_VALUE.searchKeywordsMexLength) {
+      if (prevState.length === VALID_VALUE.searchKeywordsMaxLength) {
         return [...prevState.slice(1), keyword];
       }
 

--- a/src/hooks/common/useSearchKeywordStorage.ts
+++ b/src/hooks/common/useSearchKeywordStorage.ts
@@ -36,11 +36,10 @@ export function useSearchKeywordStorage() {
     });
   };
 
-  // TODO: 필요 시 주석 해제
-  // const handleDeleteAllSearchKeyword = () => {
-  //   localStorage.removeItem(LOCAL_STORAGE_KEYS.searchKeyword);
-  //   setKeywords([]);
-  // };
+  const handleDeleteAllSearchKeyword = () => {
+    localStorage.removeItem(LOCAL_STORAGE_KEYS.searchKeyword);
+    setKeywords([]);
+  };
 
   useEffect(() => {
     if (isLastKeyword && keywords.length === 0) {
@@ -71,6 +70,6 @@ export function useSearchKeywordStorage() {
     keywords,
     handleSaveSearchKeyword,
     handleDeleteSearchKeyword,
-    // handleDeleteAllSearchKeyword,
+    handleDeleteAllSearchKeyword,
   };
 }

--- a/src/hooks/common/useSearchKeywordStorage.ts
+++ b/src/hooks/common/useSearchKeywordStorage.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { LOCAL_STORAGE_KEYS } from 'constants/common';
+import { VALID_VALUE } from 'constants/validation';
 
 export function useSearchKeywordStorage() {
   const [keywords, setKeywords] = useState<string[]>([]);
@@ -16,7 +17,7 @@ export function useSearchKeywordStorage() {
         return prevState;
       }
 
-      if (prevState.length === 8) {
+      if (prevState.length === VALID_VALUE.searchKeywordsMexLength) {
         return [...prevState.slice(1), keywordValue];
       }
 

--- a/src/hooks/common/useSearchKeywordStorage.ts
+++ b/src/hooks/common/useSearchKeywordStorage.ts
@@ -1,0 +1,58 @@
+import { useEffect, useState } from 'react';
+import { LOCAL_STORAGE_KEYS } from 'constants/common';
+
+export function useSearchKeywordStorage() {
+  const [keywordList, setKeywordList] = useState<string[]>([]);
+
+  const handleSaveSearchKeyword = (value: string) => {
+    const keywordValue = value.trim();
+    const isValidKeyword = keywordValue.length > 0;
+
+    if (!isValidKeyword) return;
+
+    setKeywordList((prevState) => {
+      if (prevState.includes(keywordValue)) {
+        return prevState;
+      }
+      if (prevState.length === 8) {
+        return [...prevState.slice(1), keywordValue];
+      }
+      return [...prevState, keywordValue];
+    });
+  };
+
+  // TODO: 필요 시 주석 해제
+  // const handleDeleteSearchKeyword = (value: string) => {
+  //   setKeywordList((prevState) => prevState.filter((key) => key !== value));
+  // };
+
+  // const handleDeleteAllSearchKeyword = () => {
+  //   localStorage.removeItem(LOCAL_STORAGE_KEYS.searchKeyword);
+  //   setKeywordList([]);
+  // };
+
+  useEffect(() => {
+    if (keywordList.length > 0) {
+      localStorage.setItem(
+        LOCAL_STORAGE_KEYS.searchKeyword,
+        JSON.stringify(keywordList),
+      );
+    }
+  }, [keywordList]);
+
+  useEffect(() => {
+    const localStorageKeyword =
+      localStorage.getItem(LOCAL_STORAGE_KEYS.searchKeyword) ?? '[]';
+
+    if (localStorageKeyword !== 'undefined') {
+      setKeywordList(JSON.parse(localStorageKeyword) as string[]);
+    }
+  }, []);
+
+  return {
+    keywordList,
+    handleSaveSearchKeyword,
+    // handleDeleteSearchKeyword,
+    // handleDeleteAllSearchKeyword,
+  };
+}

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -11,8 +11,12 @@ const SearchPage: NextPage = () => {
   const { watch } = methods;
   const { searchKeyword } = watch();
 
-  const { keywords, handleSaveSearchKeyword, handleDeleteSearchKeyword } =
-    useSearchKeywordStorage();
+  const {
+    keywords,
+    handleSaveSearchKeyword,
+    handleDeleteSearchKeyword,
+    handleDeleteAllSearchKeyword,
+  } = useSearchKeywordStorage();
 
   const isShowRecentSearchResult =
     searchKeyword === undefined || searchKeyword.trim().length === 0;
@@ -27,6 +31,7 @@ const SearchPage: NextPage = () => {
             <RecentSearchContainer
               recentSearchKeywords={keywords}
               onDeleteSearchKeyword={handleDeleteSearchKeyword}
+              onDeleteAllSearchKeyword={handleDeleteAllSearchKeyword}
             />
           ) : (
             <div>검색결과</div>

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -19,7 +19,7 @@ const SearchPage: NextPage = () => {
   } = useSearchKeywordStorage();
 
   const isShowRecentSearchResult =
-    searchKeyword === undefined || searchKeyword.trim().length === 0;
+    searchKeyword === undefined || searchKeyword.length === 0;
 
   return (
     <>

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -11,7 +11,8 @@ const SearchPage: NextPage = () => {
   const { watch } = methods;
   const { searchKeyword } = watch();
 
-  const { keywordList, handleSaveSearchKeyword } = useSearchKeywordStorage();
+  const { keywords, handleSaveSearchKeyword, handleDeleteSearchKeyword } =
+    useSearchKeywordStorage();
 
   const isShowRecentSearchResult =
     searchKeyword === undefined || searchKeyword.trim().length === 0;
@@ -23,7 +24,10 @@ const SearchPage: NextPage = () => {
         <FormProvider {...methods}>
           <SearchHeader onSaveSearchKeyword={handleSaveSearchKeyword} />
           {isShowRecentSearchResult ? (
-            <RecentSearchContainer recentSearchList={keywordList} />
+            <RecentSearchContainer
+              recentSearchKeywords={keywords}
+              onDeleteSearchKeyword={handleDeleteSearchKeyword}
+            />
           ) : (
             <div>검색결과</div>
           )}

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -4,11 +4,14 @@ import type { NextPage } from 'next';
 import type { SearchForm } from 'types/search';
 import { Seo } from 'components/common';
 import { RecentSearchContainer, SearchHeader } from 'components/search';
+import { useSearchKeywordStorage } from 'hooks/common';
 
 const SearchPage: NextPage = () => {
   const methods = useForm<SearchForm>({ mode: 'onChange' });
   const { watch } = methods;
   const { searchKeyword } = watch();
+
+  const { keywordList, handleSaveSearchKeyword } = useSearchKeywordStorage();
 
   const isShowRecentSearchResult =
     searchKeyword === undefined || searchKeyword.trim().length === 0;
@@ -18,9 +21,9 @@ const SearchPage: NextPage = () => {
       <Seo title={'검색 | a daily diary'} />
       <Section>
         <FormProvider {...methods}>
-          <SearchHeader />
+          <SearchHeader onSaveSearchKeyword={handleSaveSearchKeyword} />
           {isShowRecentSearchResult ? (
-            <RecentSearchContainer />
+            <RecentSearchContainer recentSearchList={keywordList} />
           ) : (
             <div>검색결과</div>
           )}


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #224 
- #219 머지 선행 필요

<br />

## 🗒 작업 목록

- [x] useSearchKeywordStorage 커스텀 훅 생성
- [x] 최근 검색어 기능 구현
- [x] 최근 검색어 삭제 기능 구현
- [x] 최근 검색어 전체 삭제 기능 구현

<br />

## 🧐 PR Point

- useSearchKeywordStorage 커스텀 훅을 생성하여 로컬 스토리지에 최근 검색어를 저장, 단일 검색어 삭제, 전체 삭제 기능을 구현했습니다.
- next.js에서 로컬 스토리지에 접근 시 서버사이드 렌더링이 먼저 실행되면서 useEffect로 클라이언트사이드 렌더링 시 로컬 스토리지에 접근 및 저장한 데이터를 가공할 수 있도록 했습니다. 
- 최근 검색어 전체 삭제 버튼은 피그마 상 없지만 필요할 것 같아 제가 임의로 추가했습니다.

<br />

## 💥 Trouble Shooting
- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크

https://github.com/a-daily-diary/ADD.FE/assets/85009583/037c04f5-aba3-4417-8208-fd09dfdf0cc1

<br />

## 📚 참고

- 참고한 내용 또는 링크를 입력해주세요.

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다. 
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
