### PR TITLE
로그인 > 비밀번호 재설정 API 연동

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -80,6 +80,12 @@
         ],
         "alphabetize": { "order": "asc" }
       }
+    ],
+    "@typescript-eslint/strict-boolean-expressions": [
+      "error",
+      {
+        "allowNullableString": true
+      }
     ]
   },
   "settings": {

--- a/src/api/users.ts
+++ b/src/api/users.ts
@@ -1,5 +1,8 @@
 import type { LoginRequest, LoginResponse } from 'types/login';
-import type { PasswordResetLinkRequest } from 'types/password';
+import type {
+  PasswordResetLinkRequest,
+  PasswordResetRequest,
+} from 'types/password';
 import type { ExistsRequest, RegisterRequest } from 'types/register';
 import type { OnlyMessageResponse, SuccessResponse } from 'types/response';
 import { API_PATH } from 'constants/services';
@@ -57,4 +60,16 @@ export const passwordResetLink = async ({
     API_PATH.users.passwordResetLink,
     { email, redirectUrl },
   );
+};
+
+export const resetPassword = async ({
+  email,
+  tempToken,
+  password,
+}: PasswordResetRequest) => {
+  return await axios.put(API_PATH.users.password, {
+    email,
+    tempToken,
+    password,
+  });
 };

--- a/src/api/users.ts
+++ b/src/api/users.ts
@@ -69,11 +69,14 @@ export const resetPassword = async ({
   tempToken,
   password,
 }: PasswordResetRequest) => {
-  return await axios.put(API_PATH.users.password, {
-    email,
-    tempToken,
-    password,
-  });
+  return await axios.put<SuccessResponse<OnlyMessageResponse>>(
+    API_PATH.users.password,
+    {
+      email,
+      tempToken,
+      password,
+    },
+  );
 };
 
 export const tempTokenValidation = async ({

--- a/src/api/users.ts
+++ b/src/api/users.ts
@@ -2,6 +2,8 @@ import type { LoginRequest, LoginResponse } from 'types/login';
 import type {
   PasswordResetLinkRequest,
   PasswordResetRequest,
+  TempTokenValidationRequest,
+  TempTokenValidationResponse,
 } from 'types/password';
 import type { ExistsRequest, RegisterRequest } from 'types/register';
 import type { OnlyMessageResponse, SuccessResponse } from 'types/response';
@@ -72,4 +74,17 @@ export const resetPassword = async ({
     tempToken,
     password,
   });
+};
+
+export const tempTokenValidation = async ({
+  email,
+  tempToken,
+}: TempTokenValidationRequest) => {
+  return await axios.post<SuccessResponse<TempTokenValidationResponse>>(
+    API_PATH.users.tempTokenValidation,
+    {
+      email,
+      tempToken,
+    },
+  );
 };

--- a/src/components/account/FindPasswordForm.tsx
+++ b/src/components/account/FindPasswordForm.tsx
@@ -5,7 +5,7 @@ import type { Dispatch, SetStateAction } from 'react';
 import type { SubmitHandler } from 'react-hook-form';
 import type { PasswordFindForm } from 'types/password';
 import type { ErrorResponse } from 'types/response';
-import { passwordResetLink } from 'api';
+import * as api from 'api';
 import { Button } from 'components/common';
 import { FormInput } from 'components/form';
 import { ERROR_MESSAGE, VALID_VALUE } from 'constants/validation';
@@ -25,7 +25,7 @@ export const FindPasswordForm = ({ setIsSubmitted }: FindPasswordFormProps) => {
   const onSubmit: SubmitHandler<PasswordFindForm> = async (data) => {
     try {
       const { email } = data;
-      await passwordResetLink({
+      await api.passwordResetLink({
         email,
         redirectUrl: `${window.location.origin}/account/resetPassword`,
       });

--- a/src/components/account/ResetPasswordForm.tsx
+++ b/src/components/account/ResetPasswordForm.tsx
@@ -5,7 +5,7 @@ import { useForm } from 'react-hook-form';
 import type { SubmitHandler } from 'react-hook-form';
 import type { PasswordResetForm } from 'types/password';
 import type { ErrorResponse } from 'types/response';
-import { resetPassword } from 'api';
+import * as api from 'api';
 import { Button } from 'components/common';
 import { FormInput } from 'components/form';
 import { PAGE_PATH } from 'constants/common';
@@ -31,7 +31,7 @@ export const ResetPasswordForm = ({ email, token }: ResetPasswordFormProps) => {
   const onSubmit: SubmitHandler<PasswordResetForm> = async (data) => {
     try {
       const { password } = data;
-      await resetPassword({ email, tempToken: token, password });
+      await api.resetPassword({ email, tempToken: token, password });
       await router.replace(PAGE_PATH.account.login);
     } catch (error) {
       if (isAxiosError<ErrorResponse>(error)) {

--- a/src/components/account/ResetPasswordForm.tsx
+++ b/src/components/account/ResetPasswordForm.tsx
@@ -11,7 +11,12 @@ import {
   VALID_VALUE,
 } from 'constants/validation';
 
-export const ResetPasswordForm = () => {
+interface ResetPasswordFormProps {
+  email: string;
+  token: string;
+}
+
+export const ResetPasswordForm = ({ email, token }: ResetPasswordFormProps) => {
   const {
     register,
     getValues,

--- a/src/components/account/ResetPasswordForm.tsx
+++ b/src/components/account/ResetPasswordForm.tsx
@@ -1,7 +1,11 @@
 import styled from '@emotion/styled';
+import { isAxiosError } from 'axios';
 import router from 'next/router';
 import { useForm } from 'react-hook-form';
+import type { SubmitHandler } from 'react-hook-form';
 import type { PasswordResetForm } from 'types/password';
+import type { ErrorResponse } from 'types/response';
+import { resetPassword } from 'api';
 import { Button } from 'components/common';
 import { FormInput } from 'components/form';
 import { PAGE_PATH } from 'constants/common';
@@ -24,12 +28,20 @@ export const ResetPasswordForm = ({ email, token }: ResetPasswordFormProps) => {
     formState: { isValid, errors, isSubmitting },
   } = useForm<PasswordResetForm>({ mode: 'onChange' });
 
-  const onSubmit = async () => {
-    /**
-     * @todo
-     * 비밀번호 재설정 API 요청
-     */
-    await router.replace(PAGE_PATH.account.login);
+  const onSubmit: SubmitHandler<PasswordResetForm> = async (data) => {
+    try {
+      const { password } = data;
+      await resetPassword({ email, tempToken: token, password });
+      await router.replace(PAGE_PATH.account.login);
+    } catch (error) {
+      if (isAxiosError<ErrorResponse>(error)) {
+        /**
+         * @todo
+         * 에러 처리
+         */
+        console.log(error.response?.status);
+      }
+    }
   };
 
   return (

--- a/src/constants/services/path.ts
+++ b/src/constants/services/path.ts
@@ -7,6 +7,7 @@ export const API_PATH = {
     register: '/users/register',
     login: '/users/login',
     passwordResetLink: '/users/password-reset-link',
+    password: '/users/password',
   },
   diaries: {
     index: '/diaries',

--- a/src/constants/services/path.ts
+++ b/src/constants/services/path.ts
@@ -8,6 +8,7 @@ export const API_PATH = {
     login: '/users/login',
     passwordResetLink: '/users/password-reset-link',
     password: '/users/password',
+    tempTokenValidation: '/users/temp-token-validation',
   },
   diaries: {
     index: '/diaries',

--- a/src/pages/account/resetPassword.tsx
+++ b/src/pages/account/resetPassword.tsx
@@ -4,20 +4,17 @@ import * as api from 'api';
 import { ResetPasswordForm } from 'components/account';
 import { Seo } from 'components/common';
 import { PAGE_PATH } from 'constants/common';
-import { getQueryParam } from 'utils';
+import { getQueryParams } from 'utils';
 
-interface PageProps {
+interface ResetPasswordPageProps {
   email: string;
   token: string;
 }
 
-const ResetPassword: NextPage<PageProps> = ({
+const ResetPassword: NextPage<ResetPasswordPageProps> = ({
   email,
   token,
-}: {
-  email: string;
-  token: string;
-}) => {
+}: ResetPasswordPageProps) => {
   return (
     <>
       <Seo title={'비밀번호 재성정 | a daily diary'} />
@@ -30,8 +27,8 @@ const ResetPassword: NextPage<PageProps> = ({
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const { query } = context;
-  const email = getQueryParam(query.email);
-  const token = getQueryParam(query.token);
+  const [email] = getQueryParams(query.email);
+  const [token] = getQueryParams(query.token);
 
   const REDIRECT_LOGIN_PAGE_PROPS = {
     redirect: {
@@ -40,19 +37,19 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     },
   };
 
-  if (email.length === 0 || token.length === 0) {
+  if (!email || !token) {
     return REDIRECT_LOGIN_PAGE_PROPS;
-  } else {
-    try {
-      await api.tempTokenValidation({
-        email: email[0],
-        tempToken: token[0],
-      });
+  }
 
-      return { props: { email: email[0], token: token[0] } };
-    } catch (error) {
-      return REDIRECT_LOGIN_PAGE_PROPS;
-    }
+  try {
+    await api.tempTokenValidation({
+      email,
+      tempToken: token,
+    });
+
+    return { props: { email, token } };
+  } catch (error) {
+    return REDIRECT_LOGIN_PAGE_PROPS;
   }
 };
 

--- a/src/pages/account/resetPassword.tsx
+++ b/src/pages/account/resetPassword.tsx
@@ -1,17 +1,49 @@
 import styled from '@emotion/styled';
-import type { NextPage } from 'next/types';
+import type { GetServerSideProps, NextPage } from 'next/types';
 import { ResetPasswordForm } from 'components/account';
 import { Seo } from 'components/common';
+import { PAGE_PATH } from 'constants/common';
 
-const ResetPassword: NextPage = () => {
+interface PageProps {
+  email: string;
+  token: string;
+}
+
+const ResetPassword: NextPage<PageProps> = ({
+  email,
+  token,
+}: {
+  email: string;
+  token: string;
+}) => {
   return (
     <>
       <Seo title={'비밀번호 재성정 | a daily diary'} />
       <ContentWrapper>
-        <ResetPasswordForm />
+        <ResetPasswordForm email={email} token={token} />
       </ContentWrapper>
     </>
   );
+};
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const { query } = context;
+  const { email, token } = query as { email: string; token: string };
+
+  /**
+   * @todo
+   * 이메일과 토큰이 매칭되는 지 검증
+   */
+  if (email === '' || token === '') {
+    return {
+      redirect: {
+        destination: PAGE_PATH.account.login,
+        permanent: false,
+      },
+    };
+  }
+
+  return { props: { email, token } };
 };
 
 export default ResetPassword;

--- a/src/pages/account/resetPassword.tsx
+++ b/src/pages/account/resetPassword.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import type { GetServerSideProps, NextPage } from 'next/types';
+import * as api from 'api';
 import { ResetPasswordForm } from 'components/account';
 import { Seo } from 'components/common';
 import { PAGE_PATH } from 'constants/common';
@@ -32,20 +33,27 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
   const email = getQueryParam(query.email);
   const token = getQueryParam(query.token);
 
-  /**
-   * @todo
-   * 이메일과 토큰이 매칭되는 지 검증
-   */
-  if (email.length === 0 || token.length === 0) {
-    return {
-      redirect: {
-        destination: PAGE_PATH.account.login,
-        permanent: false,
-      },
-    };
-  }
+  const REDIRECT_LOGIN_PAGE_PROPS = {
+    redirect: {
+      destination: PAGE_PATH.account.login,
+      permanent: false,
+    },
+  };
 
-  return { props: { email: email[0], token: token[0] } };
+  if (email.length === 0 || token.length === 0) {
+    return REDIRECT_LOGIN_PAGE_PROPS;
+  } else {
+    try {
+      await api.tempTokenValidation({
+        email: email[0],
+        tempToken: token[0],
+      });
+
+      return { props: { email: email[0], token: token[0] } };
+    } catch (error) {
+      return REDIRECT_LOGIN_PAGE_PROPS;
+    }
+  }
 };
 
 export default ResetPassword;

--- a/src/pages/account/resetPassword.tsx
+++ b/src/pages/account/resetPassword.tsx
@@ -3,6 +3,7 @@ import type { GetServerSideProps, NextPage } from 'next/types';
 import { ResetPasswordForm } from 'components/account';
 import { Seo } from 'components/common';
 import { PAGE_PATH } from 'constants/common';
+import { getQueryParam } from 'utils';
 
 interface PageProps {
   email: string;
@@ -28,13 +29,14 @@ const ResetPassword: NextPage<PageProps> = ({
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const { query } = context;
-  const { email, token } = query as { email: string; token: string };
+  const email = getQueryParam(query.email);
+  const token = getQueryParam(query.token);
 
   /**
    * @todo
    * 이메일과 토큰이 매칭되는 지 검증
    */
-  if (email === '' || token === '') {
+  if (email.length === 0 || token.length === 0) {
     return {
       redirect: {
         destination: PAGE_PATH.account.login,
@@ -43,7 +45,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     };
   }
 
-  return { props: { email, token } };
+  return { props: { email: email[0], token: token[0] } };
 };
 
 export default ResetPassword;

--- a/src/pages/account/resetPassword.tsx
+++ b/src/pages/account/resetPassword.tsx
@@ -1,20 +1,18 @@
 import styled from '@emotion/styled';
-import type { GetServerSideProps, NextPage } from 'next/types';
+import type {
+  GetServerSideProps,
+  InferGetServerSidePropsType,
+  NextPage,
+} from 'next/types';
 import * as api from 'api';
 import { ResetPasswordForm } from 'components/account';
 import { Seo } from 'components/common';
 import { PAGE_PATH } from 'constants/common';
 import { getQueryParams } from 'utils';
 
-interface ResetPasswordPageProps {
-  email: string;
-  token: string;
-}
-
-const ResetPassword: NextPage<ResetPasswordPageProps> = ({
-  email,
-  token,
-}: ResetPasswordPageProps) => {
+const ResetPassword: NextPage<
+  InferGetServerSidePropsType<typeof getServerSideProps>
+> = ({ email, token }) => {
   return (
     <>
       <Seo title={'비밀번호 재성정 | a daily diary'} />
@@ -25,7 +23,7 @@ const ResetPassword: NextPage<ResetPasswordPageProps> = ({
   );
 };
 
-export const getServerSideProps: GetServerSideProps = async (context) => {
+export const getServerSideProps = (async (context) => {
   const { query } = context;
   const [email] = getQueryParams(query.email);
   const [token] = getQueryParams(query.token);
@@ -51,7 +49,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
   } catch (error) {
     return REDIRECT_LOGIN_PAGE_PROPS;
   }
-};
+}) satisfies GetServerSideProps;
 
 export default ResetPassword;
 

--- a/src/types/password.ts
+++ b/src/types/password.ts
@@ -12,6 +12,18 @@ export interface PasswordResetRequest {
   password: string;
 }
 
+export interface TempTokenValidationRequest {
+  email: string;
+  tempToken: string;
+}
+
+/**
+ * Response
+ */
+export interface TempTokenValidationResponse {
+  isValidate: boolean;
+}
+
 /**
  * Others
  */

--- a/src/types/password.ts
+++ b/src/types/password.ts
@@ -6,6 +6,12 @@ export interface PasswordResetLinkRequest {
   redirectUrl: string;
 }
 
+export interface PasswordResetRequest {
+  email: string;
+  tempToken: string;
+  password: string;
+}
+
 /**
  * Others
  */

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,5 @@
 export * from './date';
 export * from './ErrorResponseMessage';
 export * from './Formatter';
+export * from './query';
 export { default as textareaAutosize } from './TextareaAutosize';

--- a/src/utils/query.ts
+++ b/src/utils/query.ts
@@ -1,0 +1,11 @@
+export const getQueryParam = (
+  param: string | string[] | undefined,
+): string[] => {
+  if (Array.isArray(param)) {
+    return param;
+  }
+  if (param === undefined || param === '') {
+    return [];
+  }
+  return [param];
+};

--- a/src/utils/query.ts
+++ b/src/utils/query.ts
@@ -1,14 +1,16 @@
 /**
  * 쿼리 파라미터를 받아 항상 문자열 배열로 반환합니다.
  */
-export const getQueryParam = (
+export const getQueryParams = (
   param: string | string[] | undefined,
 ): string[] => {
   if (Array.isArray(param)) {
     return param;
   }
+
   if (param === undefined || param === '') {
     return [];
   }
+
   return [param];
 };

--- a/src/utils/query.ts
+++ b/src/utils/query.ts
@@ -1,3 +1,6 @@
+/**
+ * 쿼리 파라미터를 받아 항상 문자열 배열로 반환합니다.
+ */
 export const getQueryParam = (
   param: string | string[] | undefined,
 ): string[] => {


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #234 

<br />

## 🗒 작업 목록

- [x] 로그인 > 비밀번호 재설정 API 연동
- [x] 비밀번호 재설정 페이지 입장 전 query param으로 전달된 email과 token의 매칭 체크 

<br />

## 🧐 PR Point

- 비밀번호 재설정 api 연동 하였습니다.
- 비밀번호 재설정 페이지는 전송 받은 메일에 명시된 url을 통해 접근할 수 있습니다. 
url 에는 변경을 원하는 계정의 email 과 인증을 위한 token이 query param으로 명시됩니다.  
![스크린샷 2024-05-05 오후 9 24 37](https://github.com/a-daily-diary/ADD.FE/assets/23066745/e48109e4-d362-4ea2-882b-6d037ed387ac)
따라서 이메일과 토큰이 매칭되지 않으면 비밀번호 페이지에 입장할 수 없도록 `getServerSideProps()` 에서 email과 token의 유효성을 검사하였습니다. 유효하면 비밀번호 재설정 페이지로 이동하고 유효하지 않으면 로그인 페이지로 이동합니다.

---
query.ts util 추가
-  next.js 에서는 query 타입으로 	`string | string[] | undefined` 를 모두 허용합니다. 하지만 ADD 에서는 대게의 경우 단일 param을 사용하여 `string`으로 타입 캐스팅(ex. `as string`)하는 경우가 빈번한 것 같다고 생각했습니다. 따라서 query param의 타입 변동성에 대해 일관된 방식으로 데이터를 처리할 수 있도록 util 함수를 만들었습니다. 해당 util 함수는 항상 `string[]` 을 반환합니다.  
- 입력 값이 배열(`string[]`)인 경우, 입력받은 그대로의 배열을 반환합니다.
- 입력 값이 `string`인 경우, 해당 문자열을 원소로 가지는 배열을 반환합니다. 
- 입력 값이 `undefined` 또는 빈 문자열(`''`)인 경우, 빈 배열([])을 반환합니다.

<br />

## 💥 Trouble Shooting


<br />

## 📸 스크린샷 / 피그마 링크

유효한 이메일&토큰 일 경우 | 유효하지 않은 이메일 & 토큰일 경우
-- | --
![May-05-2024 21-34-29](https://github.com/a-daily-diary/ADD.FE/assets/23066745/0c1a0e30-ce9e-46de-bed8-a0dc1082b878) | ![May-05-2024 21-57-50](https://github.com/a-daily-diary/ADD.FE/assets/23066745/618d7ece-6edb-4205-a297-59daa13cb70d)

<br />

## 📚 참고

- 참고한 내용 또는 링크를 입력해주세요.

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다. 
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
