### PR TITLE
로그인 상태에 따른 middleware 설정 수정

### DIFF
--- a/src/constants/common/page.ts
+++ b/src/constants/common/page.ts
@@ -40,3 +40,12 @@ export const PAGE_PATH = {
     keyword: (keyword: string) => `/search/${keyword}`,
   },
 } as const;
+
+export const WITH_AUTH_PAGE_LIST = [
+  PAGE_PATH.main,
+  PAGE_PATH.matching.index,
+  PAGE_PATH.diary.index,
+  PAGE_PATH.profile.index,
+  PAGE_PATH.setting.index,
+  PAGE_PATH.search.index,
+] as readonly string[];

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,23 +1,34 @@
 import { NextResponse } from 'next/server';
 import { getToken } from 'next-auth/jwt';
 import type { NextRequest } from 'next/server';
-import { PAGE_PATH } from 'constants/common';
+import { PAGE_PATH, WITH_AUTH_PAGE_LIST } from 'constants/common';
 
 const secret = process.env.NEXTAUTH_SECRET;
 
 export async function middleware(request: NextRequest) {
-  const session = await getToken({ req: request, secret, raw: true });
   const { pathname } = request.nextUrl;
 
-  // 로그인 상태에서 로그인, 회원가입 페이지 접근 시 메인 페이지로 리다이렉트
-  if (session != null) {
+  const session = await getToken({ req: request, secret, raw: true });
+  const isLoggedIn = session != null;
+
+  if (isLoggedIn) {
+    // NOTE: 로그인 상태에서 로그인, 회원가입 페이지 접근 불가
     if (pathname.startsWith(PAGE_PATH.account.index)) {
       return NextResponse.redirect(new URL(PAGE_PATH.main, request.url));
     }
   }
+
+  if (!isLoggedIn) {
+    // NOTE: 비로그인 상태에서 WITH_AUTH_PAGE_LIST 접근 불가
+    if (WITH_AUTH_PAGE_LIST.includes(pathname)) {
+      return NextResponse.redirect(
+        new URL(PAGE_PATH.account.login, request.url),
+      );
+    }
+  }
 }
 
-// matcher에 포함된 특정 경로에서만 middleware 실행
+// NOTE: page route에서만 middleware 실행
 export const config = {
-  matcher: ['/account/:path*'],
+  matcher: ['/((?!api|_next/static|_next/image|favicon.ico).*)'],
 };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,8 +1,6 @@
 import styled from '@emotion/styled';
 import Link from 'next/link';
-import { getServerSession } from 'next-auth';
-import { authOptions } from './api/auth/[...nextauth]';
-import type { GetServerSideProps, NextPage } from 'next';
+import type { NextPage } from 'next';
 import {
   FullPageLoading,
   ObserverTarget,
@@ -13,7 +11,6 @@ import { DiariesContainer } from 'components/diary';
 import EmptyDiary from 'components/diary/EmptyDiary';
 import { Header, HeaderLeft, HeaderRight } from 'components/layouts';
 import { PAGE_PATH } from 'constants/common';
-import { SERVER_SIDE_PROPS } from 'constants/server';
 import { useIntersectionObserver } from 'hooks/common';
 import { useDiaries } from 'hooks/services';
 
@@ -53,17 +50,6 @@ const Home: NextPage = () => {
       />
     </>
   );
-};
-
-export const getServerSideProps: GetServerSideProps = async (context) => {
-  const { req, res } = context;
-  const session = await getServerSession(req, res, authOptions);
-
-  if (session === null) {
-    return SERVER_SIDE_PROPS.REDIRECT_LOGIN;
-  }
-
-  return { props: { session } };
 };
 
 export default Home;

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -1,12 +1,9 @@
 import styled from '@emotion/styled';
-import { getServerSession } from 'next-auth';
 import { FormProvider, useForm } from 'react-hook-form';
-import type { GetServerSideProps, NextPage } from 'next';
+import type { NextPage } from 'next';
 import type { SearchForm } from 'types/search';
 import { Seo } from 'components/common';
 import { RecentSearchContainer, SearchHeader } from 'components/search';
-import { PAGE_PATH } from 'constants/common';
-import { authOptions } from 'pages/api/auth/[...nextauth]';
 
 const SearchPage: NextPage = () => {
   const methods = useForm<SearchForm>({ mode: 'onChange' });
@@ -22,22 +19,6 @@ const SearchPage: NextPage = () => {
       </Section>
     </>
   );
-};
-
-export const getServerSideProps: GetServerSideProps = async (context) => {
-  const { req, res } = context;
-  const session = await getServerSession(req, res, authOptions);
-
-  if (session === null) {
-    return {
-      redirect: {
-        destination: PAGE_PATH.account.login,
-        permanent: false,
-      },
-    };
-  }
-
-  return { props: { session } };
 };
 
 export default SearchPage;


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #258 

<br />

## 🗒 작업 목록

- [x] 로그인 상태에 따른 페이지 라우팅을 위한 middleware 수정
- [x] 서버 사이드 렌더링 시 로그인 상태에 따른 페이지 라우팅 처리만 하는 코드 제거

<br />

## 🧐 PR Point

- 로그인 상태에 따른 페이지 라우팅을 middleware로 설정하여 불필요한 코드를 제거합니다.
- 이 전에 모든 페이지 라우트에 대해 미들웨어를 실행하기 위해 잘못된 matcher 설정으로 인해 파일 시스템 등 불필요한 경로에서도 미들웨어가 실행되어 과도한 요청으로 인해 에러가 발생했습니다.
- 공식 문서의 matcher를 참고하여 페이지 라우트에서만 미들웨어가 동작할 수 있도록 수정했습니다
```ts
export const config = {
  matcher: ['/((?!api|_next/static|_next/image|favicon.ico).*)'],
};
```
- 서버사이드 렌더링에서 session 의 값만 체크하는 코드를 제거했습니다.
  - session 체크 후 후속 작업이 필요한 경우에는 제거하지 않았습니다.
  - 추후 handler 사용하여 일괄 처리할 예정입니다.

<br />

## 💥 Trouble Shooting
- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크

- 내용을 입력해주세요.

<br />

## 📚 참고

- [match paths | next.js](https://nextjs.org/docs/app/building-your-application/routing/middleware#matching-paths)
- [문서보며 알아보는 nextjs 미들웨어
](https://velog.io/@pds0309/nextjs-%EB%AF%B8%EB%93%A4%EC%9B%A8%EC%96%B4%EB%9E%80)

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다. 
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
