### PR TITLE
프로필 수정 페이지 >  배지 목록 구현 및 pinned 배지 수정 기능

### DIFF
--- a/src/api/badges.ts
+++ b/src/api/badges.ts
@@ -1,4 +1,9 @@
-import type { Badge, GetBadgesByUsernameRequest } from 'types/badges';
+import type {
+  Badge,
+  GetBadgesByUsernameRequest,
+  PatchPinnedBadgeByBadgeIdRequest,
+  UserToBadge,
+} from 'types/badges';
 import type { SuccessResponse } from 'types/response';
 import { API_PATH } from 'constants/services';
 import axios from 'lib/axios';
@@ -18,6 +23,17 @@ export const getBadgesByUsername = async ({
         onlyPinned,
       },
     },
+  );
+  return data;
+};
+
+export const patchPinnedBadgeByBadgeId = async ({
+  id,
+}: PatchPinnedBadgeByBadgeIdRequest) => {
+  const {
+    data: { data },
+  } = await axios.patch<SuccessResponse<UserToBadge>>(
+    `${API_PATH.badges.index}/${id}`,
   );
   return data;
 };

--- a/src/assets/icons/checkbox-circle_off.svg
+++ b/src/assets/icons/checkbox-circle_off.svg
@@ -1,0 +1,4 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="10" cy="10" r="10" fill="#DDDDDD"/>
+<path d="M5 9.72727L8.17647 13L14 7" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/assets/icons/checkbox-circle_on.svg
+++ b/src/assets/icons/checkbox-circle_on.svg
@@ -1,0 +1,4 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="10" cy="10" r="10" fill="#00C73C"/>
+<path d="M5 9.72727L8.17647 13L14 7" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/assets/icons/index.ts
+++ b/src/assets/icons/index.ts
@@ -6,6 +6,8 @@ import BlockIcon from './block.svg';
 import BookmarkOffIcon from './bookmark_off.svg';
 import BookmarkOnIcon from './bookmark_on.svg';
 import CheckIcon from './check.svg';
+import CircleCheckedOffIcon from './checkbox-circle_off.svg';
+import CircleCheckedOnIcon from './checkbox-circle_on.svg';
 import CheckedOffIcon from './checkbox_off.svg';
 import CheckedOnIcon from './checkbox_on.svg';
 import CloseIcon from './close.svg';
@@ -58,6 +60,8 @@ export {
   CheckIcon,
   CheckedOffIcon,
   CheckedOnIcon,
+  CircleCheckedOffIcon,
+  CircleCheckedOnIcon,
   DeleteIcon,
   EditIcon,
   HideIcon,

--- a/src/components/badge/BadgeContainer.tsx
+++ b/src/components/badge/BadgeContainer.tsx
@@ -1,0 +1,96 @@
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+import Image from 'next/image';
+import { useSession } from 'next-auth/react';
+import { CircleCheckedOffIcon, CircleCheckedOnIcon } from 'assets/icons';
+import { useBadges } from 'hooks/services';
+import { SVGVerticalAlignStyle } from 'styles';
+
+export const BadgeContainer = () => {
+  const { data: session } = useSession();
+  const { badgesData } = useBadges({
+    username: session?.user.username as string,
+  });
+
+  return (
+    <Section>
+      <Title>배지 목록</Title>
+      <Description>공개할 뱃지를 선택해주세요.(최대 8개)</Description>
+      <BadgeList>
+        {badgesData?.map((badge) => {
+          const { id, imgUrl, description, name, userToBadge } = badge;
+
+          return (
+            <li key={id}>
+              <BadgeButton type="button">
+                <BadgeImageContainer>
+                  <Image
+                    src={imgUrl}
+                    alt={description}
+                    width={80}
+                    height={80}
+                    priority
+                  />
+                  {userToBadge?.isPinned === true ? (
+                    <CheckedOnIcon />
+                  ) : (
+                    <CheckedOffIcon />
+                  )}
+                </BadgeImageContainer>
+                <span>{name}</span>
+              </BadgeButton>
+            </li>
+          );
+        })}
+      </BadgeList>
+    </Section>
+  );
+};
+
+const Section = styled.section`
+  padding: 28px 20px;
+`;
+
+const Title = styled.h2`
+  color: ${({ theme }) => theme.colors.gray_00};
+  ${({ theme }) => theme.fonts.headline_02}
+`;
+
+const Description = styled.p`
+  color: ${({ theme }) => theme.colors.gray_02};
+  ${({ theme }) => theme.fonts.body_04}
+`;
+
+const BadgeList = styled.ul`
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 28px 34px;
+  margin-top: 24px;
+`;
+
+const BadgeButton = styled.button`
+  display: grid;
+  grid-template-rows: 80px;
+  place-items: center;
+  gap: 10px;
+  ${({ theme }) => theme.fonts.body_08};
+`;
+
+const BadgeImageContainer = styled.div`
+  position: relative;
+  ${SVGVerticalAlignStyle}
+`;
+
+const StyledIcon = css`
+  position: absolute;
+  right: 0;
+  bottom: 0;
+`;
+
+const CheckedOnIcon = styled(CircleCheckedOnIcon)`
+  ${StyledIcon}
+`;
+
+const CheckedOffIcon = styled(CircleCheckedOffIcon)`
+  ${StyledIcon}
+`;

--- a/src/components/badge/BadgeContainer.tsx
+++ b/src/components/badge/BadgeContainer.tsx
@@ -1,16 +1,32 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
+import { isAxiosError } from 'axios';
 import Image from 'next/image';
 import { useSession } from 'next-auth/react';
+import type { ErrorResponse } from 'types/response';
 import { CircleCheckedOffIcon, CircleCheckedOnIcon } from 'assets/icons';
-import { useBadges } from 'hooks/services';
+import { useBadges, useChangePinnedBadge } from 'hooks/services';
+
 import { SVGVerticalAlignStyle } from 'styles';
+import { errorResponseMessage } from 'utils';
 
 export const BadgeContainer = () => {
   const { data: session } = useSession();
+
   const { badgesData } = useBadges({
     username: session?.user.username as string,
   });
+  const changePinnedBadgeMutation = useChangePinnedBadge();
+
+  const handleChangePinned = (id: string) => () => {
+    try {
+      changePinnedBadgeMutation(id);
+    } catch (error) {
+      if (isAxiosError<ErrorResponse>(error)) {
+        alert(errorResponseMessage(error.response?.data.message));
+      }
+    }
+  };
 
   return (
     <Section>
@@ -19,10 +35,10 @@ export const BadgeContainer = () => {
       <BadgeList>
         {badgesData?.map((badge) => {
           const { id, imgUrl, description, name, userToBadge } = badge;
-
+          // TODO: 획득 전 배지 UI
           return (
             <li key={id}>
-              <BadgeButton type="button">
+              <BadgeButton type="button" onClick={handleChangePinned(id)}>
                 <BadgeImageContainer>
                   <Image
                     src={imgUrl}
@@ -31,10 +47,14 @@ export const BadgeContainer = () => {
                     height={80}
                     priority
                   />
-                  {userToBadge?.isPinned === true ? (
-                    <CheckedOnIcon />
-                  ) : (
-                    <CheckedOffIcon />
+                  {userToBadge !== null && (
+                    <>
+                      {userToBadge.isPinned ? (
+                        <CheckedOnIcon />
+                      ) : (
+                        <CheckedOffIcon />
+                      )}
+                    </>
                   )}
                 </BadgeImageContainer>
                 <span>{name}</span>

--- a/src/components/badge/BadgeContainer.tsx
+++ b/src/components/badge/BadgeContainer.tsx
@@ -23,6 +23,7 @@ export const BadgeContainer = () => {
       changePinnedBadgeMutation(id);
     } catch (error) {
       if (isAxiosError<ErrorResponse>(error)) {
+        // TODO: 에러 처리 필요
         alert(errorResponseMessage(error.response?.data.message));
       }
     }
@@ -34,7 +35,7 @@ export const BadgeContainer = () => {
       <Description>공개할 뱃지를 선택해주세요.(최대 8개)</Description>
       <BadgeList>
         {badgesData?.map((badge) => {
-          const { id, imgUrl, description, name, userToBadge } = badge;
+          const { id, imgUrl, description, name, userToBadge, hasOwn } = badge;
           // TODO: 획득 전 배지 UI
           return (
             <li key={id}>
@@ -47,7 +48,7 @@ export const BadgeContainer = () => {
                     height={80}
                     priority
                   />
-                  {userToBadge !== null && (
+                  {hasOwn && userToBadge !== null && (
                     <>
                       {userToBadge.isPinned ? (
                         <CheckedOnIcon />

--- a/src/components/badge/BadgesContainer.tsx
+++ b/src/components/badge/BadgesContainer.tsx
@@ -5,6 +5,7 @@ import Image from 'next/image';
 import { useSession } from 'next-auth/react';
 import type { ErrorResponse } from 'types/response';
 import { CircleCheckedOffIcon, CircleCheckedOnIcon } from 'assets/icons';
+import { FullPageLoading } from 'components/common';
 import { useBadges, useChangePinnedBadge } from 'hooks/services';
 
 import { SVGVerticalAlignStyle } from 'styles';
@@ -29,12 +30,14 @@ export const BadgesContainer = () => {
     }
   };
 
+  if (badgesData === undefined) return <FullPageLoading />;
+
   return (
     <Section>
       <Title>배지 목록</Title>
       <Description>공개할 뱃지를 선택해주세요.(최대 8개)</Description>
       <BadgeList>
-        {badgesData?.map((badge) => {
+        {badgesData.map((badge) => {
           const { id, imgUrl, description, name, userToBadge, hasOwn } = badge;
           // TODO: 획득 전 배지 UI
           return (

--- a/src/components/badge/BadgesContainer.tsx
+++ b/src/components/badge/BadgesContainer.tsx
@@ -10,7 +10,7 @@ import { useBadges, useChangePinnedBadge } from 'hooks/services';
 import { SVGVerticalAlignStyle } from 'styles';
 import { errorResponseMessage } from 'utils';
 
-export const BadgeContainer = () => {
+export const BadgesContainer = () => {
   const { data: session } = useSession();
 
   const { badgesData } = useBadges({

--- a/src/components/badge/BadgesContainer.tsx
+++ b/src/components/badge/BadgesContainer.tsx
@@ -19,7 +19,7 @@ export const BadgesContainer = () => {
   });
   const changePinnedBadgeMutation = useChangePinnedBadge();
 
-  const handleChangePinned = (id: string) => () => {
+  const handleChangePinned = (id: string) => {
     try {
       changePinnedBadgeMutation(id);
     } catch (error) {
@@ -42,7 +42,12 @@ export const BadgesContainer = () => {
           // TODO: 획득 전 배지 UI
           return (
             <li key={id}>
-              <BadgeButton type="button" onClick={handleChangePinned(id)}>
+              <BadgeButton
+                type="button"
+                onClick={() => {
+                  handleChangePinned(id);
+                }}
+              >
                 <BadgeImageContainer>
                   <Image
                     src={imgUrl}

--- a/src/components/badge/index.ts
+++ b/src/components/badge/index.ts
@@ -1,1 +1,2 @@
 export * from './BadgeDetailButton';
+export * from './BadgeContainer';

--- a/src/components/badge/index.ts
+++ b/src/components/badge/index.ts
@@ -1,2 +1,2 @@
 export * from './BadgeDetailButton';
-export * from './BadgeContainer';
+export * from './BadgesContainer';

--- a/src/hooks/services/mutations/index.ts
+++ b/src/hooks/services/mutations/index.ts
@@ -1,4 +1,5 @@
 export * from './useBookmarkDiary';
+export * from './useChangePinnedBadge';
 export * from './useCancelBookmarkDiary';
 export * from './useCancelFavoriteDiary';
 export * from './useDeleteComment';

--- a/src/hooks/services/mutations/useChangePinnedBadge.ts
+++ b/src/hooks/services/mutations/useChangePinnedBadge.ts
@@ -1,0 +1,18 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import * as api from 'api';
+import { queryKeys } from 'constants/services';
+
+export const useChangePinnedBadge = () => {
+  const queryClient = useQueryClient();
+  const { mutate } = useMutation(
+    async (badgeId: string) =>
+      await api.patchPinnedBadgeByBadgeId({ id: badgeId }),
+    {
+      onSuccess: async () => {
+        await queryClient.invalidateQueries([queryKeys.badges]);
+      },
+    },
+  );
+
+  return mutate;
+};

--- a/src/pages/profile/edit.tsx
+++ b/src/pages/profile/edit.tsx
@@ -17,7 +17,7 @@ import type {
 } from 'types/response';
 import * as api from 'api';
 
-import { BadgeContainer } from 'components/badge';
+import { BadgesContainer } from 'components/badge';
 import { Seo } from 'components/common';
 import { FormInput } from 'components/form';
 import {
@@ -194,7 +194,7 @@ const ProfileEditPage: NextPage = () => {
           </FormInputContainer>
         </Form>
 
-        <BadgeContainer />
+        <BadgesContainer />
       </Section>
     </>
   );

--- a/src/pages/profile/edit.tsx
+++ b/src/pages/profile/edit.tsx
@@ -1,5 +1,7 @@
 import styled from '@emotion/styled';
+import { QueryClient, dehydrate } from '@tanstack/react-query';
 import { isAxiosError } from 'axios';
+
 import { useRouter } from 'next/router';
 import { getServerSession } from 'next-auth';
 import { useSession } from 'next-auth/react';
@@ -14,6 +16,8 @@ import type {
   SuccessResponse,
 } from 'types/response';
 import * as api from 'api';
+
+import { BadgeContainer } from 'components/badge';
 import { Seo } from 'components/common';
 import { FormInput } from 'components/form';
 import {
@@ -24,6 +28,7 @@ import {
 } from 'components/layouts';
 import { NoLinkProfileImage, SelectProfileImage } from 'components/profile';
 import { PAGE_PATH } from 'constants/common';
+import { queryKeys } from 'constants/services';
 import {
   ERROR_MESSAGE,
   INVALID_VALUE,
@@ -188,6 +193,8 @@ const ProfileEditPage: NextPage = () => {
             />
           </FormInputContainer>
         </Form>
+
+        <BadgeContainer />
       </Section>
     </>
   );
@@ -206,14 +213,25 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     };
   }
 
-  return { props: { session } };
+  const { username, accessToken } = session.user;
+
+  const headers = {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  };
+
+  const queryClient = new QueryClient();
+  await queryClient.prefetchQuery([queryKeys.badges, username], async () => {
+    return await api.getBadgesByUsername({ username, config: headers });
+  });
+  return { props: { dehydratedState: dehydrate(queryClient), session } };
 };
 
 export default ProfileEditPage;
 
 const Section = styled.section`
   margin-top: 54px;
-  min-height: calc(100vh - 54px);
 `;
 
 const Title = styled.h1`
@@ -222,6 +240,7 @@ const Title = styled.h1`
 
 const Form = styled.form`
   padding: 28px 20px;
+  border-bottom: 12px solid ${({ theme }) => theme.colors.gray_06};
 `;
 
 const FormInputContainer = styled.div`

--- a/src/types/badges.ts
+++ b/src/types/badges.ts
@@ -22,3 +22,5 @@ export interface GetBadgesByUsernameRequest {
   onlyPinned?: boolean;
   config?: AxiosRequestConfig;
 }
+
+export type PatchPinnedBadgeByBadgeIdRequest = Pick<Badge, 'id'>;


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #237 

<br />

## 🗒 작업 목록

- [x] 배지 목록 UI 구현
- [x] pinned 된 배지 수정 api 추가 및 커스텀 훅 생성
- [x] pinned 된 배지 수정 기능 구현

<br />

## 🧐 PR Point

- 프로필 수정 페이지에서 배지 목록을 보여주고, pinned 된 배지를 수정할 수 있는 기능을 구현했습니다.
- 해당 기능은 username, profile 이미지를 수정하는 것과 별개로 동작합니다.

#### 전달 사항
- 프로필 이미지 수정하는 부분이 피그마와 다르게 구현되어 있습니다.
  - 추후 피그마와 동일하게 수정할 예정입니다.
- 배지 획득 전 UI는 디자인이 나오면 구현할 예정입니다.
  - 현재는 획득한 상태의 UI와 동일하게 구현되어 있습니다.

<br />

## 💥 Trouble Shooting
- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크

> 프로필 이미지 수정 부분이 피그마와 다른 점 양해 부탁드립니다.

https://github.com/a-daily-diary/ADD.FE/assets/85009583/f8323ac5-a46b-47bd-a927-5aaabd5fafbf

<br />

## 📚 참고

- 참고한 내용 또는 링크를 입력해주세요.

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다. 
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
