### PR TITLE
활동 탭 > 지난 활동 내역 중 활동/일기작성 내역이 없는 경우 UI 수정

### DIFF
--- a/src/components/diary/EmptyActivitiesDiary.tsx
+++ b/src/components/diary/EmptyActivitiesDiary.tsx
@@ -5,10 +5,12 @@ import { PAGE_PATH } from 'constants/common';
 
 interface EmptyActivitiesDiaryProps {
   isVisibleGoToWriteButton: boolean;
+  isMyProfile: boolean;
 }
 
 export const EmptyActivitiesDiary = ({
   isVisibleGoToWriteButton,
+  isMyProfile,
 }: EmptyActivitiesDiaryProps) => {
   const router = useRouter();
 
@@ -20,10 +22,10 @@ export const EmptyActivitiesDiary = ({
     <EmptyContainer>
       <EmptyTextContainer>
         <p>일기가 없습니다.</p>
-        <p>오늘 일기를 작성해보세요.</p>
+        {isMyProfile && <p>오늘 일기를 작성해보세요.</p>}
       </EmptyTextContainer>
 
-      {isVisibleGoToWriteButton && (
+      {isMyProfile && isVisibleGoToWriteButton && (
         <Button
           text="일기 작성하러 가기"
           size="sm"

--- a/src/components/diary/EmptyActivitiesDiary.tsx
+++ b/src/components/diary/EmptyActivitiesDiary.tsx
@@ -3,7 +3,13 @@ import { useRouter } from 'next/router';
 import { Button } from 'components/common';
 import { PAGE_PATH } from 'constants/common';
 
-export const EmptyActivitiesDiary = () => {
+interface EmptyActivitiesDiaryProps {
+  isVisibleGoToWriteButton: boolean;
+}
+
+export const EmptyActivitiesDiary = ({
+  isVisibleGoToWriteButton,
+}: EmptyActivitiesDiaryProps) => {
   const router = useRouter();
 
   const handleGoToWriteDiary = () => {
@@ -16,11 +22,14 @@ export const EmptyActivitiesDiary = () => {
         <p>일기가 없습니다.</p>
         <p>오늘 일기를 작성해보세요.</p>
       </EmptyTextContainer>
-      <Button
-        text="일기 작성하러 가기"
-        size="sm"
-        onClick={handleGoToWriteDiary}
-      />
+
+      {isVisibleGoToWriteButton && (
+        <Button
+          text="일기 작성하러 가기"
+          size="sm"
+          onClick={handleGoToWriteDiary}
+        />
+      )}
     </EmptyContainer>
   );
 };

--- a/src/components/profile/ActivityDetail.tsx
+++ b/src/components/profile/ActivityDetail.tsx
@@ -3,7 +3,9 @@ import { Loading } from 'components/common';
 import { ActivityDiariesContainer } from 'components/diary';
 import { EmptyActivitiesDiary } from 'components/diary/EmptyActivitiesDiary';
 import { useActivityDetail } from 'hooks/services/queries';
-import { dateWithDayFormat } from 'utils';
+import { dateStringFormat, dateWithDayFormat } from 'utils';
+
+const today = new Date();
 
 interface ActivityDetailProps {
   dateString: string;
@@ -20,11 +22,15 @@ export const ActivityDetail = ({
   });
 
   if (activityDetailData === undefined) return <Loading />;
-
   const {
     date: activityDetailDate,
     activities: { commentCount, diaryCount, randomMatchingCount, diaries },
   } = activityDetailData;
+
+  const todayDateString = dateStringFormat(today.toDateString());
+  const activityDetailDateString = dateStringFormat(activityDetailDate);
+
+  const isVisibleGoToWriteButton = activityDetailDateString === todayDateString;
 
   return (
     <>
@@ -50,7 +56,11 @@ export const ActivityDetail = ({
       <ActivityDiariesContainer
         title={`${dateString} 작성한 일기`}
         diariesData={diaries}
-        empty={<EmptyActivitiesDiary />}
+        empty={
+          <EmptyActivitiesDiary
+            isVisibleGoToWriteButton={isVisibleGoToWriteButton}
+          />
+        }
       />
     </>
   );

--- a/src/components/profile/ActivityDetail.tsx
+++ b/src/components/profile/ActivityDetail.tsx
@@ -37,7 +37,7 @@ export const ActivityDetail = ({
 
   const isToday = activityDetailDateString === todayDateString;
   const isMyProfile = session?.user.username === username;
-  const hanActivities = activityCount > 0;
+  const hasActivities = activityCount > 0;
 
   return (
     <>
@@ -63,8 +63,8 @@ export const ActivityDetail = ({
         title={`${dateString} 작성한 일기`}
         diariesData={diaries}
         empty={
-          !isToday && !hanActivities ? (
-            <NoActivitiesTest>활동 내역이 없습니다</NoActivitiesTest>
+          !isToday && !hasActivities ? (
+            <NoActivitiesText>활동 내역이 없습니다</NoActivitiesText>
           ) : (
             <EmptyActivitiesDiary
               isVisibleGoToWriteButton={isToday}
@@ -98,7 +98,7 @@ const Count = styled.strong`
   font-weight: 700;
 `;
 
-const NoActivitiesTest = styled.p`
+const NoActivitiesText = styled.p`
   padding: 50px;
   text-align: center;
   color: ${({ theme }) => theme.colors.gray_02};

--- a/src/components/profile/ActivityDetail.tsx
+++ b/src/components/profile/ActivityDetail.tsx
@@ -29,13 +29,15 @@ export const ActivityDetail = ({
   const {
     date: activityDetailDate,
     activities: { commentCount, diaryCount, randomMatchingCount, diaries },
+    activityCount,
   } = activityDetailData;
 
   const todayDateString = dateStringFormat(today.toDateString());
   const activityDetailDateString = dateStringFormat(activityDetailDate);
 
-  const isVisibleGoToWriteButton = activityDetailDateString === todayDateString;
+  const isToday = activityDetailDateString === todayDateString;
   const isMyProfile = session?.user.username === username;
+  const hanActivities = activityCount > 0;
 
   return (
     <>
@@ -61,10 +63,14 @@ export const ActivityDetail = ({
         title={`${dateString} 작성한 일기`}
         diariesData={diaries}
         empty={
-          <EmptyActivitiesDiary
-            isVisibleGoToWriteButton={isVisibleGoToWriteButton}
-            isMyProfile={isMyProfile}
-          />
+          !isToday && !hanActivities ? (
+            <NoActivitiesTest>활동 내역이 없습니다</NoActivitiesTest>
+          ) : (
+            <EmptyActivitiesDiary
+              isVisibleGoToWriteButton={isToday}
+              isMyProfile={isMyProfile}
+            />
+          )
         }
       />
     </>
@@ -90,4 +96,11 @@ const CountList = styled.ul`
 
 const Count = styled.strong`
   font-weight: 700;
+`;
+
+const NoActivitiesTest = styled.p`
+  padding: 50px;
+  text-align: center;
+  color: ${({ theme }) => theme.colors.gray_02};
+  ${({ theme }) => theme.fonts.body_08};
 `;

--- a/src/components/profile/ActivityDetail.tsx
+++ b/src/components/profile/ActivityDetail.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import { useSession } from 'next-auth/react';
 import { Loading } from 'components/common';
 import { ActivityDiariesContainer } from 'components/diary';
 import { EmptyActivitiesDiary } from 'components/diary/EmptyActivitiesDiary';
@@ -16,12 +17,15 @@ export const ActivityDetail = ({
   dateString,
   username,
 }: ActivityDetailProps) => {
+  const { data: session } = useSession();
+
   const { activityDetailData } = useActivityDetail({
     username,
     dateString,
   });
 
   if (activityDetailData === undefined) return <Loading />;
+
   const {
     date: activityDetailDate,
     activities: { commentCount, diaryCount, randomMatchingCount, diaries },
@@ -31,6 +35,7 @@ export const ActivityDetail = ({
   const activityDetailDateString = dateStringFormat(activityDetailDate);
 
   const isVisibleGoToWriteButton = activityDetailDateString === todayDateString;
+  const isMyProfile = session?.user.username === username;
 
   return (
     <>
@@ -52,13 +57,13 @@ export const ActivityDetail = ({
         </CountList>
       </DetailHeader>
 
-      {/* TODO: 날짜별, 사용자별 UI 수정 필요 */}
       <ActivityDiariesContainer
         title={`${dateString} 작성한 일기`}
         diariesData={diaries}
         empty={
           <EmptyActivitiesDiary
             isVisibleGoToWriteButton={isVisibleGoToWriteButton}
+            isMyProfile={isMyProfile}
           />
         }
       />


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #243 

<br />

## 🗒 작업 목록

- [x] 활동 상세 영역 > 오늘 날짜에만 일기 작성하러 가기 버튼 노출
- [x] 다른 사용자 프로필 > 활동 상세 영역 일부 텍스트, button 비노출
- [x] activityCount에 따른 UI 적용

<br />

## 🧐 PR Point

- 활동 상세 영역의 activityCount, 날짜, 내 프로필/다른 사용자 프로필에 따라라 노출되는 UI가 달라지도록 했습니다.

<br />

## 💥 Trouble Shooting
- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크

- 내용을 입력해주세요.

#### 내 프로필 > 작성한 일기가 없는 경우
| 오늘 | 지난 날 | 지난날, activityCount가 0인 경우 |
|:-----------------------------:|:-----------------------------:|:-----------------------------:|
|<img width="403" alt="image" src="https://github.com/a-daily-diary/ADD.FE/assets/85009583/0ae67fb0-9803-41d5-b13d-30ae684c49ed">|<img width="403" alt="image" src="https://github.com/a-daily-diary/ADD.FE/assets/85009583/134786e9-f453-4852-88f3-93de7f07780b">|<img width="403" alt="image" src="https://github.com/a-daily-diary/ADD.FE/assets/85009583/ebcf1db7-5570-4e6d-a6f9-e3f8b7c4b5e8">|

#### 다른 사용자 프로필 > 작성한 일기가 없는 경우
- 날짜에 상관없이 동일한 텍스트를 노출합니다.

| 오늘 | 지난 날 | 지난날, activityCount가 0인 경우 |
|:-----------------------------:|:-----------------------------:|:-----------------------------:|
|<img width="403" alt="image" src="https://github.com/a-daily-diary/ADD.FE/assets/85009583/19a92b76-d7b8-4d29-b610-190016e06627">|<img width="403" alt="image" src="https://github.com/a-daily-diary/ADD.FE/assets/85009583/a4ec4fe2-bebc-46f6-b881-615138824937">|<img width="403" alt="image" src="https://github.com/a-daily-diary/ADD.FE/assets/85009583/c9e4148d-184b-4c7e-9f9c-7b731997a978">|




<br />

## 📚 참고

- 참고한 내용 또는 링크를 입력해주세요.

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다. 
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
