### PR TITLE
프로필 페이지 수정 사항

### DIFF
--- a/src/components/profile/ProfileLayout.tsx
+++ b/src/components/profile/ProfileLayout.tsx
@@ -15,7 +15,9 @@ export const ProfileLayout = ({
 }: ProfileLayoutProps) => {
   return (
     <>
-      <Seo title={`${isMyProfile ? username : ''} 프로필 | a daily diary`} />
+      <Seo
+        title={`${isMyProfile ? '' : `${username} `}프로필 | a daily diary`}
+      />
       <ProfileContainer username={username} isMyProfile={isMyProfile} />
 
       <ProfileTab username={isMyProfile ? undefined : username} />

--- a/src/hooks/services/queries/useBadges.ts
+++ b/src/hooks/services/queries/useBadges.ts
@@ -8,7 +8,7 @@ export const useBadges = ({
   onlyPinned,
 }: GetBadgesByUsernameRequest) => {
   const { data: badgesData, isLoading } = useQuery(
-    [queryKeys.badges, username],
+    [queryKeys.badges, username, onlyPinned],
     async () => await api.getBadgesByUsername({ username, onlyPinned }),
   );
   return { badgesData, isLoading };

--- a/src/pages/profile/[username]/index.tsx
+++ b/src/pages/profile/[username]/index.tsx
@@ -57,7 +57,11 @@ export const getServerSideProps = (async (context) => {
       return await api.getProfileByUsername({ username, config: headers });
     });
     await queryClient.fetchQuery([queryKeys.badges, username], async () => {
-      return await api.getBadgesByUsername({ username, config: headers });
+      return await api.getBadgesByUsername({
+        username,
+        onlyPinned: true,
+        config: headers,
+      });
     });
   } catch (error) {
     if (isAxiosError(error)) {

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -44,7 +44,11 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     return await api.getProfileByUsername({ username, config: headers });
   });
   await queryClient.prefetchQuery([queryKeys.badges, username], async () => {
-    return await api.getBadgesByUsername({ username, config: headers });
+    return await api.getBadgesByUsername({
+      username,
+      onlyPinned: true,
+      config: headers,
+    });
   });
   return { props: { dehydratedState: dehydrate(queryClient), session } };
 };


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #252 

<br />

## 🗒 작업 목록

- [x]  프로필 페이지 title 수정
- [x] 프로필 페이지 서버사이드 렌더링 시 pinned 된 배지 목록을 호출하도록 수정
- [x] useBadges 쿼리 키에 onlyPinned 추가

<br />

## 🧐 PR Point

- 프로필 페이지 title이 나의 프로필/다른 사용자 프로필에 따라 다르게 나타나는데, 반대로 적용되어 있어 이를 수정했습니다.
- 프로필 페이지의 서버사이드에서 배지 목록을 호출 시 `onlyPinned: false`인 목록을 호출하여, 전체 배지 데이터를 보여준 후 pinned 된 목록을 나타내며 깜빡이는 현상이 나타났습니다.
  - `onlyPinned: true`인 목록을 호출하도록 수정
  - 쿼리 키에 onlyPinned를 추가
- 배지 목록 렌더링 시 깜빡임 없이 나타나도록 수정했습니다.

<br />

## 💥 Trouble Shooting
- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크

- 내용을 입력해주세요.

<br />

## 📚 참고

- 참고한 내용 또는 링크를 입력해주세요.

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다. 
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
