### PR TITLE
검색 결과에 정렬 기능 추가 

### DIFF
--- a/src/api/diaries.ts
+++ b/src/api/diaries.ts
@@ -16,6 +16,7 @@ import axios from 'lib/axios';
 export const getDiaries = async ({
   currentPage,
   searchKeyword,
+  sortBy,
 }: GetDiariesRequest) => {
   const currentPageIndex = currentPage - 1;
   const {
@@ -25,6 +26,7 @@ export const getDiaries = async ({
       skip: PAGE_SIZE * currentPageIndex,
       take: PAGE_SIZE,
       searchKeyword,
+      sortBy,
     },
   });
 

--- a/src/components/search/SearchResultHeader.tsx
+++ b/src/components/search/SearchResultHeader.tsx
@@ -7,12 +7,14 @@ import { useClickOutside } from 'hooks/common';
 
 interface SearchResultHeaderProps {
   totalCount: number;
+  selectedSortOption: SortByOption;
   sortOptions: SortByOption[];
   setSortOptions: Dispatch<SetStateAction<SortByOption[]>>;
 }
 
 export const SearchResultHeader = ({
   totalCount,
+  selectedSortOption,
   sortOptions,
   setSortOptions,
 }: SearchResultHeaderProps) => {
@@ -42,7 +44,7 @@ export const SearchResultHeader = ({
         type="button"
         onClick={handleSortSearchResult}
       >
-        {sortOptions.find((option) => option.selected)?.title}
+        {selectedSortOption.title}
         <ArrowDownIcon />
       </SortSearchResultButton>
       {isVisible && (

--- a/src/components/search/SearchResultHeader.tsx
+++ b/src/components/search/SearchResultHeader.tsx
@@ -1,51 +1,38 @@
 import styled from '@emotion/styled';
-import { useState } from 'react';
+import { useCallback, type Dispatch, type SetStateAction } from 'react';
+import type { SortByOption } from 'types/search';
 import { ArrowDownIcon, CheckIcon } from 'assets/icons';
 import { Popover } from 'components/common';
 import { useClickOutside } from 'hooks/common';
 
 interface SearchResultHeaderProps {
   totalCount: number;
+  sortOptions: SortByOption[];
+  setSortOptions: Dispatch<SetStateAction<SortByOption[]>>;
 }
 
-interface SortOptions {
-  id: string;
-  title: string;
-  selected: boolean;
-}
-
-const initialSortOptions = [
-  {
-    id: 'latest',
-    title: '최신순',
-    selected: true,
-  },
-  {
-    id: 'comments',
-    title: '댓글순',
-    selected: false,
-  },
-];
-
-export const SearchResultHeader = ({ totalCount }: SearchResultHeaderProps) => {
-  const [sortOptions, setSortOptions] =
-    useState<SortOptions[]>(initialSortOptions);
-
+export const SearchResultHeader = ({
+  totalCount,
+  sortOptions,
+  setSortOptions,
+}: SearchResultHeaderProps) => {
   const { ref, isVisible, setIsVisible } = useClickOutside();
 
   const handleSortSearchResult = () => {
     setIsVisible((state) => !state);
   };
 
-  // TODO: 정렬 기능 추가
-  const handleSelectSortOption = (selectedIndex: number) => () => {
-    setSortOptions((prevState) => {
-      return prevState.map((state, stateIndex) => ({
-        ...state,
-        selected: stateIndex === selectedIndex,
-      }));
-    });
-  };
+  const handleSelectSortOption = useCallback(
+    (selectedIndex: number) => () => {
+      setSortOptions((prevState) => {
+        return prevState.map((state, stateIndex) => ({
+          ...state,
+          selected: stateIndex === selectedIndex,
+        }));
+      });
+    },
+    [],
+  );
 
   return (
     <Container>
@@ -59,7 +46,7 @@ export const SearchResultHeader = ({ totalCount }: SearchResultHeaderProps) => {
         <ArrowDownIcon />
       </SortSearchResultButton>
       {isVisible && (
-        <Popover right={20}>
+        <Popover top={50} right={20}>
           <ul>
             {sortOptions.map((option, index) => {
               const { id, selected, title } = option;

--- a/src/constants/search/index.ts
+++ b/src/constants/search/index.ts
@@ -1,0 +1,1 @@
+export * from './sortBy';

--- a/src/constants/search/sortBy.ts
+++ b/src/constants/search/sortBy.ts
@@ -1,0 +1,24 @@
+export const SORT_BY_ID = {
+  latest: 'latest',
+  popularity: 'popularity',
+  comments: 'comments',
+} as const;
+
+// NOTE: SORT_BY_LIST를 useState 초기값으로 사용하기 위해 'as const' 사용하지 않음
+export const SORT_BY_LIST = [
+  {
+    id: SORT_BY_ID.latest,
+    title: '최신순',
+    selected: true,
+  },
+  {
+    id: SORT_BY_ID.popularity,
+    title: '인기순',
+    selected: false,
+  },
+  {
+    id: SORT_BY_ID.comments,
+    title: '댓글순',
+    selected: false,
+  },
+];

--- a/src/constants/search/sortBy.ts
+++ b/src/constants/search/sortBy.ts
@@ -4,8 +4,7 @@ export const SORT_BY_ID = {
   comments: 'comments',
 } as const;
 
-// NOTE: SORT_BY_LIST를 useState 초기값으로 사용하기 위해 'as const' 사용하지 않음
-export const SORT_BY_LIST = [
+export const INITIAL_SORT_BY_LIST = [
   {
     id: SORT_BY_ID.latest,
     title: '최신순',
@@ -21,4 +20,4 @@ export const SORT_BY_LIST = [
     title: '댓글순',
     selected: false,
   },
-];
+] as const;

--- a/src/hooks/services/queries/useDiaries.ts
+++ b/src/hooks/services/queries/useDiaries.ts
@@ -1,15 +1,17 @@
 import { useInfiniteQuery } from '@tanstack/react-query';
+import type { SortByType } from 'types/search';
 import * as api from 'api';
 import { queryKeys } from 'constants/services';
 
-export const useDiaries = (searchKeyword?: string) => {
+export const useDiaries = (searchKeyword?: string, sortBy?: SortByType) => {
   const { data, isFetching, isFetchingNextPage, isError, fetchNextPage } =
     useInfiniteQuery({
-      queryKey: [queryKeys.diaries, searchKeyword],
+      queryKey: [queryKeys.diaries, searchKeyword, sortBy],
       queryFn: async ({ pageParam = 1 }) =>
         await api.getDiaries({
           currentPage: pageParam as number,
           searchKeyword,
+          sortBy,
         }),
       getNextPageParam: (lastPage) => lastPage.nextPage,
     });

--- a/src/pages/search/[keyword].tsx
+++ b/src/pages/search/[keyword].tsx
@@ -1,12 +1,13 @@
 import styled from '@emotion/styled';
 import { getServerSession } from 'next-auth';
+import { useMemo, useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import type {
   GetServerSideProps,
   InferGetServerSidePropsType,
   NextPage,
 } from 'next';
-import type { SearchForm } from 'types/search';
+import type { SearchForm, SortByOption } from 'types/search';
 import { ObserverTarget, Seo } from 'components/common';
 import { DiariesContainer } from 'components/diary';
 import {
@@ -15,6 +16,7 @@ import {
   SearchResultHeader,
 } from 'components/search';
 import { PAGE_PATH } from 'constants/common';
+import { SORT_BY_LIST } from 'constants/search';
 import { useIntersectionObserver } from 'hooks/common';
 import { useDiaries } from 'hooks/services';
 import { authOptions } from 'pages/api/auth/[...nextauth]';
@@ -22,10 +24,19 @@ import { authOptions } from 'pages/api/auth/[...nextauth]';
 const SearchResultPage: NextPage<
   InferGetServerSidePropsType<typeof getServerSideProps>
 > = ({ keyword }) => {
+  const [sortOptions, setSortOptions] = useState<SortByOption[]>(SORT_BY_LIST);
+
+  const sortBy = useMemo(
+    () => sortOptions.filter((option) => option.selected)[0].id,
+    [sortOptions],
+  );
+
   const methods = useForm<SearchForm>({ mode: 'onChange' });
 
-  const { diariesData, isLoading, isError, fetchNextPage } =
-    useDiaries(keyword);
+  const { diariesData, isLoading, isError, fetchNextPage } = useDiaries(
+    keyword,
+    sortBy,
+  );
   const { setTargetRef } = useIntersectionObserver({
     onIntersect: fetchNextPage,
   });
@@ -49,7 +60,9 @@ const SearchResultPage: NextPage<
                 }
                 header={
                   <SearchResultHeader
-                    totalCount={diariesData[0].totalCount ?? 0}
+                    totalCount={diariesData[0].totalCount}
+                    sortOptions={sortOptions}
+                    setSortOptions={setSortOptions}
                   />
                 }
                 highlightKeyword={keyword}

--- a/src/pages/search/[keyword].tsx
+++ b/src/pages/search/[keyword].tsx
@@ -16,7 +16,7 @@ import {
   SearchResultHeader,
 } from 'components/search';
 import { PAGE_PATH } from 'constants/common';
-import { SORT_BY_LIST } from 'constants/search';
+import { INITIAL_SORT_BY_LIST } from 'constants/search';
 import { useIntersectionObserver } from 'hooks/common';
 import { useDiaries } from 'hooks/services';
 import { authOptions } from 'pages/api/auth/[...nextauth]';
@@ -24,7 +24,9 @@ import { authOptions } from 'pages/api/auth/[...nextauth]';
 const SearchResultPage: NextPage<
   InferGetServerSidePropsType<typeof getServerSideProps>
 > = ({ keyword }) => {
-  const [sortOptions, setSortOptions] = useState<SortByOption[]>(SORT_BY_LIST);
+  const [sortOptions, setSortOptions] = useState<SortByOption[]>([
+    ...INITIAL_SORT_BY_LIST,
+  ]);
 
   const selectedSortOption = useMemo(
     () => sortOptions.find((option) => option.selected) ?? sortOptions[0],

--- a/src/pages/search/[keyword].tsx
+++ b/src/pages/search/[keyword].tsx
@@ -26,8 +26,8 @@ const SearchResultPage: NextPage<
 > = ({ keyword }) => {
   const [sortOptions, setSortOptions] = useState<SortByOption[]>(SORT_BY_LIST);
 
-  const sortBy = useMemo(
-    () => sortOptions.filter((option) => option.selected)[0].id,
+  const selectedSortOption = useMemo(
+    () => sortOptions.find((option) => option.selected) ?? sortOptions[0],
     [sortOptions],
   );
 
@@ -35,7 +35,7 @@ const SearchResultPage: NextPage<
 
   const { diariesData, isLoading, isError, fetchNextPage } = useDiaries(
     keyword,
-    sortBy,
+    selectedSortOption.id,
   );
   const { setTargetRef } = useIntersectionObserver({
     onIntersect: fetchNextPage,
@@ -61,6 +61,7 @@ const SearchResultPage: NextPage<
                 header={
                   <SearchResultHeader
                     totalCount={diariesData[0].totalCount}
+                    selectedSortOption={selectedSortOption}
                     sortOptions={sortOptions}
                     setSortOptions={setSortOptions}
                   />

--- a/src/types/diary.ts
+++ b/src/types/diary.ts
@@ -1,3 +1,4 @@
+import type { SortByType } from './search';
 import type { AxiosRequestConfig } from 'axios';
 import type { User } from 'next-auth';
 
@@ -33,6 +34,7 @@ export type DiaryForm = Pick<
 export interface GetDiariesRequest {
   currentPage: number;
   searchKeyword?: string;
+  sortBy?: SortByType;
 }
 
 export interface GetDiariesByUsernameRequest extends GetDiariesRequest {

--- a/src/types/search.ts
+++ b/src/types/search.ts
@@ -1,3 +1,13 @@
+import type { SORT_BY_ID } from 'constants/search';
+
 export interface SearchForm {
   searchKeyword: string;
+}
+
+export type SortByType = keyof typeof SORT_BY_ID;
+
+export interface SortByOption {
+  id: SortByType;
+  title: string;
+  selected: boolean;
 }


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #254 
- #240 브랜치 머지 후 해당 브랜치 머지

<br />

## 🗒 작업 목록

#### *이슈 번호 [#254]인 커밋만 확인 부탁드립니다.

- [x] 정렬 관련 상수 선언 및 타입 정의
- [x] useDiary에 sortBy 매개변수 추가
- [x] 검색 결과 정렬 기능 구현

<br />

## 🧐 PR Point

- 일기 리스트 조회 API 스펙에 맞게 일기 검색 결과에 정렬 기능을 추가 했습니다.

<br />

## 💥 Trouble Shooting
- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크

https://github.com/a-daily-diary/ADD.FE/assets/85009583/c27c6312-90b4-4d42-b4bc-5d7069e9568a

<br />

## 📚 참고

- 참고한 내용 또는 링크를 입력해주세요.

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다. 
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
