### PR TITLE
HeaderTitle 가운데 정렬 타입 추가

### DIFF
--- a/src/components/layouts/header/HeaderTitle.tsx
+++ b/src/components/layouts/header/HeaderTitle.tsx
@@ -2,8 +2,8 @@ import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
 interface HeaderTitleStyleProps {
-  position?: 'left';
-  fontWeight?: 700;
+  position?: 'left' | 'center';
+  fontWeight?: 500 | 700;
 }
 interface HeaderTitleProps extends HeaderTitleStyleProps {
   title: string;
@@ -12,7 +12,7 @@ interface HeaderTitleProps extends HeaderTitleStyleProps {
 export const HeaderTitle = ({
   title,
   position,
-  fontWeight,
+  fontWeight = 500,
 }: HeaderTitleProps) => {
   return (
     <TitleText position={position} fontWeight={fontWeight}>
@@ -28,6 +28,14 @@ const TitleText = styled.strong<HeaderTitleStyleProps>`
       margin-right: auto;
       padding-left: 4px;
     `};
+  ${({ position }) =>
+    position === 'center' &&
+    css`
+      position: absolute;
+      left: 50%;
+      transform: translateX(-50%);
+    `};
+
   ${({ theme }) => theme.fonts.body_02};
-  ${({ fontWeight }) => fontWeight === 700 && 'font-weight: 700'};
+  font-weight: ${({ fontWeight }) => fontWeight};
 `;

--- a/src/pages/account/findPassword.tsx
+++ b/src/pages/account/findPassword.tsx
@@ -13,7 +13,7 @@ const FindPassword: NextPage = () => {
       <Seo title={'비밀번호 찾기 | a daily diary'} />
       <Header
         left={<HeaderLeft type="이전" />}
-        title={<HeaderTitle title={'비밀번호 찾기'} position={'left'} />}
+        title={<HeaderTitle title="비밀번호 찾기" position="left" />}
       />
       <ContentWrapper>
         {isSubmitted ? (

--- a/src/pages/account/register.tsx
+++ b/src/pages/account/register.tsx
@@ -99,7 +99,7 @@ const Register: NextPage = () => {
       <Seo title={'회원가입 | a daily diary'} />
       <Header
         left={<HeaderLeft type="이전" />}
-        title={<HeaderTitle title={'회원가입'} position={'left'} />}
+        title={<HeaderTitle title="회원가입" position="left" />}
       />
       {!registerStep.welcomeMessage && (
         <FormProvider {...methods}>

--- a/src/pages/diary/[id]/edit.tsx
+++ b/src/pages/diary/[id]/edit.tsx
@@ -161,7 +161,13 @@ const EditDiary: NextPage = () => {
                 }}
               />
             }
-            title={<HeaderTitle title={createdAtDate} fontWeight={700} />}
+            title={
+              <HeaderTitle
+                title={createdAtDate}
+                fontWeight={700}
+                position="center"
+              />
+            }
             right={<HeaderRight type="수정" disabled={!isValid} />}
           />
           <FormHeader>

--- a/src/pages/diary/index.tsx
+++ b/src/pages/diary/index.tsx
@@ -115,7 +115,9 @@ const WriteDiary: NextPage = () => {
                 }}
               />
             }
-            title={<HeaderTitle title={today} fontWeight={700} />}
+            title={
+              <HeaderTitle title={today} fontWeight={700} position="center" />
+            }
             right={<HeaderRight type="등록" disabled={!isValid} />}
           />
           <FormHeader>

--- a/src/pages/matching/index.tsx
+++ b/src/pages/matching/index.tsx
@@ -21,8 +21,7 @@ const MatchingRule: NextPage = () => {
         <Title>랜덤 매칭 규칙</Title>
         <Header
           left={<HeaderLeft type="이전" />} // FIXME: 이전 버튼에 대해 클릭 이벤트 함수 props로 받을 수 있도록 셋팅
-          title={<HeaderTitle title="랜덤 매칭" />}
-          right={<div />}
+          title={<HeaderTitle title="랜덤 매칭" position="center" />}
         />
         <Article>
           <h2>


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #228 

<br />

## 🗒 작업 목록

- [x] HeaderTitle position center 스타일 추가

<br />

## 🧐 PR Point

- `HeaderTitle`에 `position` center 스타일 추가하여 가운데 정렬을 위해 불필요하게 `Header` 컴포넌트의 `right` prop에 불필요한 빈 태그를 넣지 않도록 했습니다.

<br />

## 💥 Trouble Shooting
- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크

<img width="375" alt="image" src="https://github.com/a-daily-diary/ADD.FE/assets/85009583/b1d7d5de-5b2d-49c9-87d6-c8afe39b9903">

<br />

## 📚 참고

- 참고한 내용 또는 링크를 입력해주세요.

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다. 
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
