### PR TITLE
검색 > 검색 결과 기능 구현

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,23 +1,25 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  images: { // NOTE: images domains 설정이 최상위에 있어야 합니다.
+  images: {
+    // NOTE: images domains 설정이 최상위에 있어야 합니다.
     domains: [
-      "add.bucket.s3.amazonaws.com",
-      "dummyimage.com", // 목데이터의 이미지 URL 도메인, 추후 삭제
-      "robohash.org" // 목데이터의 이미지 URL 도메인, 추후 삭제
+      'add.bucket.s3.amazonaws.com',
+      'dummyimage.com', // 목데이터의 이미지 URL 도메인, 추후 삭제
+      'robohash.org', // 목데이터의 이미지 URL 도메인, 추후 삭제
     ],
     formats: ['image/avif', 'image/webp'],
   },
   compiler: {
-    emotion: true
+    emotion: true,
   },
   experimental: {
     fontLoaders: [
       { loader: '@next/font/google', options: { subsets: ['latin'] } },
     ],
+    scrollRestoration: true,
   },
   reactStrictMode: true,
-  webpack: config => {
+  webpack: (config) => {
     config.module.rules.push({
       test: /\.svg$/,
       use: ['@svgr/webpack'],

--- a/src/api/diaries.ts
+++ b/src/api/diaries.ts
@@ -13,7 +13,10 @@ import type { OnlyMessageResponse, SuccessResponse } from 'types/response';
 import { API_PATH, PAGE_SIZE } from 'constants/services';
 import axios from 'lib/axios';
 
-export const getDiaries = async ({ currentPage }: GetDiariesRequest) => {
+export const getDiaries = async ({
+  currentPage,
+  searchKeyword,
+}: GetDiariesRequest) => {
   const currentPageIndex = currentPage - 1;
   const {
     data: { data },
@@ -21,6 +24,7 @@ export const getDiaries = async ({ currentPage }: GetDiariesRequest) => {
     params: {
       skip: PAGE_SIZE * currentPageIndex,
       take: PAGE_SIZE,
+      searchKeyword,
     },
   });
 

--- a/src/api/diaries.ts
+++ b/src/api/diaries.ts
@@ -20,7 +20,7 @@ export const getDiaries = async ({
   const currentPageIndex = currentPage - 1;
   const {
     data: { data },
-  } = await axios.get<SuccessResponse<Diaries>>(`${API_PATH.diaries.index}`, {
+  } = await axios.get<SuccessResponse<Diaries>>(API_PATH.diaries.index, {
     params: {
       skip: PAGE_SIZE * currentPageIndex,
       take: PAGE_SIZE,
@@ -41,7 +41,7 @@ export const getDiariesByUsername = async ({
   const currentPageIndex = currentPage - 1;
   const {
     data: { data },
-  } = await axios.get<SuccessResponse<Diaries>>(`${API_PATH.diaries.index}`, {
+  } = await axios.get<SuccessResponse<Diaries>>(API_PATH.diaries.index, {
     params: {
       username,
       skip: PAGE_SIZE * currentPageIndex,

--- a/src/assets/icons/arrow-down.svg
+++ b/src/assets/icons/arrow-down.svg
@@ -1,0 +1,10 @@
+<svg width="10" height="6" viewBox="0 0 10 6" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_390_363)">
+<path d="M9.375 0.666672L5 5.33334L0.625 0.666671" stroke="#222222" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+<defs>
+<clipPath id="clip0_390_363">
+<rect width="6" height="10" fill="white" transform="translate(10) rotate(90)"/>
+</clipPath>
+</defs>
+</svg>

--- a/src/assets/icons/check.svg
+++ b/src/assets/icons/check.svg
@@ -1,0 +1,3 @@
+<svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M4 8.29412L7.46154 12L14 5" stroke="#00C73C" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/assets/icons/index.ts
+++ b/src/assets/icons/index.ts
@@ -1,9 +1,11 @@
+import ArrowDownIcon from './arrow-down.svg';
 import ArrowRightIcon from './arrow-right-circle.svg';
 import BackIcon from './back.svg';
 import BadIcon from './bad.svg';
 import BlockIcon from './block.svg';
 import BookmarkOffIcon from './bookmark_off.svg';
 import BookmarkOnIcon from './bookmark_on.svg';
+import CheckIcon from './check.svg';
 import CheckedOffIcon from './checkbox_off.svg';
 import CheckedOnIcon from './checkbox_on.svg';
 import CloseIcon from './close.svg';
@@ -47,11 +49,13 @@ import WriteDiaryIcon from './write_diary.svg';
 
 export {
   ArrowRightIcon,
+  ArrowDownIcon,
   BackIcon,
   BookmarkOffIcon,
   BookmarkOnIcon,
   CommentIcon,
   CloseIcon,
+  CheckIcon,
   CheckedOffIcon,
   CheckedOnIcon,
   DeleteIcon,

--- a/src/components/common/HighlightText.tsx
+++ b/src/components/common/HighlightText.tsx
@@ -1,0 +1,20 @@
+import styled from '@emotion/styled';
+
+interface HighlightTextProps {
+  text: string;
+  keyword: string;
+}
+
+export const HighlightText = ({ text, keyword }: HighlightTextProps) => {
+  const regExp = new RegExp(keyword, 'gi');
+  const replaceText = text.replace(regExp, `<mark>${keyword}</mark>`);
+
+  return <Text dangerouslySetInnerHTML={{ __html: replaceText }} />;
+};
+
+const Text = styled.span`
+  & mark {
+    color: ${({ theme }) => theme.colors.primary_00};
+    background-color: transparent;
+  }
+`;

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -5,6 +5,7 @@ export * from './ConfirmModal';
 export * from './IconButton';
 export * from './FloatingMenu';
 export * from './FloatingMenuButton';
+export * from './HighlightText';
 export * from './ResponsiveImage';
 export * from './Seo';
 export * from './Tab';

--- a/src/components/diary/ActivityDiariesContainer.tsx
+++ b/src/components/diary/ActivityDiariesContainer.tsx
@@ -24,7 +24,7 @@ export const ActivityDiariesContainer = ({
       <List>
         {diariesData.map((diary) => {
           const { id } = diary;
-          return <Diary key={`diary-list-${id}`} {...diary} />;
+          return <Diary key={`diary-list-${id}`} diaryData={diary} />;
         })}
       </List>
     </section>

--- a/src/components/diary/DiariesContainer.tsx
+++ b/src/components/diary/DiariesContainer.tsx
@@ -7,12 +7,14 @@ interface DiariesContainerProps {
   title: string;
   diariesData: Diaries[];
   empty: JSX.Element;
+  page?: 'main' | 'search';
 }
 
 export const DiariesContainer = ({
   title,
   diariesData,
   empty,
+  page = 'main',
 }: DiariesContainerProps) => {
   const { totalCount } = diariesData[0];
   const isEmptyDiaries = totalCount === 0;
@@ -22,6 +24,12 @@ export const DiariesContainer = ({
   return (
     <section>
       <Title>{title}</Title>
+      {page === 'search' && (
+        <SearchResultHeader>
+          <TotalCountText>{`총 ${totalCount}건`}</TotalCountText>
+          {/* TODO: 정렬 기능 추가 */}
+        </SearchResultHeader>
+      )}
       <List>
         {diariesData.map((data) => {
           const { diaries } = data;
@@ -37,6 +45,15 @@ export const DiariesContainer = ({
 
 const Title = styled.h2`
   ${ScreenReaderOnly}
+`;
+
+const SearchResultHeader = styled.div`
+  padding: 26px 20px 6px;
+`;
+
+const TotalCountText = styled.span`
+  color: ${({ theme }) => theme.colors.gray_02};
+  ${({ theme }) => theme.fonts.body_08}
 `;
 
 const List = styled.ul`

--- a/src/components/diary/DiariesContainer.tsx
+++ b/src/components/diary/DiariesContainer.tsx
@@ -7,6 +7,7 @@ interface DiariesContainerProps {
   title: string;
   diariesData: Diaries[];
   empty: JSX.Element;
+  header?: JSX.Element;
   page?: 'main' | 'search';
 }
 
@@ -14,6 +15,7 @@ export const DiariesContainer = ({
   title,
   diariesData,
   empty,
+  header,
   page = 'main',
 }: DiariesContainerProps) => {
   const { totalCount } = diariesData[0];
@@ -24,12 +26,7 @@ export const DiariesContainer = ({
   return (
     <section>
       <Title>{title}</Title>
-      {page === 'search' && (
-        <SearchResultHeader>
-          <TotalCountText>{`총 ${totalCount}건`}</TotalCountText>
-          {/* TODO: 정렬 기능 추가 */}
-        </SearchResultHeader>
-      )}
+      {page === 'search' && header}
       <List>
         {diariesData.map((data) => {
           const { diaries } = data;
@@ -45,15 +42,6 @@ export const DiariesContainer = ({
 
 const Title = styled.h2`
   ${ScreenReaderOnly}
-`;
-
-const SearchResultHeader = styled.div`
-  padding: 26px 20px 6px;
-`;
-
-const TotalCountText = styled.span`
-  color: ${({ theme }) => theme.colors.gray_02};
-  ${({ theme }) => theme.fonts.body_08}
 `;
 
 const List = styled.ul`

--- a/src/components/diary/DiariesContainer.tsx
+++ b/src/components/diary/DiariesContainer.tsx
@@ -8,7 +8,7 @@ interface DiariesContainerProps {
   diariesData: Diaries[];
   empty: JSX.Element;
   header?: JSX.Element;
-  page?: 'main' | 'search';
+  highlightKeyword?: string;
 }
 
 export const DiariesContainer = ({
@@ -16,7 +16,7 @@ export const DiariesContainer = ({
   diariesData,
   empty,
   header,
-  page = 'main',
+  highlightKeyword,
 }: DiariesContainerProps) => {
   const { totalCount } = diariesData[0];
   const isEmptyDiaries = totalCount === 0;
@@ -26,13 +26,21 @@ export const DiariesContainer = ({
   return (
     <section>
       <Title>{title}</Title>
-      {page === 'search' && header}
+
+      {header !== undefined && header}
+
       <List>
         {diariesData.map((data) => {
           const { diaries } = data;
           return diaries.map((diary) => {
             const { id } = diary;
-            return <Diary key={`diary-list-${id}`} {...diary} />;
+            return (
+              <Diary
+                key={`diary-list-${id}`}
+                diaryData={diary}
+                highlightKeyword={highlightKeyword}
+              />
+            );
           });
         })}
       </List>

--- a/src/components/diary/Diary.tsx
+++ b/src/components/diary/Diary.tsx
@@ -9,24 +9,34 @@ import {
   HeartOnIcon,
   HeartOffIcon,
 } from 'assets/icons';
-import { ResponsiveImage } from 'components/common';
+import { HighlightText, ResponsiveImage } from 'components/common';
 import { PAGE_PATH } from 'constants/common';
 import { useHandleFavorite, useHandleBookmark } from 'hooks/services/common';
 import { EllipsisStyle } from 'styles';
 import { dateFormat, timeFormat } from 'utils';
 
+interface DiaryProps {
+  diaryData: DiaryDetail;
+  highlightKeyword?: string;
+}
+
 const Diary = ({
-  id,
-  title,
-  content,
-  imgUrl,
-  commentCount,
-  favoriteCount,
-  isFavorite,
-  isBookmark,
-  createdAt,
-  author,
-}: DiaryDetail) => {
+  diaryData: {
+    id,
+    title,
+    content,
+    imgUrl,
+    commentCount,
+    favoriteCount,
+    isFavorite,
+    isBookmark,
+    createdAt,
+    author,
+  },
+  highlightKeyword,
+}: DiaryProps) => {
+  const isHighlightKeyword = highlightKeyword !== undefined;
+
   const handleFavorite = useHandleFavorite({ isFavorite, id });
   const handleBookmark = useHandleBookmark({
     isBookmark,
@@ -37,8 +47,20 @@ const Diary = ({
   return (
     <Container>
       <ContentContainer>
-        <Title>{title}</Title>
-        <ContentLink href={PAGE_PATH.diary.detail(id)}>{content}</ContentLink>
+        <Title>
+          {isHighlightKeyword ? (
+            <HighlightText text={title} keyword={highlightKeyword} />
+          ) : (
+            title
+          )}
+        </Title>
+        <ContentLink href={PAGE_PATH.diary.detail(id)}>
+          {isHighlightKeyword ? (
+            <HighlightText text={content} keyword={highlightKeyword} />
+          ) : (
+            content
+          )}
+        </ContentLink>
         {imgUrl !== null && (
           <ResponsiveImage src={imgUrl} alt={title} aspectRatio={2 / 1} />
         )}

--- a/src/components/search/RecentSearchContainer.tsx
+++ b/src/components/search/RecentSearchContainer.tsx
@@ -1,7 +1,11 @@
 import styled from '@emotion/styled';
+import { useRouter } from 'next/router';
+import { useFormContext } from 'react-hook-form';
 import { NoSearchResults } from './NoSearchResults';
+import type { SearchForm } from 'types/search';
 import { CloseIcon } from 'assets/icons';
-import { theme } from 'styles';
+import { PAGE_PATH } from 'constants/common';
+import { SVGVerticalAlignStyle, theme } from 'styles';
 
 interface RecentSearchContainerProps {
   recentSearchKeywords: string[];
@@ -15,6 +19,20 @@ export const RecentSearchContainer = ({
   onDeleteAllSearchKeyword,
 }: RecentSearchContainerProps) => {
   const isEmptyRecentSearches = recentSearchKeywords.length === 0;
+
+  const router = useRouter();
+
+  const { setValue } = useFormContext<SearchForm>();
+
+  const handleMoveSearchResult = (keyword: string) => async () => {
+    setValue('searchKeyword', keyword);
+
+    await router.push(PAGE_PATH.search.keyword(keyword));
+  };
+
+  const handleDeleteRecentSearch = (keyword: string) => () => {
+    onDeleteSearchKeyword(keyword);
+  };
 
   return (
     <Container>
@@ -32,21 +50,24 @@ export const RecentSearchContainer = ({
         <RecentSearchList>
           {recentSearchKeywords.map((recentSearchKeyword) => {
             return (
-              <li key={recentSearchKeyword}>
-                <RecentSearchButton
+              <RecentSearchItem key={recentSearchKeyword}>
+                <button
                   type="button"
-                  onClick={() => {
-                    onDeleteSearchKeyword(recentSearchKeyword);
-                  }}
+                  onClick={handleMoveSearchResult(recentSearchKeyword)}
                 >
                   {recentSearchKeyword}
+                </button>
+                <DeleteButton
+                  type="button"
+                  onClick={handleDeleteRecentSearch(recentSearchKeyword)}
+                >
                   <CloseIcon
                     width={16}
                     height={16}
                     stroke={theme.colors.gray_04}
                   />
-                </RecentSearchButton>
-              </li>
+                </DeleteButton>
+              </RecentSearchItem>
             );
           })}
         </RecentSearchList>
@@ -77,11 +98,12 @@ const DeleteAllButton = styled.button`
 const RecentSearchList = styled.ul`
   display: flex;
   flex-direction: column;
+  align-items: flex-start;
   gap: 10px;
   padding-top: 18px;
 `;
 
-const RecentSearchButton = styled.button`
+const RecentSearchItem = styled.li`
   display: flex;
   align-items: center;
   gap: 12px;
@@ -89,4 +111,8 @@ const RecentSearchButton = styled.button`
   border-radius: 100px;
   background-color: ${({ theme }) => theme.colors.bg_01};
   ${({ theme }) => theme.fonts.body_05}
+`;
+
+const DeleteButton = styled.button`
+  ${SVGVerticalAlignStyle}
 `;

--- a/src/components/search/SearchHeader.tsx
+++ b/src/components/search/SearchHeader.tsx
@@ -1,30 +1,54 @@
 import styled from '@emotion/styled';
-import Link from 'next/link';
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
 import { useFormContext } from 'react-hook-form';
 import type { SubmitHandler } from 'react-hook-form';
 import type { SearchForm } from 'types/search';
 import { DeleteIcon, SearchIcon } from 'assets/icons';
 import { PAGE_PATH } from 'constants/common';
+import { Z_INDEX } from 'constants/styles';
 import { SVGVerticalAlignStyle, theme } from 'styles';
 
 interface SearchHeaderProps {
-  onSaveSearchKeyword: (keywordValue: string) => void;
+  onSaveSearchKeyword: (keyword: string) => void;
 }
 
 export const SearchHeader = ({ onSaveSearchKeyword }: SearchHeaderProps) => {
-  const { register, watch, setValue, handleSubmit } =
+  const router = useRouter();
+  const {
+    query: { keyword },
+  } = router;
+
+  const { register, watch, setValue, setFocus, handleSubmit } =
     useFormContext<SearchForm>();
   const { searchKeyword: watchSearchKeyword } = watch();
 
   const handleDeleteSearchKeyword = () => {
     setValue('searchKeyword', '');
+    setFocus('searchKeyword');
   };
 
-  const onSubmit: SubmitHandler<SearchForm> = (data) => {
-    // TODO: 검색 기능 구현
-    const { searchKeyword } = data;
-    onSaveSearchKeyword(searchKeyword);
+  const handleCancel = () => {
+    if (keyword === undefined) {
+      void router.push(PAGE_PATH.main);
+
+      return;
+    }
+
+    void router.push(PAGE_PATH.search.index);
   };
+
+  const onSubmit: SubmitHandler<SearchForm> = async (data) => {
+    const { searchKeyword } = data;
+
+    onSaveSearchKeyword(searchKeyword);
+
+    await router.push(PAGE_PATH.search.keyword(searchKeyword));
+  };
+
+  useEffect(() => {
+    setValue('searchKeyword', keyword as string);
+  }, []);
 
   return (
     <HeaderLayout>
@@ -55,7 +79,9 @@ export const SearchHeader = ({ onSaveSearchKeyword }: SearchHeaderProps) => {
           <DeleteIcon />
         </DeleteButton>
       </SearchKeywordForm>
-      <CancelLink href={PAGE_PATH.main}>취소</CancelLink>
+      <CancelButton type="button" onClick={handleCancel}>
+        취소
+      </CancelButton>
     </HeaderLayout>
   );
 };
@@ -69,6 +95,7 @@ const HeaderLayout = styled.header`
   top: 0;
   right: 0;
   left: 0;
+  z-index: ${Z_INDEX.header};
   height: 54px;
   padding: 0 20px;
   border-bottom: 1px solid ${({ theme }) => theme.colors.gray_06};
@@ -111,6 +138,6 @@ const DeleteButton = styled.button<{ isVisible: boolean }>`
   ${SVGVerticalAlignStyle}
 `;
 
-const CancelLink = styled(Link)`
+const CancelButton = styled.button`
   ${({ theme }) => theme.fonts.body_05}
 `;

--- a/src/components/search/SearchResultHeader.tsx
+++ b/src/components/search/SearchResultHeader.tsx
@@ -8,6 +8,12 @@ interface SearchResultHeaderProps {
   totalCount: number;
 }
 
+interface SortOptions {
+  id: string;
+  title: string;
+  selected: boolean;
+}
+
 const initialSortOptions = [
   {
     id: 'latest',
@@ -22,7 +28,8 @@ const initialSortOptions = [
 ];
 
 export const SearchResultHeader = ({ totalCount }: SearchResultHeaderProps) => {
-  const [sortOptions, setSortOptions] = useState(initialSortOptions);
+  const [sortOptions, setSortOptions] =
+    useState<SortOptions[]>(initialSortOptions);
 
   const { ref, isVisible, setIsVisible } = useClickOutside();
 
@@ -31,13 +38,12 @@ export const SearchResultHeader = ({ totalCount }: SearchResultHeaderProps) => {
   };
 
   // TODO: 정렬 기능 추가
-  const handleSelectSortOption = (index: number) => () => {
+  const handleSelectSortOption = (selectedIndex: number) => () => {
     setSortOptions((prevState) => {
-      return prevState.map((state, stateIndex) =>
-        stateIndex === index
-          ? { ...state, selected: true }
-          : { ...state, selected: false },
-      );
+      return prevState.map((state, stateIndex) => ({
+        ...state,
+        selected: stateIndex === selectedIndex,
+      }));
     });
   };
 

--- a/src/components/search/SearchResultHeader.tsx
+++ b/src/components/search/SearchResultHeader.tsx
@@ -1,0 +1,110 @@
+import styled from '@emotion/styled';
+import { useState } from 'react';
+import { ArrowDownIcon, CheckIcon } from 'assets/icons';
+import { Popover } from 'components/common';
+import { useClickOutside } from 'hooks/common';
+
+interface SearchResultHeaderProps {
+  totalCount: number;
+}
+
+const initialSortOptions = [
+  {
+    id: 'latest',
+    title: '최신순',
+    selected: true,
+  },
+  {
+    id: 'comments',
+    title: '댓글순',
+    selected: false,
+  },
+];
+
+export const SearchResultHeader = ({ totalCount }: SearchResultHeaderProps) => {
+  const [sortOptions, setSortOptions] = useState(initialSortOptions);
+
+  const { ref, isVisible, setIsVisible } = useClickOutside();
+
+  const handleSortSearchResult = () => {
+    setIsVisible((state) => !state);
+  };
+
+  // TODO: 정렬 기능 추가
+  const handleSelectSortOption = (index: number) => () => {
+    setSortOptions((prevState) => {
+      return prevState.map((state, stateIndex) =>
+        stateIndex === index
+          ? { ...state, selected: true }
+          : { ...state, selected: false },
+      );
+    });
+  };
+
+  return (
+    <Container>
+      <TotalCountText>{`총 ${totalCount}건`}</TotalCountText>
+      <SortSearchResultButton
+        ref={ref}
+        type="button"
+        onClick={handleSortSearchResult}
+      >
+        {sortOptions.find((option) => option.selected)?.title}
+        <ArrowDownIcon />
+      </SortSearchResultButton>
+      {isVisible && (
+        <Popover right={20}>
+          <ul>
+            {sortOptions.map((option, index) => {
+              const { id, selected, title } = option;
+              return (
+                <li key={id}>
+                  <SortOptionButton
+                    type="button"
+                    selected={selected}
+                    onClick={handleSelectSortOption(index)}
+                  >
+                    {title}
+                    {selected && <CheckIcon />}
+                  </SortOptionButton>
+                </li>
+              );
+            })}
+          </ul>
+        </Popover>
+      )}
+    </Container>
+  );
+};
+
+const Container = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  position: relative;
+  padding: 26px 20px 6px;
+  color: ${({ theme }) => theme.colors.black};
+  ${({ theme }) => theme.fonts.body_08}
+`;
+
+const SortSearchResultButton = styled.button`
+  display: flex;
+  align-items: center;
+  gap: 6px;
+`;
+
+const SortOptionButton = styled.button<{ selected: boolean }>`
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 140px;
+  padding: 13px 16px;
+  color: ${({ theme, selected }) =>
+    selected ? theme.colors.primary_00 : theme.colors.gray_01};
+  ${({ theme }) => theme.fonts.button_01}
+  text-align: left;
+`;
+
+const TotalCountText = styled.span`
+  color: ${({ theme }) => theme.colors.gray_02};
+`;

--- a/src/components/search/index.ts
+++ b/src/components/search/index.ts
@@ -1,3 +1,4 @@
 export * from './SearchHeader';
 export * from './NoSearchResults';
 export * from './RecentSearchContainer';
+export * from './SearchResultHeader';

--- a/src/constants/common/page.ts
+++ b/src/constants/common/page.ts
@@ -30,4 +30,9 @@ export const PAGE_PATH = {
   setting: {
     index: '/setting',
   },
+
+  search: {
+    index: '/search',
+    keyword: (keyword: string) => `/search/${keyword}`,
+  },
 } as const;

--- a/src/hooks/services/queries/useDiaries.ts
+++ b/src/hooks/services/queries/useDiaries.ts
@@ -2,12 +2,15 @@ import { useInfiniteQuery } from '@tanstack/react-query';
 import * as api from 'api';
 import { queryKeys } from 'constants/services';
 
-export const useDiaries = () => {
+export const useDiaries = (searchKeyword?: string) => {
   const { data, isFetching, isFetchingNextPage, isError, fetchNextPage } =
     useInfiniteQuery({
-      queryKey: [queryKeys.diaries],
+      queryKey: [queryKeys.diaries, searchKeyword],
       queryFn: async ({ pageParam = 1 }) =>
-        await api.getDiaries({ currentPage: pageParam as number }),
+        await api.getDiaries({
+          currentPage: pageParam as number,
+          searchKeyword,
+        }),
       getNextPageParam: (lastPage) => lastPage.nextPage,
     });
 

--- a/src/pages/search/[keyword].tsx
+++ b/src/pages/search/[keyword].tsx
@@ -47,7 +47,7 @@ const SearchResultPage: NextPage<
 
   return (
     <>
-      <Seo title={'검색 | a daily diary'} />
+      <Seo title={`${searchKeyword} 검색 결과 | a daily diary`} />
       <Section>
         <FormProvider {...methods}>
           <SearchHeader onSaveSearchKeyword={handleSaveSearchKeyword} />

--- a/src/pages/search/[keyword].tsx
+++ b/src/pages/search/[keyword].tsx
@@ -69,7 +69,7 @@ const SearchResultPage: NextPage<
                     totalCount={diariesData[0].totalCount ?? 0}
                   />
                 }
-                page="search"
+                highlightKeyword={searchKeyword}
               />
               <ObserverTarget
                 targetRef={setTargetRef}

--- a/src/pages/search/[keyword].tsx
+++ b/src/pages/search/[keyword].tsx
@@ -63,6 +63,7 @@ const SearchResultPage: NextPage<
                 title={`${searchKeyword} 검색 결과`}
                 diariesData={diariesData}
                 empty={<NoSearchResults description="검색 결과가 없습니다." />}
+                page="search"
               />
               <ObserverTarget
                 targetRef={setTargetRef}

--- a/src/pages/search/[keyword].tsx
+++ b/src/pages/search/[keyword].tsx
@@ -34,9 +34,8 @@ const SearchResultPage: NextPage<
     handleDeleteAllSearchKeyword,
   } = useSearchKeywordStorage();
 
-  const { diariesData, isLoading, isError, fetchNextPage } = useDiaries(
-    keyword as string,
-  );
+  const { diariesData, isLoading, isError, fetchNextPage } =
+    useDiaries(keyword);
   const { setTargetRef } = useIntersectionObserver({
     onIntersect: fetchNextPage,
   });
@@ -83,8 +82,7 @@ const SearchResultPage: NextPage<
     </>
   );
 };
-
-export const getServerSideProps: GetServerSideProps = (async (context) => {
+export const getServerSideProps = (async (context) => {
   const { req, res, params } = context;
   const keyword = params?.keyword as string;
 
@@ -99,7 +97,7 @@ export const getServerSideProps: GetServerSideProps = (async (context) => {
     };
   }
 
-  return { props: { session, keyword } };
+  return { props: { keyword } };
 }) satisfies GetServerSideProps;
 
 export default SearchResultPage;

--- a/src/pages/search/[keyword].tsx
+++ b/src/pages/search/[keyword].tsx
@@ -47,7 +47,7 @@ const SearchResultPage: NextPage<
 
   return (
     <>
-      <Seo title={`${searchKeyword} 검색 결과 | a daily diary`} />
+      <Seo title={`${keyword} 검색 결과 | a daily diary`} />
       <Section>
         <FormProvider {...methods}>
           <SearchHeader onSaveSearchKeyword={handleSaveSearchKeyword} />
@@ -60,7 +60,7 @@ const SearchResultPage: NextPage<
           ) : (
             <>
               <DiariesContainer
-                title={`${searchKeyword} 검색 결과`}
+                title={`${keyword} 검색 결과`}
                 diariesData={diariesData}
                 empty={<NoSearchResults description="검색 결과가 없습니다." />}
                 header={
@@ -68,7 +68,7 @@ const SearchResultPage: NextPage<
                     totalCount={diariesData[0].totalCount ?? 0}
                   />
                 }
-                highlightKeyword={searchKeyword}
+                highlightKeyword={keyword}
               />
               <ObserverTarget
                 targetRef={setTargetRef}

--- a/src/pages/search/[keyword].tsx
+++ b/src/pages/search/[keyword].tsx
@@ -1,0 +1,110 @@
+import styled from '@emotion/styled';
+import { getServerSession } from 'next-auth';
+import { FormProvider, useForm } from 'react-hook-form';
+import type {
+  GetServerSideProps,
+  InferGetServerSidePropsType,
+  NextPage,
+} from 'next';
+import type { SearchForm } from 'types/search';
+import { FullPageLoading, ObserverTarget, Seo } from 'components/common';
+import { DiariesContainer } from 'components/diary';
+import {
+  NoSearchResults,
+  RecentSearchContainer,
+  SearchHeader,
+} from 'components/search';
+import { PAGE_PATH } from 'constants/common';
+import { useIntersectionObserver, useSearchKeywordStorage } from 'hooks/common';
+import { useDiaries } from 'hooks/services';
+import { authOptions } from 'pages/api/auth/[...nextauth]';
+
+const SearchResultPage: NextPage<
+  InferGetServerSidePropsType<typeof getServerSideProps>
+> = ({ keyword }) => {
+  const methods = useForm<SearchForm>({ mode: 'onChange' });
+  const { watch } = methods;
+  const { searchKeyword } = watch();
+
+  const {
+    keywords,
+    handleSaveSearchKeyword,
+    handleDeleteSearchKeyword,
+    handleDeleteAllSearchKeyword,
+  } = useSearchKeywordStorage();
+
+  const { diariesData, isLoading, isError, fetchNextPage } = useDiaries(
+    keyword as string,
+  );
+  const { setTargetRef } = useIntersectionObserver({
+    onIntersect: fetchNextPage,
+  });
+
+  const isShowRecentSearchResult =
+    searchKeyword === undefined || searchKeyword.length === 0;
+
+  if (diariesData === undefined) return <FullPageLoading />;
+
+  return (
+    <>
+      <Seo title={'검색 | a daily diary'} />
+      <Section>
+        <FormProvider {...methods}>
+          <SearchHeader onSaveSearchKeyword={handleSaveSearchKeyword} />
+          {isShowRecentSearchResult ? (
+            <RecentSearchContainer
+              recentSearchKeywords={keywords}
+              onDeleteSearchKeyword={handleDeleteSearchKeyword}
+              onDeleteAllSearchKeyword={handleDeleteAllSearchKeyword}
+            />
+          ) : (
+            <>
+              <DiariesContainer
+                title={`${searchKeyword} 검색 결과`}
+                diariesData={diariesData}
+                empty={<NoSearchResults description="검색 결과가 없습니다." />}
+              />
+              <ObserverTarget
+                targetRef={setTargetRef}
+                isLoading={isLoading}
+                isError={isError}
+              />
+            </>
+          )}
+        </FormProvider>
+      </Section>
+    </>
+  );
+};
+
+export const getServerSideProps: GetServerSideProps = (async (context) => {
+  const { req, res, params } = context;
+  const keyword = params?.keyword as string;
+
+  const session = await getServerSession(req, res, authOptions);
+
+  if (session === null) {
+    return {
+      redirect: {
+        destination: PAGE_PATH.account.login,
+        permanent: false,
+      },
+    };
+  }
+
+  return { props: { session, keyword } };
+}) satisfies GetServerSideProps;
+
+export default SearchResultPage;
+
+const Section = styled.section`
+  overflow-y: auto;
+  height: 100vh;
+  scrollbar-width: none;
+
+  -ms-overflow-style: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+`;

--- a/src/pages/search/[keyword].tsx
+++ b/src/pages/search/[keyword].tsx
@@ -13,6 +13,7 @@ import {
   NoSearchResults,
   RecentSearchContainer,
   SearchHeader,
+  SearchResultHeader,
 } from 'components/search';
 import { PAGE_PATH } from 'constants/common';
 import { useIntersectionObserver, useSearchKeywordStorage } from 'hooks/common';
@@ -63,6 +64,11 @@ const SearchResultPage: NextPage<
                 title={`${searchKeyword} 검색 결과`}
                 diariesData={diariesData}
                 empty={<NoSearchResults description="검색 결과가 없습니다." />}
+                header={
+                  <SearchResultHeader
+                    totalCount={diariesData[0].totalCount ?? 0}
+                  />
+                }
                 page="search"
               />
               <ObserverTarget

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -1,15 +1,16 @@
 import styled from '@emotion/styled';
+import { getServerSession } from 'next-auth';
 import { FormProvider, useForm } from 'react-hook-form';
-import type { NextPage } from 'next';
+import type { GetServerSideProps, NextPage } from 'next';
 import type { SearchForm } from 'types/search';
 import { Seo } from 'components/common';
 import { RecentSearchContainer, SearchHeader } from 'components/search';
+import { PAGE_PATH } from 'constants/common';
 import { useSearchKeywordStorage } from 'hooks/common';
+import { authOptions } from 'pages/api/auth/[...nextauth]';
 
 const SearchPage: NextPage = () => {
   const methods = useForm<SearchForm>({ mode: 'onChange' });
-  const { watch } = methods;
-  const { searchKeyword } = watch();
 
   const {
     keywords,
@@ -18,34 +19,44 @@ const SearchPage: NextPage = () => {
     handleDeleteAllSearchKeyword,
   } = useSearchKeywordStorage();
 
-  const isShowRecentSearchResult =
-    searchKeyword === undefined || searchKeyword.length === 0;
-
   return (
     <>
       <Seo title={'검색 | a daily diary'} />
       <Section>
         <FormProvider {...methods}>
           <SearchHeader onSaveSearchKeyword={handleSaveSearchKeyword} />
-          {isShowRecentSearchResult ? (
-            <RecentSearchContainer
-              recentSearchKeywords={keywords}
-              onDeleteSearchKeyword={handleDeleteSearchKeyword}
-              onDeleteAllSearchKeyword={handleDeleteAllSearchKeyword}
-            />
-          ) : (
-            <div>검색결과</div>
-          )}
+          <RecentSearchContainer
+            recentSearchKeywords={keywords}
+            onDeleteSearchKeyword={handleDeleteSearchKeyword}
+            onDeleteAllSearchKeyword={handleDeleteAllSearchKeyword}
+          />
         </FormProvider>
       </Section>
     </>
   );
 };
 
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const { req, res } = context;
+  const session = await getServerSession(req, res, authOptions);
+
+  if (session === null) {
+    return {
+      redirect: {
+        destination: PAGE_PATH.account.login,
+        permanent: false,
+      },
+    };
+  }
+
+  return { props: { session } };
+};
+
 export default SearchPage;
 
 const Section = styled.section`
   overflow-y: auto;
+  height: 100vh;
   scrollbar-width: none;
 
   -ms-overflow-style: none;

--- a/src/types/diary.ts
+++ b/src/types/diary.ts
@@ -32,6 +32,7 @@ export type DiaryForm = Pick<
 
 export interface GetDiariesRequest {
   currentPage: number;
+  searchKeyword?: string;
 }
 
 export interface GetDiariesByUsernameRequest extends GetDiariesRequest {


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #226 

<br />

## 🗒 작업 목록

- [x] 일기 조회 API에 검색어(searchKeyword)를 prams에 추가하여 검색어에 따른 일기를 조회할 수 있도록 적용
  - 타입, API, 커스텀 훅 수정
- [x] PAGE_PATH에 search 관련 path 추가
- [x] 검색 결과 페이지 구현
- [x] 총 검색된 일기 갯수 및 검색 결과 정렬 선택 UI 적용
- [x] 최근 검색어 클릭 시 검색 결과 페이지로 이동 기능 구현 및 최근 검색어 삭제 기능과 분리
- [x] 검색 결과 페이지 내 검색어와 일치하는 텍스트에 하이라이트 UI 적용
  - 제목, 글에만 적용, 대소문자 무관 

<br />

## 🧐 PR Point

- 기존에 사용하는 일기 조회 API에 searchKeyword를 prams으로 추가하여 검색에 따른 일기를 조회 할 수 있도록 적용했습니다.
- 검색 페이지에 진입하면 최근 검색어가 나타나고 검색창에 검색어를 입력하면 검색 결과 페이지로 이동하여 검색 결과를 노출했습니다.
- 검색 결과 페이지에서 검색창에 입력된 검색어가 없을 경우 최근 검색어를 노출합니다.
- 최근 검색어 텍스트를 클릭할 경우, 해당 검색어의 검색 결과 페이지로 이동합니다.
- 검색 결과 페이지에서 검색어와 일치하는 텍스트에 하이라이트 UI가 나타납니다.

#### 요청 사항

<img width="334" alt="image" src="https://github.com/a-daily-diary/ADD.FE/assets/85009583/52f89281-fb46-4b71-8a2a-c520a1f0d455">

- 검색 결과 정렬이 현재는 최신순으로 고정되어 있습니다.
- 정렬 기준에 따라 서버에서 정렬한 값을 받을 수 있으면 좋을 것 같습니다.
- 인기순에 대한 명확한 기준이 정해지지 않은 것으로 알고 있는데, 이에 대한 논의가 필요합니다. 

#### 추가 전달 사항
- 스크롤 위치 최상단으로 이동
  - 검색 결과 페이지에서 일기 상세로 이동 후 다시 해당 검색 결과 페이지로 돌아올 경우
  - 검색어 입력 시 리렌더링이 발생하면서 스크롤 최상단으로 이동 
  - 프로필 - 일기 탭/북마크 탭에서 일기 상세로 이동 후 뒤로가기 시 프로필 활동 탭으로 이동하면서 스크롤 최상단으로 이동
  ⇒ (내용 추가)프로필 페이지를 활동/일기/북마크 별로 페이지 분리하면 스트롤 문제 해결 가능해보입니다.
  - 홈 - 일기 목록의 경우 next.config.js에 속성을 추가하여 스크롤 복원할 수 있으나, 위의 세 가지의 경우 리렌더링이 발생하면서 스크롤 위치가 최상단으로 이동하여 사용자에게 좋지 못한 경험을 줄 것으로 예상이 됩니다.

<br />

## 💥 Trouble Shooting
#### `searchKeyword`를 `prams`로 전달하여 API를 호출하였으나 브라우저 화면을 이탈했다가 다시 포커스 하는 등의 트리거가 있어야 API 호출 후 화면이 갱신되는 문제
- 정상적으로 API 호출하였으나 캐시된 데이터가 보여지고, 갱신이 되지 않았던 문제입니다.
- useDiaries 커스텀 훅의 쿼리 키에 searchKeyword를 추가하여 검색어에 따라 캐시 무효화를 할 수 있도록 하여 해결했습니다.

```typescript
export const useDiaries = (searchKeyword?: string) => {
  const { data, isFetching, isFetchingNextPage, isError, fetchNextPage } =
    useInfiniteQuery({
      queryKey: [queryKeys.diaries, searchKeyword], // 기존 [queryKeys.diaries]만 있던 쿼리 키에 searchKeyword를 추가함
      queryFn: ...,
      ...
    });

  ...
};
```

<br />

## 📸 스크린샷 / 피그마 링크

https://github.com/a-daily-diary/ADD.FE/assets/85009583/cf8a5470-7444-4217-a25a-005d74adec56

#### 검색 결과 정렬 선택 UI
<img width="373" alt="image" src="https://github.com/a-daily-diary/ADD.FE/assets/85009583/fed101f9-134f-41eb-8333-d2276b0cb9a3">

#### 검색어 하이라이트 UI
<img width="373" alt="image" src="https://github.com/a-daily-diary/ADD.FE/assets/85009583/4fc97431-1630-4f18-b439-728356a46e05">


<br />

## 📚 참고

- 참고한 내용 또는 링크를 입력해주세요.

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다. 
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
