### PR TITLE
getServerSideProps withAuth handler 생성 및 적용

### DIFF
--- a/src/lib/auth/index.ts
+++ b/src/lib/auth/index.ts
@@ -1,0 +1,1 @@
+export * from './serverSidePropsWithAuth';

--- a/src/lib/auth/serverSidePropsWithAuth.ts
+++ b/src/lib/auth/serverSidePropsWithAuth.ts
@@ -1,10 +1,15 @@
 import { getServerSession } from 'next-auth';
-import type { GetServerSideProps, GetServerSidePropsContext } from 'next';
+import type { GetServerSidePropsContext, GetServerSidePropsResult } from 'next';
+import type { GetServerSidePropsContext as GetServerSidePropsContextType } from 'next/types';
 import { SERVER_SIDE_PROPS } from 'constants/server';
 import { authOptions } from 'pages/api/auth/[...nextauth]';
 
+type WithAuthOptions<P> = (
+  context: GetServerSidePropsContextType,
+) => GetServerSidePropsResult<P> | Promise<GetServerSidePropsResult<P>>;
+
 export const getServerSidePropsWithAuth =
-  (getServerSideProps: GetServerSideProps) =>
+  <P extends Record<string, unknown>>(getServerSideProps: WithAuthOptions<P>) =>
   async (context: GetServerSidePropsContext) => {
     const { req, res } = context;
     const session = await getServerSession(req, res, authOptions);

--- a/src/lib/auth/serverSidePropsWithAuth.ts
+++ b/src/lib/auth/serverSidePropsWithAuth.ts
@@ -1,0 +1,21 @@
+import { getServerSession } from 'next-auth';
+import type { GetServerSideProps, GetServerSidePropsContext } from 'next';
+import { SERVER_SIDE_PROPS } from 'constants/server';
+import { authOptions } from 'pages/api/auth/[...nextauth]';
+
+export const getServerSidePropsWithAuth =
+  (getServerSideProps: GetServerSideProps) =>
+  async (context: GetServerSidePropsContext) => {
+    const { req, res } = context;
+    const session = await getServerSession(req, res, authOptions);
+
+    if (session === null) {
+      return SERVER_SIDE_PROPS.REDIRECT_LOGIN;
+    }
+
+    context.user = session.user;
+
+    const serverSideProps = await getServerSideProps(context);
+
+    return { ...serverSideProps };
+  };

--- a/src/lib/auth/serverSidePropsWithAuth.ts
+++ b/src/lib/auth/serverSidePropsWithAuth.ts
@@ -1,11 +1,11 @@
 import { getServerSession } from 'next-auth';
 import type { GetServerSidePropsContext, GetServerSidePropsResult } from 'next';
-import type { GetServerSidePropsContext as GetServerSidePropsContextType } from 'next/types';
+import type { GetServerSidePropsContext as DefaultGetServerSidePropsContext } from 'next/types';
 import { SERVER_SIDE_PROPS } from 'constants/server';
 import { authOptions } from 'pages/api/auth/[...nextauth]';
 
 type WithAuthOptions<P> = (
-  context: GetServerSidePropsContextType,
+  context: DefaultGetServerSidePropsContext,
 ) => GetServerSidePropsResult<P> | Promise<GetServerSidePropsResult<P>>;
 
 export const getServerSidePropsWithAuth =

--- a/src/pages/account/reset-password.tsx
+++ b/src/pages/account/reset-password.tsx
@@ -7,7 +7,7 @@ import type {
 import * as api from 'api';
 import { ResetPasswordForm } from 'components/account';
 import { Seo } from 'components/common';
-import { PAGE_PATH } from 'constants/common';
+import { SERVER_SIDE_PROPS } from 'constants/server';
 import { getQueryParams } from 'utils';
 
 const ResetPassword: NextPage<
@@ -28,15 +28,8 @@ export const getServerSideProps = (async (context) => {
   const [email] = getQueryParams(query.email);
   const [token] = getQueryParams(query.token);
 
-  const REDIRECT_LOGIN_PAGE_PROPS = {
-    redirect: {
-      destination: PAGE_PATH.account.login,
-      permanent: false,
-    },
-  };
-
   if (!email || !token) {
-    return REDIRECT_LOGIN_PAGE_PROPS;
+    return SERVER_SIDE_PROPS.REDIRECT_LOGIN;
   }
 
   try {
@@ -47,7 +40,7 @@ export const getServerSideProps = (async (context) => {
 
     return { props: { email, token } };
   } catch (error) {
-    return REDIRECT_LOGIN_PAGE_PROPS;
+    return SERVER_SIDE_PROPS.REDIRECT_LOGIN;
   }
 }) satisfies GetServerSideProps;
 

--- a/src/pages/diary/[id]/edit.tsx
+++ b/src/pages/diary/[id]/edit.tsx
@@ -2,10 +2,10 @@ import styled from '@emotion/styled';
 import { QueryClient, dehydrate } from '@tanstack/react-query';
 import { isAxiosError } from 'axios';
 import { useRouter } from 'next/router';
-import { getServerSession } from 'next-auth';
 import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
-import type { GetServerSideProps, NextPage } from 'next';
+import type { NextPage, GetServerSidePropsContext } from 'next';
+import type { User } from 'next-auth';
 import type { ChangeEventHandler, FocusEventHandler } from 'react';
 import type { SubmitHandler } from 'react-hook-form';
 import type { DiaryForm } from 'types/diary';
@@ -32,11 +32,10 @@ import {
 } from 'components/layouts';
 import { PAGE_PATH } from 'constants/common';
 import { MODAL_BUTTON, MODAL_MESSAGE } from 'constants/modal';
-import { SERVER_SIDE_PROPS } from 'constants/server';
 import { queryKeys } from 'constants/services';
 import { useBeforeLeave, useModal } from 'hooks/common';
 import { useDiary, useEditDiary, useImageUpload } from 'hooks/services';
-import { authOptions } from 'pages/api/auth/[...nextauth]';
+import { getServerSidePropsWithAuth } from 'lib/auth';
 import { ScreenReaderOnly } from 'styles';
 import { dateFormat, errorResponseMessage, textareaAutosize } from 'utils';
 
@@ -254,30 +253,30 @@ const EditDiary: NextPage = () => {
   );
 };
 
-export const getServerSideProps: GetServerSideProps = async (context) => {
-  const { req, res, query } = context;
-  const { id } = query;
-  const session = await getServerSession(req, res, authOptions);
+export const getServerSideProps = getServerSidePropsWithAuth(
+  async (context: GetServerSidePropsContext) => {
+    const { user, query } = context;
+    const { id } = query;
 
-  if (session === null) {
-    return SERVER_SIDE_PROPS.REDIRECT_LOGIN;
-  }
+    const { accessToken } = user as User;
 
-  const queryClient = new QueryClient();
-  await queryClient.prefetchQuery(
-    [queryKeys.diaries, id],
-    async () =>
-      await api.getDiaryDetail({
-        id: id as string,
-        config: {
-          headers: {
-            Authorization: `Bearer ${session.user.accessToken}`,
+    const queryClient = new QueryClient();
+    await queryClient.prefetchQuery(
+      [queryKeys.diaries, id],
+      async () =>
+        await api.getDiaryDetail({
+          id: id as string,
+          config: {
+            headers: {
+              Authorization: `Bearer ${accessToken}`,
+            },
           },
-        },
-      }),
-  );
-  return { props: { dehydratedState: dehydrate(queryClient) } };
-};
+        }),
+    );
+
+    return { props: { dehydratedState: dehydrate(queryClient) } };
+  },
+);
 
 export default EditDiary;
 

--- a/src/pages/diary/[id]/index.tsx
+++ b/src/pages/diary/[id]/index.tsx
@@ -24,7 +24,11 @@ import { useDeleteDiary, useDiary } from 'hooks/services';
 import { getServerSidePropsWithAuth } from 'lib/auth';
 import { errorResponseMessage } from 'utils';
 
-const DiaryDetailPage: NextPage<{ user: User }> = ({ user }) => {
+interface DiaryDetailPageProps {
+  user: User;
+}
+
+const DiaryDetailPage: NextPage<DiaryDetailPageProps> = ({ user }) => {
   const router = useRouter();
   const { id } = router.query;
 

--- a/src/pages/diary/[id]/index.tsx
+++ b/src/pages/diary/[id]/index.tsx
@@ -2,9 +2,8 @@ import styled from '@emotion/styled';
 import { QueryClient, dehydrate } from '@tanstack/react-query';
 import { isAxiosError } from 'axios';
 import { useRouter } from 'next/router';
-import { getServerSession } from 'next-auth';
-import { useSession } from 'next-auth/react';
-import type { GetServerSideProps, NextPage } from 'next';
+import type { NextPage, GetServerSidePropsContext } from 'next';
+import type { User } from 'next-auth';
 import type { ErrorResponse } from 'types/response';
 import * as api from 'api';
 import { EditIcon, ReportIcon, TrashIcon } from 'assets/icons';
@@ -19,17 +18,15 @@ import { DiaryDetailContainer } from 'components/diary';
 import { Header, HeaderLeft, HeaderRight } from 'components/layouts';
 import { PAGE_PATH } from 'constants/common';
 import { MODAL_BUTTON, MODAL_MESSAGE } from 'constants/modal';
-import { SERVER_SIDE_PROPS } from 'constants/server';
 import { queryKeys } from 'constants/services';
 import { useClickOutside, useModal } from 'hooks/common';
 import { useDeleteDiary, useDiary } from 'hooks/services';
-import { authOptions } from 'pages/api/auth/[...nextauth]';
+import { getServerSidePropsWithAuth } from 'lib/auth';
 import { errorResponseMessage } from 'utils';
 
-const DiaryDetailPage: NextPage = () => {
+const DiaryDetailPage: NextPage<{ user: User }> = ({ user }) => {
   const router = useRouter();
   const { id } = router.query;
-  const { data: session } = useSession();
 
   const { isVisible: isVisibleDeleteModal, handleModal: handleDeleteModal } =
     useModal();
@@ -57,7 +54,7 @@ const DiaryDetailPage: NextPage = () => {
   if (diaryData === undefined || isLoading) return <FullPageLoading />;
 
   const { author, title } = diaryData;
-  const isAuthor = author.id === session?.user.id;
+  const isAuthor = author.id === user.id;
 
   return (
     <>
@@ -119,28 +116,29 @@ const DiaryDetailPage: NextPage = () => {
   );
 };
 
-export const getServerSideProps: GetServerSideProps = async (context) => {
-  const { req, res, query } = context;
-  const { id } = query;
-  const session = await getServerSession(req, res, authOptions);
+export const getServerSideProps = getServerSidePropsWithAuth(
+  async (context: GetServerSidePropsContext) => {
+    const { user, query } = context;
+    const { id } = query;
 
-  if (session === null) {
-    return SERVER_SIDE_PROPS.REDIRECT_LOGIN;
-  }
-  const headers = {
-    headers: {
-      Authorization: `Bearer ${session.user.accessToken}`,
-    },
-  };
+    const { accessToken } = user as User;
 
-  const queryClient = new QueryClient();
-  await queryClient.prefetchQuery(
-    [queryKeys.diaries, id],
-    async () => await api.getDiaryDetail({ id: id as string, config: headers }),
-  );
+    const headers = {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    };
 
-  return { props: { dehydratedState: dehydrate(queryClient) } };
-};
+    const queryClient = new QueryClient();
+    await queryClient.prefetchQuery(
+      [queryKeys.diaries, id],
+      async () =>
+        await api.getDiaryDetail({ id: id as string, config: headers }),
+    );
+
+    return { props: { dehydratedState: dehydrate(queryClient), user } };
+  },
+);
 
 export default DiaryDetailPage;
 

--- a/src/pages/profile/[username]/badges.tsx
+++ b/src/pages/profile/[username]/badges.tsx
@@ -9,9 +9,9 @@ import { Header, HeaderLeft, HeaderTitle } from 'components/layouts';
 import { queryKeys } from 'constants/services';
 import { useBadges } from 'hooks/services';
 import { getServerSidePropsWithAuth } from 'lib/auth';
+import { getQueryParams } from 'utils';
 
-const BadgePage: NextPage<{ user: User }> = ({ user }) => {
-  const { username } = user;
+const BadgePage: NextPage<{ username: string }> = ({ username }) => {
   const { badgesData } = useBadges({ username });
 
   return (
@@ -39,9 +39,10 @@ const BadgePage: NextPage<{ user: User }> = ({ user }) => {
 
 export const getServerSideProps = getServerSidePropsWithAuth(
   async (context: GetServerSidePropsContext) => {
-    const { user } = context;
+    const { user, query } = context;
+    const [username] = getQueryParams(query.username);
 
-    const { username, accessToken } = user as User;
+    const { accessToken } = user as User;
 
     const headers = {
       headers: {
@@ -54,7 +55,7 @@ export const getServerSideProps = getServerSidePropsWithAuth(
       return await api.getBadgesByUsername({ username, config: headers });
     });
 
-    return { props: { dehydratedState: dehydrate(queryClient), user } };
+    return { props: { dehydratedState: dehydrate(queryClient), username } };
   },
 );
 

--- a/src/pages/profile/[username]/badges.tsx
+++ b/src/pages/profile/[username]/badges.tsx
@@ -1,35 +1,25 @@
 import styled from '@emotion/styled';
 import { QueryClient, dehydrate } from '@tanstack/react-query';
-import { useRouter } from 'next/router';
-import { getServerSession } from 'next-auth';
-import type { GetServerSideProps, NextPage } from 'next';
+import type { GetServerSidePropsContext, NextPage } from 'next';
+import type { User } from 'next-auth';
 import * as api from 'api';
 import { BadgeDetailButton } from 'components/badge';
 import { Seo } from 'components/common';
 import { Header, HeaderLeft, HeaderTitle } from 'components/layouts';
-import { SERVER_SIDE_PROPS } from 'constants/server';
 import { queryKeys } from 'constants/services';
 import { useBadges } from 'hooks/services';
-import { authOptions } from 'pages/api/auth/[...nextauth]';
+import { getServerSidePropsWithAuth } from 'lib/auth';
 
-const BadgePage: NextPage = () => {
-  const router = useRouter();
-  const {
-    query: { username },
-  } = router;
-  const { badgesData } = useBadges({ username: username as string });
+const BadgePage: NextPage<{ user: User }> = ({ user }) => {
+  const { username } = user;
+  const { badgesData } = useBadges({ username });
 
   return (
     <>
-      <Seo title={`${username as string}님의 배지 | a daily diary`} />
+      <Seo title={`${username}님의 배지 | a daily diary`} />
       <Header
         left={<HeaderLeft type="이전" />}
-        title={
-          <HeaderTitle
-            title={`${username as string}님의 배지`}
-            position="center"
-          />
-        }
+        title={<HeaderTitle title={`${username}님의 배지`} position="center" />}
       />
       <Section>
         <BadgeList>
@@ -47,28 +37,26 @@ const BadgePage: NextPage = () => {
   );
 };
 
-export const getServerSideProps: GetServerSideProps = async (context) => {
-  const { req, res } = context;
-  const session = await getServerSession(req, res, authOptions);
+export const getServerSideProps = getServerSidePropsWithAuth(
+  async (context: GetServerSidePropsContext) => {
+    const { user } = context;
 
-  if (session === null) {
-    return SERVER_SIDE_PROPS.REDIRECT_LOGIN;
-  }
+    const { username, accessToken } = user as User;
 
-  const { username, accessToken } = session.user;
+    const headers = {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    };
 
-  const headers = {
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-    },
-  };
+    const queryClient = new QueryClient();
+    await queryClient.prefetchQuery([queryKeys.badges, username], async () => {
+      return await api.getBadgesByUsername({ username, config: headers });
+    });
 
-  const queryClient = new QueryClient();
-  await queryClient.prefetchQuery([queryKeys.badges, username], async () => {
-    return await api.getBadgesByUsername({ username, config: headers });
-  });
-  return { props: { dehydratedState: dehydrate(queryClient), session } };
-};
+    return { props: { dehydratedState: dehydrate(queryClient), user } };
+  },
+);
 
 export default BadgePage;
 

--- a/src/pages/profile/[username]/badges.tsx
+++ b/src/pages/profile/[username]/badges.tsx
@@ -11,7 +11,11 @@ import { useBadges } from 'hooks/services';
 import { getServerSidePropsWithAuth } from 'lib/auth';
 import { getQueryParams } from 'utils';
 
-const BadgePage: NextPage<{ username: string }> = ({ username }) => {
+interface BadgePageProps {
+  username: string;
+}
+
+const BadgePage: NextPage<BadgePageProps> = ({ username }) => {
   const { badgesData } = useBadges({ username });
 
   return (

--- a/src/pages/profile/[username]/diaries.tsx
+++ b/src/pages/profile/[username]/diaries.tsx
@@ -13,7 +13,13 @@ import { useUserDiaries } from 'hooks/services';
 import { getServerSidePropsWithAuth } from 'lib/auth';
 import { getQueryParams } from 'utils';
 
-const YourProfileDiaries: NextPage<{ username: string }> = ({ username }) => {
+interface YourProfileDiariesProps {
+  username: string;
+}
+
+const YourProfileDiaries: NextPage<YourProfileDiariesProps> = ({
+  username,
+}) => {
   const {
     userDiariesData,
     isLoading: isUserDiariesLoading,

--- a/src/pages/profile/[username]/diaries.tsx
+++ b/src/pages/profile/[username]/diaries.tsx
@@ -1,25 +1,18 @@
 import { QueryClient, dehydrate } from '@tanstack/react-query';
 import { isAxiosError } from 'axios';
-import { getServerSession } from 'next-auth';
-import type {
-  GetServerSideProps,
-  InferGetServerSidePropsType,
-  NextPage,
-} from 'next';
+import type { GetServerSidePropsContext, NextPage } from 'next';
+import type { User } from 'next-auth';
 import * as api from 'api';
 import { FullPageLoading, ObserverTarget } from 'components/common';
 import { DiariesContainer } from 'components/diary';
 import EmptyDiary from 'components/diary/EmptyDiary';
 import { ProfileLayout } from 'components/profile';
-import { PAGE_PATH } from 'constants/common';
 import { queryKeys } from 'constants/services';
 import { useIntersectionObserver } from 'hooks/common';
 import { useUserDiaries } from 'hooks/services';
-import { authOptions } from 'pages/api/auth/[...nextauth]';
+import { getServerSidePropsWithAuth } from 'lib/auth';
 
-const YourProfileDiaries: NextPage<
-  InferGetServerSidePropsType<typeof getServerSideProps>
-> = ({ username }) => {
+const YourProfileDiaries: NextPage<{ username: string }> = ({ username }) => {
   const {
     userDiariesData,
     isLoading: isUserDiariesLoading,
@@ -50,44 +43,35 @@ const YourProfileDiaries: NextPage<
   );
 };
 
-export const getServerSideProps = (async (context) => {
-  const { req, res, params } = context;
-  const username = params?.username as string;
+export const getServerSideProps = getServerSidePropsWithAuth(
+  async (context: GetServerSidePropsContext) => {
+    const { user, query } = context;
+    const username = query?.username as string;
 
-  const session = await getServerSession(req, res, authOptions);
+    const { accessToken } = user as User;
 
-  if (session === null) {
-    return {
-      redirect: {
-        destination: PAGE_PATH.account.login,
-        permanent: false,
+    const headers = {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
       },
     };
-  }
 
-  const { accessToken } = session.user;
+    const queryClient = new QueryClient();
 
-  const headers = {
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-    },
-  };
-
-  const queryClient = new QueryClient();
-
-  try {
-    await queryClient.fetchQuery([queryKeys.users, username], async () => {
-      return await api.getProfileByUsername({ username, config: headers });
-    });
-  } catch (error) {
-    if (isAxiosError(error)) {
-      return {
-        notFound: true,
-      };
+    try {
+      await queryClient.fetchQuery([queryKeys.users, username], async () => {
+        return await api.getProfileByUsername({ username, config: headers });
+      });
+    } catch (error) {
+      if (isAxiosError(error)) {
+        return {
+          notFound: true,
+        };
+      }
     }
-  }
 
-  return { props: { dehydratedState: dehydrate(queryClient), username } };
-}) satisfies GetServerSideProps;
+    return { props: { dehydratedState: dehydrate(queryClient), username } };
+  },
+);
 
 export default YourProfileDiaries;

--- a/src/pages/profile/[username]/diaries.tsx
+++ b/src/pages/profile/[username]/diaries.tsx
@@ -11,6 +11,7 @@ import { queryKeys } from 'constants/services';
 import { useIntersectionObserver } from 'hooks/common';
 import { useUserDiaries } from 'hooks/services';
 import { getServerSidePropsWithAuth } from 'lib/auth';
+import { getQueryParams } from 'utils';
 
 const YourProfileDiaries: NextPage<{ username: string }> = ({ username }) => {
   const {
@@ -46,7 +47,7 @@ const YourProfileDiaries: NextPage<{ username: string }> = ({ username }) => {
 export const getServerSideProps = getServerSidePropsWithAuth(
   async (context: GetServerSidePropsContext) => {
     const { user, query } = context;
-    const username = query?.username as string;
+    const [username] = getQueryParams(query.username);
 
     const { accessToken } = user as User;
 

--- a/src/pages/profile/[username]/index.tsx
+++ b/src/pages/profile/[username]/index.tsx
@@ -7,6 +7,7 @@ import { ActivitiesContainer, ProfileLayout } from 'components/profile';
 import { PAGE_PATH } from 'constants/common';
 import { queryKeys } from 'constants/services';
 import { getServerSidePropsWithAuth } from 'lib/auth';
+import { getQueryParams } from 'utils';
 
 const YourProfile: NextPage<{ username: string }> = ({ username }) => {
   return (
@@ -19,7 +20,7 @@ const YourProfile: NextPage<{ username: string }> = ({ username }) => {
 export const getServerSideProps = getServerSidePropsWithAuth(
   async (context: GetServerSidePropsContext) => {
     const { user, query } = context;
-    const username = query?.username as string;
+    const [username] = getQueryParams(query.username);
 
     const { accessToken, username: loggedInUsername } = user as User;
 

--- a/src/pages/profile/[username]/index.tsx
+++ b/src/pages/profile/[username]/index.tsx
@@ -9,7 +9,11 @@ import { queryKeys } from 'constants/services';
 import { getServerSidePropsWithAuth } from 'lib/auth';
 import { getQueryParams } from 'utils';
 
-const YourProfile: NextPage<{ username: string }> = ({ username }) => {
+interface YourProfileProps {
+  username: string;
+}
+
+const YourProfile: NextPage<YourProfileProps> = ({ username }) => {
   return (
     <ProfileLayout isMyProfile={false} username={username}>
       <ActivitiesContainer title={`${username} - 활동`} username={username} />

--- a/src/pages/profile/[username]/index.tsx
+++ b/src/pages/profile/[username]/index.tsx
@@ -1,21 +1,14 @@
 import { QueryClient, dehydrate } from '@tanstack/react-query';
 import { isAxiosError } from 'axios';
-import { getServerSession } from 'next-auth';
-import type {
-  GetServerSideProps,
-  InferGetServerSidePropsType,
-  NextPage,
-} from 'next';
+import type { GetServerSidePropsContext, NextPage } from 'next';
+import type { User } from 'next-auth';
 import * as api from 'api';
 import { ActivitiesContainer, ProfileLayout } from 'components/profile';
 import { PAGE_PATH } from 'constants/common';
-import { SERVER_SIDE_PROPS } from 'constants/server';
 import { queryKeys } from 'constants/services';
-import { authOptions } from 'pages/api/auth/[...nextauth]';
+import { getServerSidePropsWithAuth } from 'lib/auth';
 
-const YourProfile: NextPage<
-  InferGetServerSidePropsType<typeof getServerSideProps>
-> = ({ username }) => {
+const YourProfile: NextPage<{ username: string }> = ({ username }) => {
   return (
     <ProfileLayout isMyProfile={false} username={username}>
       <ActivitiesContainer title={`${username} - 활동`} username={username} />
@@ -23,55 +16,51 @@ const YourProfile: NextPage<
   );
 };
 
-export const getServerSideProps = (async (context) => {
-  const { req, res, params } = context;
-  const username = params?.username as string;
+export const getServerSideProps = getServerSidePropsWithAuth(
+  async (context: GetServerSidePropsContext) => {
+    const { user, query } = context;
+    const username = query?.username as string;
 
-  const session = await getServerSession(req, res, authOptions);
+    const { accessToken, username: loggedInUsername } = user as User;
 
-  if (session === null) {
-    return SERVER_SIDE_PROPS.REDIRECT_LOGIN;
-  }
-
-  const { accessToken, username: loggedInUsername } = session.user;
-
-  if (loggedInUsername === username) {
-    return {
-      redirect: {
-        destination: PAGE_PATH.profile.index,
-        permanent: false,
-      },
-    };
-  }
-
-  const headers = {
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-    },
-  };
-
-  const queryClient = new QueryClient();
-
-  try {
-    await queryClient.fetchQuery([queryKeys.users, username], async () => {
-      return await api.getProfileByUsername({ username, config: headers });
-    });
-    await queryClient.fetchQuery([queryKeys.badges, username], async () => {
-      return await api.getBadgesByUsername({
-        username,
-        onlyPinned: true,
-        config: headers,
-      });
-    });
-  } catch (error) {
-    if (isAxiosError(error)) {
+    if (loggedInUsername === username) {
       return {
-        notFound: true,
+        redirect: {
+          destination: PAGE_PATH.profile.index,
+          permanent: false,
+        },
       };
     }
-  }
 
-  return { props: { dehydratedState: dehydrate(queryClient), username } };
-}) satisfies GetServerSideProps;
+    const headers = {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    };
+
+    const queryClient = new QueryClient();
+
+    try {
+      await queryClient.fetchQuery([queryKeys.users, username], async () => {
+        return await api.getProfileByUsername({ username, config: headers });
+      });
+      await queryClient.fetchQuery([queryKeys.badges, username], async () => {
+        return await api.getBadgesByUsername({
+          username,
+          onlyPinned: true,
+          config: headers,
+        });
+      });
+    } catch (error) {
+      if (isAxiosError(error)) {
+        return {
+          notFound: true,
+        };
+      }
+    }
+
+    return { props: { dehydratedState: dehydrate(queryClient), username } };
+  },
+);
 
 export default YourProfile;

--- a/src/pages/profile/bookmarks.tsx
+++ b/src/pages/profile/bookmarks.tsx
@@ -1,29 +1,25 @@
 import { QueryClient, dehydrate } from '@tanstack/react-query';
-import { getServerSession } from 'next-auth';
-import { useSession } from 'next-auth/react';
-import type { GetServerSideProps, NextPage } from 'next';
+import type { GetServerSidePropsContext, NextPage } from 'next';
+import type { User } from 'next-auth';
 import * as api from 'api';
 import { FullPageLoading, ObserverTarget } from 'components/common';
 import { DiariesContainer } from 'components/diary';
 import EmptyDiary from 'components/diary/EmptyDiary';
 import { ProfileLayout } from 'components/profile';
-import { PAGE_PATH } from 'constants/common';
 import { queryKeys } from 'constants/services';
 import { useIntersectionObserver } from 'hooks/common';
 import { useBookmarkedDiaries } from 'hooks/services';
-import { authOptions } from 'pages/api/auth/[...nextauth]';
+import { getServerSidePropsWithAuth } from 'lib/auth';
 
-const MyProfileBookmarks: NextPage = () => {
-  const { data: session } = useSession();
-
-  if (session === null) return <div>로그인이 필요합니다.</div>; // TODO: 로그인 페이지로 이동 모달 생성하여 적용하기
+const MyProfileBookmarks: NextPage<{ user: User }> = ({ user }) => {
+  const { username } = user;
 
   const {
     bookmarkedDiariesData,
     isLoading: isBookmarkedDiariesLoading,
     isError: isBookmarkedDiariesError,
     fetchNextPage: fetchBookmarkedDiariesNextPage,
-  } = useBookmarkedDiaries(session.user.username);
+  } = useBookmarkedDiaries(username);
   const { setTargetRef: setBookmarkedDiariesTargetRef } =
     useIntersectionObserver({
       onIntersect: fetchBookmarkedDiariesNextPage,
@@ -34,7 +30,7 @@ const MyProfileBookmarks: NextPage = () => {
   }
 
   return (
-    <ProfileLayout isMyProfile username={session.user.username}>
+    <ProfileLayout isMyProfile username={username}>
       <DiariesContainer
         title="프로필 - 북마크"
         diariesData={bookmarkedDiariesData}
@@ -49,32 +45,24 @@ const MyProfileBookmarks: NextPage = () => {
   );
 };
 
-export const getServerSideProps: GetServerSideProps = async (context) => {
-  const { req, res } = context;
-  const session = await getServerSession(req, res, authOptions);
+export const getServerSideProps = getServerSidePropsWithAuth(
+  async (context: GetServerSidePropsContext) => {
+    const { user } = context;
 
-  if (session === null) {
-    return {
-      redirect: {
-        destination: PAGE_PATH.account.login,
-        permanent: false,
+    const { username, accessToken } = user as User;
+
+    const headers = {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
       },
     };
-  }
 
-  const { username, accessToken } = session.user;
-
-  const headers = {
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-    },
-  };
-
-  const queryClient = new QueryClient();
-  await queryClient.prefetchQuery([queryKeys.users, username], async () => {
-    return await api.getProfileByUsername({ username, config: headers });
-  });
-  return { props: { dehydratedState: dehydrate(queryClient), session } };
-};
+    const queryClient = new QueryClient();
+    await queryClient.prefetchQuery([queryKeys.users, username], async () => {
+      return await api.getProfileByUsername({ username, config: headers });
+    });
+    return { props: { dehydratedState: dehydrate(queryClient), user } };
+  },
+);
 
 export default MyProfileBookmarks;

--- a/src/pages/profile/bookmarks.tsx
+++ b/src/pages/profile/bookmarks.tsx
@@ -11,7 +11,11 @@ import { useIntersectionObserver } from 'hooks/common';
 import { useBookmarkedDiaries } from 'hooks/services';
 import { getServerSidePropsWithAuth } from 'lib/auth';
 
-const MyProfileBookmarks: NextPage<{ user: User }> = ({ user }) => {
+interface MyProfileBookmarksProps {
+  user: User;
+}
+
+const MyProfileBookmarks: NextPage<MyProfileBookmarksProps> = ({ user }) => {
   const { username } = user;
 
   const {

--- a/src/pages/profile/diaries.tsx
+++ b/src/pages/profile/diaries.tsx
@@ -11,7 +11,11 @@ import { useIntersectionObserver } from 'hooks/common';
 import { useUserDiaries } from 'hooks/services';
 import { getServerSidePropsWithAuth } from 'lib/auth';
 
-const MyProfileDiaries: NextPage<{ user: User }> = ({ user }) => {
+interface MyProfileDiariesProps {
+  user: User;
+}
+
+const MyProfileDiaries: NextPage<MyProfileDiariesProps> = ({ user }) => {
   const { username } = user;
 
   const {

--- a/src/pages/profile/diaries.tsx
+++ b/src/pages/profile/diaries.tsx
@@ -1,29 +1,25 @@
 import { QueryClient, dehydrate } from '@tanstack/react-query';
-import { getServerSession } from 'next-auth';
-import { useSession } from 'next-auth/react';
-import type { GetServerSideProps, NextPage } from 'next';
+import type { GetServerSidePropsContext, NextPage } from 'next';
+import type { User } from 'next-auth';
 import * as api from 'api';
 import { FullPageLoading, ObserverTarget } from 'components/common';
 import { DiariesContainer } from 'components/diary';
 import EmptyDiary from 'components/diary/EmptyDiary';
 import { ProfileLayout } from 'components/profile';
-import { PAGE_PATH } from 'constants/common';
 import { queryKeys } from 'constants/services';
 import { useIntersectionObserver } from 'hooks/common';
 import { useUserDiaries } from 'hooks/services';
-import { authOptions } from 'pages/api/auth/[...nextauth]';
+import { getServerSidePropsWithAuth } from 'lib/auth';
 
-const MyProfileDiaries: NextPage = () => {
-  const { data: session } = useSession();
-
-  if (session === null) return <div>로그인이 필요합니다.</div>; // TODO: 로그인 페이지로 이동 모달 생성하여 적용하기
+const MyProfileDiaries: NextPage<{ user: User }> = ({ user }) => {
+  const { username } = user;
 
   const {
     userDiariesData,
     isLoading: isUserDiariesLoading,
     isError: isUserDiariesError,
     fetchNextPage: fetchUserDiariesNextPage,
-  } = useUserDiaries(session.user.username);
+  } = useUserDiaries(username);
   const { setTargetRef: setUserDiariesTargetRef } = useIntersectionObserver({
     onIntersect: fetchUserDiariesNextPage,
   });
@@ -33,7 +29,7 @@ const MyProfileDiaries: NextPage = () => {
   }
 
   return (
-    <ProfileLayout isMyProfile username={session.user.username}>
+    <ProfileLayout isMyProfile username={username}>
       <DiariesContainer
         title="프로필 - 일기"
         diariesData={userDiariesData}
@@ -48,32 +44,25 @@ const MyProfileDiaries: NextPage = () => {
   );
 };
 
-export const getServerSideProps: GetServerSideProps = async (context) => {
-  const { req, res } = context;
-  const session = await getServerSession(req, res, authOptions);
+export const getServerSideProps = getServerSidePropsWithAuth(
+  async (context: GetServerSidePropsContext) => {
+    const { user } = context;
 
-  if (session === null) {
-    return {
-      redirect: {
-        destination: PAGE_PATH.account.login,
-        permanent: false,
+    const { username, accessToken } = user as User;
+
+    const headers = {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
       },
     };
-  }
 
-  const { username, accessToken } = session.user;
+    const queryClient = new QueryClient();
+    await queryClient.prefetchQuery([queryKeys.users, username], async () => {
+      return await api.getProfileByUsername({ username, config: headers });
+    });
 
-  const headers = {
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-    },
-  };
-
-  const queryClient = new QueryClient();
-  await queryClient.prefetchQuery([queryKeys.users, username], async () => {
-    return await api.getProfileByUsername({ username, config: headers });
-  });
-  return { props: { dehydratedState: dehydrate(queryClient), session } };
-};
+    return { props: { dehydratedState: dehydrate(queryClient), user } };
+  },
+);
 
 export default MyProfileDiaries;

--- a/src/pages/profile/edit.tsx
+++ b/src/pages/profile/edit.tsx
@@ -3,11 +3,11 @@ import { QueryClient, dehydrate } from '@tanstack/react-query';
 import { isAxiosError } from 'axios';
 
 import { useRouter } from 'next/router';
-import { getServerSession } from 'next-auth';
 import { useSession } from 'next-auth/react';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useForm } from 'react-hook-form';
-import type { GetServerSideProps, NextPage } from 'next';
+import type { GetServerSidePropsContext, NextPage } from 'next';
+import type { User } from 'next-auth';
 import type { SubmitHandler } from 'react-hook-form';
 import type { EditProfileForm } from 'types/profile';
 import type {
@@ -28,7 +28,6 @@ import {
 } from 'components/layouts';
 import { NoLinkProfileImage, SelectProfileImage } from 'components/profile';
 import { PAGE_PATH } from 'constants/common';
-import { SERVER_SIDE_PROPS } from 'constants/server';
 import { queryKeys } from 'constants/services';
 import {
   ERROR_MESSAGE,
@@ -36,38 +35,39 @@ import {
   VALID_VALUE,
 } from 'constants/validation';
 import { useEditProfile } from 'hooks/services';
-import { authOptions } from 'pages/api/auth/[...nextauth]';
+import { getServerSidePropsWithAuth } from 'lib/auth';
 import { ScreenReaderOnly } from 'styles';
 import { errorResponseMessage } from 'utils';
 
-const ProfileEditPage: NextPage = () => {
+const ProfileEditPage: NextPage<{ user: User }> = ({ user }) => {
+  const { email, username, imgUrl } = user;
+
   const router = useRouter();
-  const { data: session, update } = useSession();
+  const { update } = useSession();
   const {
     register,
     getValues,
-    setValue,
     formState: { errors, isValid },
     setError,
     handleSubmit,
   } = useForm<EditProfileForm>({
     mode: 'onChange',
     defaultValues: {
-      email: session?.user.email !== null ? session?.user.email : '',
-      username: session?.user.username !== null ? session?.user.username : '',
-      imgUrl: session?.user.imgUrl !== null ? session?.user.imgUrl : '',
+      email,
+      username,
+      imgUrl,
     },
   });
 
   const [successDuplicateCheckUsername, setSuccessDuplicateCheckUsername] =
     useState<SuccessResponse<OnlyMessageResponse> | undefined>(undefined);
-  const [previewImage, setPreviewImage] = useState<string>(getValues('imgUrl'));
+  const [previewImage, setPreviewImage] = useState<string>(imgUrl);
 
-  const editProfileMutation = useEditProfile(session?.user.username as string);
+  const editProfileMutation = useEditProfile(username);
 
   const handleDuplicateCheckUsername = async () => {
     const { username } = getValues();
-    const currentUsername = session?.user.username;
+    const currentUsername = user.username;
 
     if (currentUsername === username) {
       const data = {
@@ -97,14 +97,20 @@ const ProfileEditPage: NextPage = () => {
     }
   };
 
-  const onSubmit: SubmitHandler<EditProfileForm> = async (data) => {
+  const onSubmit: SubmitHandler<EditProfileForm> = (data) => {
     try {
       const { username, imgUrl } = data;
 
-      editProfileMutation({ username, imgUrl });
-      void update({ username, imgUrl });
-
-      await router.replace(PAGE_PATH.profile.index);
+      // TODO: 프로필 수정 시 동작 확인 필요, 현재 사용 중인 닉네임일 경우 서버 처리 수정 필요
+      editProfileMutation(
+        { username, imgUrl },
+        {
+          onSuccess: async () => {
+            await update({ username, imgUrl });
+            await router.replace(PAGE_PATH.profile.index);
+          },
+        },
+      );
     } catch (error) {
       if (isAxiosError<ErrorResponse>(error)) {
         // TODO: 에러 처리
@@ -112,12 +118,6 @@ const ProfileEditPage: NextPage = () => {
       }
     }
   };
-
-  useEffect(() => {
-    setValue('imgUrl', previewImage);
-  }, [previewImage, setValue]);
-
-  if (session === null) return <div>로그인이 필요합니다.</div>; // TODO: 로그인 페이지로 이동 모달 생성하여 적용하기
 
   return (
     <>
@@ -140,7 +140,7 @@ const ProfileEditPage: NextPage = () => {
           <NoLinkProfileImage
             size="xl"
             src={previewImage}
-            username={session.user.username}
+            username={username}
           />
           <SelectProfileImage
             previewImage={previewImage}
@@ -201,28 +201,28 @@ const ProfileEditPage: NextPage = () => {
   );
 };
 
-export const getServerSideProps: GetServerSideProps = async (context) => {
-  const { req, res } = context;
-  const session = await getServerSession(req, res, authOptions);
+export const getServerSideProps = getServerSidePropsWithAuth(
+  async (context: GetServerSidePropsContext) => {
+    const { user } = context;
 
-  if (session === null) {
-    return SERVER_SIDE_PROPS.REDIRECT_LOGIN;
-  }
+    const { username, accessToken } = user as User;
 
-  const { username, accessToken } = session.user;
+    const headers = {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    };
 
-  const headers = {
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-    },
-  };
-
-  const queryClient = new QueryClient();
-  await queryClient.prefetchQuery([queryKeys.badges, username], async () => {
-    return await api.getBadgesByUsername({ username, config: headers });
-  });
-  return { props: { dehydratedState: dehydrate(queryClient), session } };
-};
+    const queryClient = new QueryClient();
+    await queryClient.prefetchQuery(
+      [queryKeys.badges, 'username'],
+      async () => {
+        return await api.getBadgesByUsername({ username, config: headers });
+      },
+    );
+    return { props: { dehydratedState: dehydrate(queryClient), user } };
+  },
+);
 
 export default ProfileEditPage;
 

--- a/src/pages/profile/edit.tsx
+++ b/src/pages/profile/edit.tsx
@@ -39,7 +39,11 @@ import { getServerSidePropsWithAuth } from 'lib/auth';
 import { ScreenReaderOnly } from 'styles';
 import { errorResponseMessage } from 'utils';
 
-const ProfileEditPage: NextPage<{ user: User }> = ({ user }) => {
+interface ProfileEditPageProps {
+  user: User;
+}
+
+const ProfileEditPage: NextPage<ProfileEditPageProps> = ({ user }) => {
   const { email, username, imgUrl } = user;
 
   const router = useRouter();

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -6,7 +6,11 @@ import { ActivitiesContainer, ProfileLayout } from 'components/profile';
 import { queryKeys } from 'constants/services';
 import { getServerSidePropsWithAuth } from 'lib/auth';
 
-const MyProfile: NextPage<{ user: User }> = ({ user }) => {
+interface MyProfileProps {
+  user: User;
+}
+
+const MyProfile: NextPage<MyProfileProps> = ({ user }) => {
   const { username } = user;
 
   return (

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -1,56 +1,48 @@
 import { QueryClient, dehydrate } from '@tanstack/react-query';
-import { getServerSession } from 'next-auth';
-import { useSession } from 'next-auth/react';
-import type { GetServerSideProps, NextPage } from 'next';
+import type { GetServerSidePropsContext, NextPage } from 'next';
+import type { User } from 'next-auth';
 import * as api from 'api';
 import { ActivitiesContainer, ProfileLayout } from 'components/profile';
-import { SERVER_SIDE_PROPS } from 'constants/server';
 import { queryKeys } from 'constants/services';
-import { authOptions } from 'pages/api/auth/[...nextauth]';
+import { getServerSidePropsWithAuth } from 'lib/auth';
 
-const MyProfile: NextPage = () => {
-  const { data: session } = useSession();
-
-  if (session === null) return <div>로그인이 필요합니다.</div>; // TODO:
+const MyProfile: NextPage<{ user: User }> = ({ user }) => {
+  const { username } = user;
 
   return (
-    <ProfileLayout isMyProfile username={session.user.username}>
-      <ActivitiesContainer
-        title="프로필 - 활동"
-        username={session.user.username}
-      />
+    <ProfileLayout isMyProfile username={username}>
+      <ActivitiesContainer title="프로필 - 활동" username={username} />
     </ProfileLayout>
   );
 };
 
-export const getServerSideProps: GetServerSideProps = async (context) => {
-  const { req, res } = context;
-  const session = await getServerSession(req, res, authOptions);
+export const getServerSideProps = getServerSidePropsWithAuth(
+  async (context: GetServerSidePropsContext) => {
+    const { user } = context;
 
-  if (session === null) {
-    return SERVER_SIDE_PROPS.REDIRECT_LOGIN;
-  }
+    const { username, accessToken } = user as User;
 
-  const { username, accessToken } = session.user;
+    const headers = {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    };
 
-  const headers = {
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-    },
-  };
+    const queryClient = new QueryClient();
 
-  const queryClient = new QueryClient();
-  await queryClient.prefetchQuery([queryKeys.users, username], async () => {
-    return await api.getProfileByUsername({ username, config: headers });
-  });
-  await queryClient.prefetchQuery([queryKeys.badges, username], async () => {
-    return await api.getBadgesByUsername({
-      username,
-      onlyPinned: true,
-      config: headers,
+    await queryClient.prefetchQuery([queryKeys.users, username], async () => {
+      return await api.getProfileByUsername({ username, config: headers });
     });
-  });
-  return { props: { dehydratedState: dehydrate(queryClient), session } };
-};
+    await queryClient.prefetchQuery([queryKeys.badges, username], async () => {
+      return await api.getBadgesByUsername({
+        username,
+        onlyPinned: true,
+        config: headers,
+      });
+    });
+
+    return { props: { dehydratedState: dehydrate(queryClient), user } };
+  },
+);
 
 export default MyProfile;

--- a/src/pages/search/[keyword].tsx
+++ b/src/pages/search/[keyword].tsx
@@ -16,7 +16,11 @@ import { useDiaries } from 'hooks/services';
 import { getServerSidePropsWithAuth } from 'lib/auth';
 import { getQueryParams } from 'utils';
 
-const SearchResultPage: NextPage<{ keyword: string }> = ({ keyword }) => {
+interface SearchResultPageProps {
+  keyword: string;
+}
+
+const SearchResultPage: NextPage<SearchResultPageProps> = ({ keyword }) => {
   const [sortOptions, setSortOptions] = useState<SortByOption[]>([
     ...INITIAL_SORT_BY_LIST,
   ]);

--- a/src/pages/search/[keyword].tsx
+++ b/src/pages/search/[keyword].tsx
@@ -14,6 +14,7 @@ import { INITIAL_SORT_BY_LIST } from 'constants/search';
 import { useIntersectionObserver } from 'hooks/common';
 import { useDiaries } from 'hooks/services';
 import { getServerSidePropsWithAuth } from 'lib/auth';
+import { getQueryParams } from 'utils';
 
 const SearchResultPage: NextPage<{ keyword: string }> = ({ keyword }) => {
   const [sortOptions, setSortOptions] = useState<SortByOption[]>([
@@ -77,7 +78,7 @@ const SearchResultPage: NextPage<{ keyword: string }> = ({ keyword }) => {
 
 export const getServerSideProps = getServerSidePropsWithAuth((context) => {
   const { query } = context;
-  const keyword = query?.keyword as string;
+  const [keyword] = getQueryParams(query.keyword);
 
   return { props: { keyword } };
 });

--- a/src/pages/search/[keyword].tsx
+++ b/src/pages/search/[keyword].tsx
@@ -1,12 +1,7 @@
 import styled from '@emotion/styled';
-import { getServerSession } from 'next-auth';
 import { useMemo, useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
-import type {
-  GetServerSideProps,
-  InferGetServerSidePropsType,
-  NextPage,
-} from 'next';
+import type { NextPage } from 'next';
 import type { SearchForm, SortByOption } from 'types/search';
 import { ObserverTarget, Seo } from 'components/common';
 import { DiariesContainer } from 'components/diary';
@@ -15,15 +10,12 @@ import {
   SearchHeader,
   SearchResultHeader,
 } from 'components/search';
-import { PAGE_PATH } from 'constants/common';
 import { INITIAL_SORT_BY_LIST } from 'constants/search';
 import { useIntersectionObserver } from 'hooks/common';
 import { useDiaries } from 'hooks/services';
-import { authOptions } from 'pages/api/auth/[...nextauth]';
+import { getServerSidePropsWithAuth } from 'lib/auth';
 
-const SearchResultPage: NextPage<
-  InferGetServerSidePropsType<typeof getServerSideProps>
-> = ({ keyword }) => {
+const SearchResultPage: NextPage<{ keyword: string }> = ({ keyword }) => {
   const [sortOptions, setSortOptions] = useState<SortByOption[]>([
     ...INITIAL_SORT_BY_LIST,
   ]);
@@ -82,23 +74,13 @@ const SearchResultPage: NextPage<
     </>
   );
 };
-export const getServerSideProps = (async (context) => {
-  const { req, res, params } = context;
-  const keyword = params?.keyword as string;
 
-  const session = await getServerSession(req, res, authOptions);
-
-  if (session === null) {
-    return {
-      redirect: {
-        destination: PAGE_PATH.account.login,
-        permanent: false,
-      },
-    };
-  }
+export const getServerSideProps = getServerSidePropsWithAuth((context) => {
+  const { query } = context;
+  const keyword = query?.keyword as string;
 
   return { props: { keyword } };
-}) satisfies GetServerSideProps;
+});
 
 export default SearchResultPage;
 

--- a/src/types/next.d.ts
+++ b/src/types/next.d.ts
@@ -1,7 +1,8 @@
 import type { DehydratedState } from '@tanstack/react-query';
 import type { NextComponentType, NextPageContext } from 'next';
 import type { Router } from 'next/router';
-import type { Session } from 'next-auth';
+import type { GetServerSidePropsContext as DefaultGetServerSidePropsContext } from 'next/types';
+import type { Session, User } from 'next-auth';
 
 declare module 'next/app' {
   interface AppProps<P = Record<string, unknown>> {
@@ -14,5 +15,14 @@ declare module 'next/app' {
       session?: Session;
       dehydratedState: DehydratedState;
     };
+  }
+}
+
+declare module 'next' {
+  interface GetServerSidePropsContext<
+    Q extends ParsedUrlQuery = ParsedUrlQuery,
+    D = PreviewData,
+  > extends DefaultGetServerSidePropsContext<Q, D> {
+    user?: User;
   }
 }


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #261 

<br />

## 🗒 작업 목록

- [x] `getServerSidePropsWithAuth` handler를 생성하기 위한 `GetServerSidePropsContext` 타입 확장
- [x] `getServerSidePropsWithAuth` handler 생성
- [x] `getServerSideProps`를 사용하고 있는 각 페이지에 `getServerSidePropsWithAuth` 적용
- [x] `getServerSideProps` 내 누락된 `getQueryParams` 적용
- [x] 미적용 된 `SERVER_SIDE_PROPS` 상수 적용
- [x] 다른 사용자 배지 페이지에도 로그인 된 사용자의 배지 데이터가 적용되어 사용자에 따른 배지 데이터가 노출되도록 수정 

<br />

## 🧐 PR Point

- `getServerSession` 사용 시 `session`이 nullable 하여 `session === null` 인 경우, 로그인 페이지로 리다이렉트 하는 코드가 반복적으로 사용되었습니다.
- `GetServerSidePropsContext` 타입을 확장하여 `context`에 `user` 객체를 추가하고, 이를 각 페이지에서 `user` 값에 접근할 수 있도록 적용했습니다.
```typescript
export const getServerSidePropsWithAuth =
  <P extends Record<string, unknown>>(getServerSideProps: WithAuthOptions<P>) =>
  async (context: GetServerSidePropsContext) => {
    const { req, res } = context;
    const session = await getServerSession(req, res, authOptions);

    if (session === null) {
      return SERVER_SIDE_PROPS.REDIRECT_LOGIN;
    }

    // context에 user 객체를 할당하여 전달
    context.user = session.user;

    const serverSideProps = await getServerSideProps(context);

    return { ...serverSideProps };
  };
```

```typescript
// getServerSidePropsWithAuth 사용 방법

// GetServerSidePropsContext는 'next'에서 import 해야합니다.
// 'next/type'으로 import 할 경우 에러가 발생합니다.
import type { GetServerSidePropsContext } from 'next';

export const getServerSideProps = getServerSidePropsWithAuth(
  async (context: GetServerSidePropsContext) => {
    const { user, query } = context;
    const [username] = getQueryParams(query.username);

    // GetServerSidePropsContext 타입 확장 시 "user?: User" 로 적용하여 User 타입 단언이 필요합니다.
    const { accessToken } = user as User;
    .... 코드 중략
}
```

<br />

## 💥 Trouble Shooting
- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크

- 내용을 입력해주세요.

<br />

## 📚 참고

- [Next-Auth를 사용하여 손쉽게 OAuth기반 권한관리하기 + RefreshToken + Private Route](https://jeongyunlog.netlify.app/develop/nextjs/next-auth/#serverside-securing-pages)

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다. 
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
