### PR TITLE
useMutation 코드 개선

### DIFF
--- a/src/components/account/RegisterProfileImage.tsx
+++ b/src/components/account/RegisterProfileImage.tsx
@@ -23,12 +23,7 @@ export const RegisterProfileImage = () => {
 
   const { setValue } = useFormContext<RegisterForm>();
 
-  const imageUploadMutation = useImageUpload({
-    path: 'users',
-    onSuccess: (imgUrl: string) => {
-      setPreviewImage(imgUrl);
-    },
-  });
+  const imageUploadMutation = useImageUpload({ path: 'users' });
 
   useEffect(() => {
     setValue('imgUrl', previewImage);
@@ -37,16 +32,19 @@ export const RegisterProfileImage = () => {
   const handleImageFile: ChangeEventHandler<HTMLInputElement> = (e) => {
     const { files } = e.target;
     if (files !== null) {
-      try {
-        const imageFormData = new FormData();
-        imageFormData.append('image', files[0]);
+      const imageFormData = new FormData();
+      imageFormData.append('image', files[0]);
 
-        imageUploadMutation(imageFormData);
-      } catch (error) {
-        if (isAxiosError<ErrorResponse>(error)) {
-          console.log(error);
-        }
-      }
+      imageUploadMutation(imageFormData, {
+        onSuccess: (imgUrl) => {
+          setPreviewImage(imgUrl);
+        },
+        onError: (error) => {
+          if (isAxiosError<ErrorResponse>(error)) {
+            console.log(error);
+          }
+        },
+      });
     }
   };
 

--- a/src/components/account/RegisterProfileImage.tsx
+++ b/src/components/account/RegisterProfileImage.tsx
@@ -1,10 +1,8 @@
 import styled from '@emotion/styled';
 import { isAxiosError } from 'axios';
 import Image from 'next/image';
-import { useEffect, useRef, useState } from 'react';
-import { useFormContext } from 'react-hook-form';
+import { useRef, useState } from 'react';
 import type { MouseEventHandler, ChangeEventHandler } from 'react';
-import type { RegisterForm } from 'types/register';
 import type { ErrorResponse } from 'types/response';
 import { ImagePickerIcon } from 'assets/icons';
 import { DEFAULT_PROFILE_IMAGES } from 'constants/profile';
@@ -21,13 +19,7 @@ export const RegisterProfileImage = () => {
   );
   const imageRef = useRef<Array<HTMLImageElement | null>>([]);
 
-  const { setValue } = useFormContext<RegisterForm>();
-
   const imageUploadMutation = useImageUpload({ path: 'users' });
-
-  useEffect(() => {
-    setValue('imgUrl', previewImage);
-  }, [previewImage, setValue]);
 
   const handleImageFile: ChangeEventHandler<HTMLInputElement> = (e) => {
     const { files } = e.target;

--- a/src/components/account/RegisterProfileImage.tsx
+++ b/src/components/account/RegisterProfileImage.tsx
@@ -19,7 +19,7 @@ export const RegisterProfileImage = () => {
   );
   const imageRef = useRef<Array<HTMLImageElement | null>>([]);
 
-  const imageUploadMutation = useImageUpload({ path: 'users' });
+  const { mutate: imageUploadMutate } = useImageUpload({ path: 'users' });
 
   const handleImageFile: ChangeEventHandler<HTMLInputElement> = (e) => {
     const { files } = e.target;
@@ -27,7 +27,7 @@ export const RegisterProfileImage = () => {
       const imageFormData = new FormData();
       imageFormData.append('image', files[0]);
 
-      imageUploadMutation(imageFormData, {
+      imageUploadMutate(imageFormData, {
         onSuccess: (imgUrl) => {
           setPreviewImage(imgUrl);
         },

--- a/src/components/badge/BadgesContainer.tsx
+++ b/src/components/badge/BadgesContainer.tsx
@@ -20,14 +20,14 @@ export const BadgesContainer = () => {
   const changePinnedBadgeMutation = useChangePinnedBadge();
 
   const handleChangePinned = (id: string) => {
-    try {
-      changePinnedBadgeMutation(id);
-    } catch (error) {
-      if (isAxiosError<ErrorResponse>(error)) {
-        // TODO: 에러 처리 필요
-        alert(errorResponseMessage(error.response?.data.message));
-      }
-    }
+    changePinnedBadgeMutation(id, {
+      onError: (error) => {
+        if (isAxiosError<ErrorResponse>(error)) {
+          // TODO: 에러 처리 필요
+          alert(errorResponseMessage(error.response?.data.message));
+        }
+      },
+    });
   };
 
   if (badgesData === undefined) return <FullPageLoading />;

--- a/src/components/badge/BadgesContainer.tsx
+++ b/src/components/badge/BadgesContainer.tsx
@@ -17,10 +17,10 @@ export const BadgesContainer = () => {
   const { badgesData } = useBadges({
     username: session?.user.username as string,
   });
-  const changePinnedBadgeMutation = useChangePinnedBadge();
+  const { mutate: changePinnedBadgeMutate } = useChangePinnedBadge();
 
   const handleChangePinned = (id: string) => {
-    changePinnedBadgeMutation(id, {
+    changePinnedBadgeMutate(id, {
       onError: (error) => {
         if (isAxiosError<ErrorResponse>(error)) {
           // TODO: 에러 처리 필요

--- a/src/components/comment/DiaryComment.tsx
+++ b/src/components/comment/DiaryComment.tsx
@@ -31,13 +31,16 @@ export const DiaryComment = ({ diaryComment, diaryId }: DiaryCommentProps) => {
   const isCommenter = commenter.id === session?.user.id;
 
   const handleDeleteComment = () => {
-    try {
-      deleteCommentMutation({ diaryId, commentId });
-    } catch (error) {
-      if (isAxiosError<ErrorResponse>(error)) {
-        alert(errorResponseMessage(error.response?.data.message));
-      }
-    }
+    deleteCommentMutation(
+      { diaryId, commentId },
+      {
+        onError: (error) => {
+          if (isAxiosError<ErrorResponse>(error)) {
+            alert(errorResponseMessage(error.response?.data.message));
+          }
+        },
+      },
+    );
   };
 
   return (

--- a/src/components/comment/DiaryComment.tsx
+++ b/src/components/comment/DiaryComment.tsx
@@ -25,13 +25,13 @@ export const DiaryComment = ({ diaryComment, diaryId }: DiaryCommentProps) => {
     useModal();
   const { ref, isVisible, setIsVisible } = useClickOutside();
 
-  const deleteCommentMutation = useDeleteComment(diaryId);
+  const { mutate: deleteCommentMutate } = useDeleteComment(diaryId);
 
   const { id: commentId, createdAt, comment, commenter } = diaryComment;
   const isCommenter = commenter.id === session?.user.id;
 
   const handleDeleteComment = () => {
-    deleteCommentMutation(
+    deleteCommentMutate(
       { diaryId, commentId },
       {
         onError: (error) => {

--- a/src/components/comment/DiaryCommentInput.tsx
+++ b/src/components/comment/DiaryCommentInput.tsx
@@ -30,7 +30,7 @@ export const DiaryCommentInput = ({ diaryId }: DiaryCommentInputProps) => {
   } = useForm<CommentForm>({ mode: 'onChange' });
   const { comment: commentValue } = getValues();
   const { comment: commentError } = errors;
-  const writeCommentMutation = useWriteComment(diaryId);
+  const { mutate: writeCommentMutate } = useWriteComment(diaryId);
 
   useEffect(() => {
     if (commentError?.type === 'maxLength') {
@@ -49,7 +49,7 @@ export const DiaryCommentInput = ({ diaryId }: DiaryCommentInputProps) => {
   const onSubmit: SubmitHandler<CommentForm> = (data) => {
     const { comment } = data;
 
-    writeCommentMutation(
+    writeCommentMutate(
       { diaryId, comment },
       {
         onSuccess: () => {

--- a/src/components/comment/DiaryCommentInput.tsx
+++ b/src/components/comment/DiaryCommentInput.tsx
@@ -48,14 +48,20 @@ export const DiaryCommentInput = ({ diaryId }: DiaryCommentInputProps) => {
 
   const onSubmit: SubmitHandler<CommentForm> = (data) => {
     const { comment } = data;
-    try {
-      writeCommentMutation({ diaryId, comment });
-      reset();
-    } catch (error) {
-      if (isAxiosError<ErrorResponse>(error)) {
-        alert(errorResponseMessage(error.response?.data.message));
-      }
-    }
+
+    writeCommentMutation(
+      { diaryId, comment },
+      {
+        onSuccess: () => {
+          reset();
+        },
+        onError: (error) => {
+          if (isAxiosError<ErrorResponse>(error)) {
+            alert(errorResponseMessage(error.response?.data.message));
+          }
+        },
+      },
+    );
   };
 
   return (

--- a/src/components/diary/Diary.tsx
+++ b/src/components/diary/Diary.tsx
@@ -38,11 +38,7 @@ const Diary = ({
   const isHighlightKeyword = highlightKeyword !== undefined;
 
   const handleFavorite = useHandleFavorite({ isFavorite, id });
-  const handleBookmark = useHandleBookmark({
-    isBookmark,
-    id,
-    username: author.username,
-  });
+  const handleBookmark = useHandleBookmark({ isBookmark, id });
 
   return (
     <Container>

--- a/src/components/diary/DiaryDetailContainer.tsx
+++ b/src/components/diary/DiaryDetailContainer.tsx
@@ -27,11 +27,7 @@ export const DiaryDetailContainer = ({
   isFavorite,
 }: DiaryDetail) => {
   const handleFavorite = useHandleFavorite({ isFavorite, id });
-  const handleBookmark = useHandleBookmark({
-    isBookmark,
-    id,
-    username: author.username,
-  });
+  const handleBookmark = useHandleBookmark({ isBookmark, id });
 
   return (
     <Container>

--- a/src/components/profile/SelectProfileImage.tsx
+++ b/src/components/profile/SelectProfileImage.tsx
@@ -24,7 +24,7 @@ export const SelectProfileImage = ({
   setPreviewImage,
 }: SelectProfileImageProps) => {
   const imageRef = useRef<Array<HTMLImageElement | null>>([]);
-  const imageUploadMutation = useImageUpload({ path: 'users' });
+  const { mutate: imageUploadMutate } = useImageUpload({ path: 'users' });
 
   const handleImageFile: ChangeEventHandler<HTMLInputElement> = (e) => {
     const { files } = e.target;
@@ -32,7 +32,7 @@ export const SelectProfileImage = ({
       const imageFormData = new FormData();
       imageFormData.append('image', files[0]);
 
-      imageUploadMutation(imageFormData, {
+      imageUploadMutate(imageFormData, {
         onSuccess: (imgUrl) => {
           setPreviewImage(imgUrl);
         },

--- a/src/components/profile/SelectProfileImage.tsx
+++ b/src/components/profile/SelectProfileImage.tsx
@@ -24,26 +24,24 @@ export const SelectProfileImage = ({
   setPreviewImage,
 }: SelectProfileImageProps) => {
   const imageRef = useRef<Array<HTMLImageElement | null>>([]);
-  const imageUploadMutation = useImageUpload({
-    path: 'users',
-    onSuccess: (imgUrl: string) => {
-      setPreviewImage(imgUrl);
-    },
-  });
+  const imageUploadMutation = useImageUpload({ path: 'users' });
 
   const handleImageFile: ChangeEventHandler<HTMLInputElement> = (e) => {
     const { files } = e.target;
     if (files !== null) {
-      try {
-        const imageFormData = new FormData();
-        imageFormData.append('image', files[0]);
+      const imageFormData = new FormData();
+      imageFormData.append('image', files[0]);
 
-        imageUploadMutation(imageFormData);
-      } catch (error) {
-        if (isAxiosError<ErrorResponse>(error)) {
-          console.log(error);
-        }
-      }
+      imageUploadMutation(imageFormData, {
+        onSuccess: (imgUrl) => {
+          setPreviewImage(imgUrl);
+        },
+        onError: (error) => {
+          if (isAxiosError<ErrorResponse>(error)) {
+            console.log(error);
+          }
+        },
+      });
     }
   };
 

--- a/src/hooks/services/common/useHandleBookmark.ts
+++ b/src/hooks/services/common/useHandleBookmark.ts
@@ -1,20 +1,14 @@
 import { useBookmarkDiary, useCancelBookmarkDiary } from '..';
-import type { User } from 'next-auth';
 import type { MouseEventHandler } from 'react';
 import type { DiaryDetail } from 'types/diary';
 
 export const useHandleBookmark = ({
   isBookmark,
   id,
-  username,
-}: Pick<DiaryDetail, 'id' | 'isBookmark'> & Pick<User, 'username'>) => {
-  const { mutate: bookmarkMutate } = useBookmarkDiary({
-    diaryId: id,
-    username,
-  });
+}: Pick<DiaryDetail, 'id' | 'isBookmark'>) => {
+  const { mutate: bookmarkMutate } = useBookmarkDiary({ diaryId: id });
   const { mutate: cancelBookmarkMutate } = useCancelBookmarkDiary({
     diaryId: id,
-    username,
   });
 
   const handleBookmark: MouseEventHandler<HTMLButtonElement> = () => {

--- a/src/hooks/services/common/useHandleBookmark.ts
+++ b/src/hooks/services/common/useHandleBookmark.ts
@@ -8,14 +8,17 @@ export const useHandleBookmark = ({
   id,
   username,
 }: Pick<DiaryDetail, 'id' | 'isBookmark'> & Pick<User, 'username'>) => {
-  const bookmarkMutation = useBookmarkDiary(id, username);
+  const { mutate: bookmarkMutate } = useBookmarkDiary({
+    diaryId: id,
+    username,
+  });
   const cancelBookmarkMutation = useCancelBookmarkDiary(id, username);
 
   const handleBookmark: MouseEventHandler<HTMLButtonElement> = () => {
     if (isBookmark) {
       cancelBookmarkMutation();
     } else {
-      bookmarkMutation();
+      bookmarkMutate();
     }
   };
 

--- a/src/hooks/services/common/useHandleBookmark.ts
+++ b/src/hooks/services/common/useHandleBookmark.ts
@@ -12,11 +12,14 @@ export const useHandleBookmark = ({
     diaryId: id,
     username,
   });
-  const cancelBookmarkMutation = useCancelBookmarkDiary(id, username);
+  const { mutate: cancelBookmarkMutate } = useCancelBookmarkDiary({
+    diaryId: id,
+    username,
+  });
 
   const handleBookmark: MouseEventHandler<HTMLButtonElement> = () => {
     if (isBookmark) {
-      cancelBookmarkMutation();
+      cancelBookmarkMutate();
     } else {
       bookmarkMutate();
     }

--- a/src/hooks/services/common/useHandleFavorite.ts
+++ b/src/hooks/services/common/useHandleFavorite.ts
@@ -7,11 +7,11 @@ export const useHandleFavorite = ({
   id,
 }: Pick<DiaryDetail, 'id' | 'isFavorite'>) => {
   const favoriteMutation = useFavoriteDiary(id);
-  const cancelFavoriteMutation = useCancelFavoriteDiary(id);
+  const { mutate: cancelFavoriteMutate } = useCancelFavoriteDiary(id);
 
   const handleFavorite: MouseEventHandler<HTMLButtonElement> = () => {
     if (isFavorite) {
-      cancelFavoriteMutation();
+      cancelFavoriteMutate();
     } else {
       favoriteMutation();
     }

--- a/src/hooks/services/common/useHandleFavorite.ts
+++ b/src/hooks/services/common/useHandleFavorite.ts
@@ -6,14 +6,14 @@ export const useHandleFavorite = ({
   isFavorite,
   id,
 }: Pick<DiaryDetail, 'id' | 'isFavorite'>) => {
-  const favoriteMutation = useFavoriteDiary(id);
+  const { mutate: favoriteMutate } = useFavoriteDiary(id);
   const { mutate: cancelFavoriteMutate } = useCancelFavoriteDiary(id);
 
   const handleFavorite: MouseEventHandler<HTMLButtonElement> = () => {
     if (isFavorite) {
       cancelFavoriteMutate();
     } else {
-      favoriteMutation();
+      favoriteMutate();
     }
   };
 

--- a/src/hooks/services/mutations/useBookmarkDiary.ts
+++ b/src/hooks/services/mutations/useBookmarkDiary.ts
@@ -4,20 +4,16 @@ import { queryKeys } from 'constants/services';
 
 interface UseBookmarkDiaryProps {
   diaryId: string;
-  username: string;
 }
 
-export const useBookmarkDiary = ({
-  diaryId,
-  username,
-}: UseBookmarkDiaryProps) => {
+export const useBookmarkDiary = ({ diaryId }: UseBookmarkDiaryProps) => {
   const queryClient = useQueryClient();
 
   return useMutation(async () => await api.bookmarkDiary(diaryId), {
     onSuccess: async () => {
       await queryClient.invalidateQueries([queryKeys.diaries]);
       await queryClient.invalidateQueries([queryKeys.diaries, diaryId]);
-      await queryClient.invalidateQueries([queryKeys.bookmark, username]);
+      await queryClient.invalidateQueries([queryKeys.bookmark, diaryId]);
     },
   });
 };

--- a/src/hooks/services/mutations/useBookmarkDiary.ts
+++ b/src/hooks/services/mutations/useBookmarkDiary.ts
@@ -2,15 +2,22 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import * as api from 'api';
 import { queryKeys } from 'constants/services';
 
-export const useBookmarkDiary = (diaryId: string, username: string) => {
+interface UseBookmarkDiaryProps {
+  diaryId: string;
+  username: string;
+}
+
+export const useBookmarkDiary = ({
+  diaryId,
+  username,
+}: UseBookmarkDiaryProps) => {
   const queryClient = useQueryClient();
-  const { mutate } = useMutation(async () => await api.bookmarkDiary(diaryId), {
+
+  return useMutation(async () => await api.bookmarkDiary(diaryId), {
     onSuccess: async () => {
       await queryClient.invalidateQueries([queryKeys.diaries]);
       await queryClient.invalidateQueries([queryKeys.diaries, diaryId]);
       await queryClient.invalidateQueries([queryKeys.bookmark, username]);
     },
   });
-
-  return mutate;
 };

--- a/src/hooks/services/mutations/useCancelBookmarkDiary.ts
+++ b/src/hooks/services/mutations/useCancelBookmarkDiary.ts
@@ -2,18 +2,22 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import * as api from 'api';
 import { queryKeys } from 'constants/services';
 
-export const useCancelBookmarkDiary = (diaryId: string, username: string) => {
-  const queryClient = useQueryClient();
-  const { mutate } = useMutation(
-    async () => await api.cancelBookmarkDiary(diaryId),
-    {
-      onSuccess: async () => {
-        await queryClient.invalidateQueries([queryKeys.diaries]);
-        await queryClient.invalidateQueries([queryKeys.diaries, diaryId]);
-        await queryClient.invalidateQueries([queryKeys.bookmark, username]);
-      },
-    },
-  );
+interface UseCancelBookmarkDiaryProps {
+  diaryId: string;
+  username: string;
+}
 
-  return mutate;
+export const useCancelBookmarkDiary = ({
+  diaryId,
+  username,
+}: UseCancelBookmarkDiaryProps) => {
+  const queryClient = useQueryClient();
+
+  return useMutation(async () => await api.cancelBookmarkDiary(diaryId), {
+    onSuccess: async () => {
+      await queryClient.invalidateQueries([queryKeys.diaries]);
+      await queryClient.invalidateQueries([queryKeys.diaries, diaryId]);
+      await queryClient.invalidateQueries([queryKeys.bookmark, username]);
+    },
+  });
 };

--- a/src/hooks/services/mutations/useCancelBookmarkDiary.ts
+++ b/src/hooks/services/mutations/useCancelBookmarkDiary.ts
@@ -4,12 +4,10 @@ import { queryKeys } from 'constants/services';
 
 interface UseCancelBookmarkDiaryProps {
   diaryId: string;
-  username: string;
 }
 
 export const useCancelBookmarkDiary = ({
   diaryId,
-  username,
 }: UseCancelBookmarkDiaryProps) => {
   const queryClient = useQueryClient();
 
@@ -17,7 +15,7 @@ export const useCancelBookmarkDiary = ({
     onSuccess: async () => {
       await queryClient.invalidateQueries([queryKeys.diaries]);
       await queryClient.invalidateQueries([queryKeys.diaries, diaryId]);
-      await queryClient.invalidateQueries([queryKeys.bookmark, username]);
+      await queryClient.invalidateQueries([queryKeys.bookmark, diaryId]);
     },
   });
 };

--- a/src/hooks/services/mutations/useCancelFavoriteDiary.ts
+++ b/src/hooks/services/mutations/useCancelFavoriteDiary.ts
@@ -4,15 +4,11 @@ import { queryKeys } from 'constants/services';
 
 export const useCancelFavoriteDiary = (diaryId: string) => {
   const queryClient = useQueryClient();
-  const { mutate } = useMutation(
-    async () => await api.cancelFavoriteDiary(diaryId),
-    {
-      onSuccess: async () => {
-        await queryClient.invalidateQueries([queryKeys.diaries]);
-        await queryClient.invalidateQueries([queryKeys.diaries, diaryId]);
-      },
-    },
-  );
 
-  return mutate;
+  return useMutation(async () => await api.cancelFavoriteDiary(diaryId), {
+    onSuccess: async () => {
+      await queryClient.invalidateQueries([queryKeys.diaries]);
+      await queryClient.invalidateQueries([queryKeys.diaries, diaryId]);
+    },
+  });
 };

--- a/src/hooks/services/mutations/useCancelFavoriteDiary.ts
+++ b/src/hooks/services/mutations/useCancelFavoriteDiary.ts
@@ -9,6 +9,7 @@ export const useCancelFavoriteDiary = (diaryId: string) => {
     onSuccess: async () => {
       await queryClient.invalidateQueries([queryKeys.diaries]);
       await queryClient.invalidateQueries([queryKeys.diaries, diaryId]);
+      await queryClient.invalidateQueries([queryKeys.bookmark]);
     },
   });
 };

--- a/src/hooks/services/mutations/useChangePinnedBadge.ts
+++ b/src/hooks/services/mutations/useChangePinnedBadge.ts
@@ -4,7 +4,8 @@ import { queryKeys } from 'constants/services';
 
 export const useChangePinnedBadge = () => {
   const queryClient = useQueryClient();
-  const { mutate } = useMutation(
+
+  return useMutation(
     async (badgeId: string) =>
       await api.patchPinnedBadgeByBadgeId({ id: badgeId }),
     {
@@ -13,6 +14,4 @@ export const useChangePinnedBadge = () => {
       },
     },
   );
-
-  return mutate;
 };

--- a/src/hooks/services/mutations/useDeleteComment.ts
+++ b/src/hooks/services/mutations/useDeleteComment.ts
@@ -5,7 +5,8 @@ import { queryKeys } from 'constants/services';
 
 export const useDeleteComment = (diaryId: string) => {
   const queryClient = useQueryClient();
-  const { mutate } = useMutation(
+
+  return useMutation(
     async ({ diaryId, commentId }: DeleteCommentRequest) =>
       await api.deleteComments({
         diaryId,
@@ -18,6 +19,4 @@ export const useDeleteComment = (diaryId: string) => {
       },
     },
   );
-
-  return mutate;
 };

--- a/src/hooks/services/mutations/useDeleteDiary.ts
+++ b/src/hooks/services/mutations/useDeleteDiary.ts
@@ -1,21 +1,11 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 import type { DeleteDiaryRequest } from 'types/diary';
 import * as api from 'api';
-import { queryKeys } from 'constants/services';
 
-export const useDeleteDiary = ({ id }: DeleteDiaryRequest) => {
-  const queryClient = useQueryClient();
-  const { mutate } = useMutation(
-    async ({ id }: DeleteDiaryRequest) => {
-      await api.deleteDiaryDetail({ id });
-    },
-    {
-      onSuccess: async () => {
-        await queryClient.invalidateQueries([queryKeys.diaries]);
-        await queryClient.invalidateQueries([queryKeys.diaries, id]);
-      },
-    },
-  );
+export const useDeleteDiary = () => {
+  const { mutate } = useMutation(async ({ id }: DeleteDiaryRequest) => {
+    await api.deleteDiaryDetail({ id });
+  });
 
   return mutate;
 };

--- a/src/hooks/services/mutations/useDeleteDiary.ts
+++ b/src/hooks/services/mutations/useDeleteDiary.ts
@@ -3,9 +3,7 @@ import type { DeleteDiaryRequest } from 'types/diary';
 import * as api from 'api';
 
 export const useDeleteDiary = () => {
-  const { mutate } = useMutation(async ({ id }: DeleteDiaryRequest) => {
+  return useMutation(async ({ id }: DeleteDiaryRequest) => {
     await api.deleteDiaryDetail({ id });
   });
-
-  return mutate;
 };

--- a/src/hooks/services/mutations/useEditDiary.ts
+++ b/src/hooks/services/mutations/useEditDiary.ts
@@ -5,7 +5,8 @@ import { queryKeys } from 'constants/services';
 
 export const useEditDiary = (id: string) => {
   const queryClient = useQueryClient();
-  const { mutate } = useMutation(
+
+  return useMutation(
     async ({ title, content, imgUrl, isPublic, id }: EditDiaryRequest) =>
       await api.editDiaryDetail({
         title,
@@ -20,6 +21,4 @@ export const useEditDiary = (id: string) => {
       },
     },
   );
-
-  return mutate;
 };

--- a/src/hooks/services/mutations/useEditProfile.ts
+++ b/src/hooks/services/mutations/useEditProfile.ts
@@ -5,7 +5,8 @@ import { queryKeys } from 'constants/services';
 
 export const useEditProfile = (username: string) => {
   const queryClient = useQueryClient();
-  const { mutate } = useMutation(
+
+  return useMutation(
     async ({ username, imgUrl }: EditProfileRequest) =>
       await api.editProfile({
         username,
@@ -17,6 +18,4 @@ export const useEditProfile = (username: string) => {
       },
     },
   );
-
-  return mutate;
 };

--- a/src/hooks/services/mutations/useFavoriteDiary.ts
+++ b/src/hooks/services/mutations/useFavoriteDiary.ts
@@ -4,12 +4,11 @@ import { queryKeys } from 'constants/services';
 
 export const useFavoriteDiary = (diaryId: string) => {
   const queryClient = useQueryClient();
-  const { mutate } = useMutation(async () => await api.favoriteDiary(diaryId), {
+
+  return useMutation(async () => await api.favoriteDiary(diaryId), {
     onSuccess: async () => {
       await queryClient.invalidateQueries([queryKeys.diaries]);
       await queryClient.invalidateQueries([queryKeys.diaries, diaryId]);
     },
   });
-
-  return mutate;
 };

--- a/src/hooks/services/mutations/useFavoriteDiary.ts
+++ b/src/hooks/services/mutations/useFavoriteDiary.ts
@@ -9,6 +9,7 @@ export const useFavoriteDiary = (diaryId: string) => {
     onSuccess: async () => {
       await queryClient.invalidateQueries([queryKeys.diaries]);
       await queryClient.invalidateQueries([queryKeys.diaries, diaryId]);
+      await queryClient.invalidateQueries([queryKeys.bookmark]);
     },
   });
 };

--- a/src/hooks/services/mutations/useImageUpload.ts
+++ b/src/hooks/services/mutations/useImageUpload.ts
@@ -6,7 +6,7 @@ interface useImageUploadProps {
 }
 
 export const useImageUpload = ({ path }: useImageUploadProps) => {
-  const { mutate } = useMutation(async (imageFormData: FormData) => {
+  return useMutation(async (imageFormData: FormData) => {
     const {
       data: {
         data: { imgUrl },
@@ -14,6 +14,4 @@ export const useImageUpload = ({ path }: useImageUploadProps) => {
     } = await api.uploadImage({ path, imageFormData });
     return imgUrl;
   });
-
-  return mutate;
 };

--- a/src/hooks/services/mutations/useImageUpload.ts
+++ b/src/hooks/services/mutations/useImageUpload.ts
@@ -3,25 +3,17 @@ import * as api from 'api';
 
 interface useImageUploadProps {
   path: 'users' | 'diaries';
-  onSuccess: (imgUrl: string) => void;
 }
 
-export const useImageUpload = ({ path, onSuccess }: useImageUploadProps) => {
-  const { mutate } = useMutation(
-    async (imageFormData: FormData) => {
-      const {
-        data: {
-          data: { imgUrl },
-        },
-      } = await api.uploadImage({ path, imageFormData });
-      return imgUrl;
-    },
-    {
-      onSuccess: (imgUrl) => {
-        onSuccess(imgUrl);
+export const useImageUpload = ({ path }: useImageUploadProps) => {
+  const { mutate } = useMutation(async (imageFormData: FormData) => {
+    const {
+      data: {
+        data: { imgUrl },
       },
-    },
-  );
+    } = await api.uploadImage({ path, imageFormData });
+    return imgUrl;
+  });
 
   return mutate;
 };

--- a/src/hooks/services/mutations/useRegisterUser.ts
+++ b/src/hooks/services/mutations/useRegisterUser.ts
@@ -3,7 +3,7 @@ import type { RegisterRequest } from 'types/register';
 import * as api from 'api';
 
 export const useRegisterUser = () => {
-  const { mutate } = useMutation(
+  return useMutation(
     async ({
       email,
       username,
@@ -20,6 +20,4 @@ export const useRegisterUser = () => {
       });
     },
   );
-
-  return mutate;
 };

--- a/src/hooks/services/mutations/useRegisterUser.ts
+++ b/src/hooks/services/mutations/useRegisterUser.ts
@@ -2,11 +2,7 @@ import { useMutation } from '@tanstack/react-query';
 import type { RegisterRequest } from 'types/register';
 import * as api from 'api';
 
-interface UseRegisterUserProps {
-  onSuccess: () => void;
-}
-
-export const useRegisterUser = ({ onSuccess }: UseRegisterUserProps) => {
+export const useRegisterUser = () => {
   const { mutate } = useMutation(
     async ({
       email,
@@ -23,11 +19,7 @@ export const useRegisterUser = ({ onSuccess }: UseRegisterUserProps) => {
         termsAgreementIdList,
       });
     },
-    {
-      onSuccess: () => {
-        onSuccess();
-      },
-    },
   );
+
   return mutate;
 };

--- a/src/hooks/services/mutations/useWriteComment.ts
+++ b/src/hooks/services/mutations/useWriteComment.ts
@@ -5,7 +5,8 @@ import { queryKeys } from 'constants/services';
 
 export const useWriteComment = (diaryId: string) => {
   const queryClient = useQueryClient();
-  const { mutate } = useMutation(
+
+  return useMutation(
     async ({ diaryId, comment }: WriteCommentRequest) =>
       await api.writeComment({
         diaryId,
@@ -18,6 +19,4 @@ export const useWriteComment = (diaryId: string) => {
       },
     },
   );
-
-  return mutate;
 };

--- a/src/hooks/services/mutations/useWriteDiary.ts
+++ b/src/hooks/services/mutations/useWriteDiary.ts
@@ -1,14 +1,12 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { useRouter } from 'next/router';
 import type { WriteDiaryRequest } from 'types/diary';
 import * as api from 'api';
-import { PAGE_PATH } from 'constants/common';
 import { queryKeys } from 'constants/services';
 
 export const useWriteDiary = () => {
-  const router = useRouter();
   const queryClient = useQueryClient();
-  const { mutate } = useMutation(
+
+  return useMutation(
     async ({ title, content, imgUrl, isPublic }: WriteDiaryRequest) => {
       const {
         data: { diary },
@@ -23,10 +21,7 @@ export const useWriteDiary = () => {
     {
       onSuccess: async (diary) => {
         await queryClient.invalidateQueries([queryKeys.diaries, diary.id]);
-        await router.replace(PAGE_PATH.diary.detail(diary.id));
       },
     },
   );
-
-  return mutate;
 };

--- a/src/pages/account/register.tsx
+++ b/src/pages/account/register.tsx
@@ -46,13 +46,7 @@ const Register: NextPage = () => {
     welcomeMessage: false,
   });
 
-  const registerMutation = useRegisterUser({
-    onSuccess: () => {
-      setRegisterStep((state) => {
-        return { ...state, welcomeMessage: true };
-      });
-    },
-  });
+  const registerMutation = useRegisterUser();
 
   const onSubmit: SubmitHandler<RegisterForm> = (data) => {
     if (registerStep.email)
@@ -78,25 +72,33 @@ const Register: NextPage = () => {
     }
 
     if (registerStep.termsAgreement) {
-      try {
-        const { email, username, password, imgUrl, termsAgreement } = data;
-        // NOTE: 동의한 약관 객체를 약관 ID 문자열 배열로 변환
-        const termsAgreementIdList = Object.entries(termsAgreement)
-          .filter(([_, value]) => value)
-          .map(([id, _]) => id) as TermsAgreementId[];
+      const { email, username, password, imgUrl, termsAgreement } = data;
+      // NOTE: 동의한 약관 객체를 약관 ID 문자열 배열로 변환
+      const termsAgreementIdList = Object.entries(termsAgreement)
+        .filter(([_, value]) => value)
+        .map(([id, _]) => id) as TermsAgreementId[];
 
-        registerMutation({
+      registerMutation(
+        {
           email,
           username,
           password,
           imgUrl,
           termsAgreementIdList,
-        });
-      } catch (error) {
-        if (isAxiosError<ErrorResponse>(error)) {
-          alert(errorResponseMessage(error.response?.data.message));
-        }
-      }
+        },
+        {
+          onSuccess: () => {
+            setRegisterStep((state) => {
+              return { ...state, welcomeMessage: true };
+            });
+          },
+          onError: (error) => {
+            if (isAxiosError<ErrorResponse>(error)) {
+              alert(errorResponseMessage(error.response?.data.message));
+            }
+          },
+        },
+      );
     }
   };
 

--- a/src/pages/account/register.tsx
+++ b/src/pages/account/register.tsx
@@ -18,13 +18,19 @@ import {
 
 import { Button, Seo } from 'components/common';
 import { HeaderTitle, Header, HeaderLeft } from 'components/layouts';
+import { DEFAULT_PROFILE_IMAGES } from 'constants/profile';
 import { queryKeys } from 'constants/services';
 import { Z_INDEX } from 'constants/styles';
 import { useRegisterUser } from 'hooks/services';
 import { errorResponseMessage } from 'utils';
 
 const Register: NextPage = () => {
-  const methods = useForm<RegisterForm>({ mode: 'onChange' });
+  const methods = useForm<RegisterForm>({
+    mode: 'onChange',
+    defaultValues: {
+      imgUrl: DEFAULT_PROFILE_IMAGES[0].url,
+    },
+  });
   const {
     handleSubmit,
     formState: { isValid },

--- a/src/pages/account/register.tsx
+++ b/src/pages/account/register.tsx
@@ -46,7 +46,7 @@ const Register: NextPage = () => {
     welcomeMessage: false,
   });
 
-  const registerMutation = useRegisterUser();
+  const { mutate: registerMutate } = useRegisterUser();
 
   const onSubmit: SubmitHandler<RegisterForm> = (data) => {
     if (registerStep.email)
@@ -78,7 +78,7 @@ const Register: NextPage = () => {
         .filter(([_, value]) => value)
         .map(([id, _]) => id) as TermsAgreementId[];
 
-      registerMutation(
+      registerMutate(
         {
           email,
           username,

--- a/src/pages/diary/[id]/edit.tsx
+++ b/src/pages/diary/[id]/edit.tsx
@@ -78,7 +78,7 @@ const EditDiary: NextPage = () => {
     beforeLeaveCallback: handleBeforeLeaveModal.open,
   });
 
-  const editDiaryMutation = useEditDiary(id as string);
+  const { mutate: editDiaryMutate } = useEditDiary(id as string);
   const imageUploadMutation = useImageUpload({ path: 'diaries' });
 
   useEffect(() => {
@@ -120,7 +120,7 @@ const EditDiary: NextPage = () => {
   const onSubmit: SubmitHandler<DiaryForm> = (data) => {
     const { title, content, imgUrl, isPublic } = data;
 
-    editDiaryMutation(
+    editDiaryMutate(
       {
         title,
         content,

--- a/src/pages/diary/[id]/edit.tsx
+++ b/src/pages/diary/[id]/edit.tsx
@@ -79,7 +79,7 @@ const EditDiary: NextPage = () => {
   });
 
   const { mutate: editDiaryMutate } = useEditDiary(id as string);
-  const imageUploadMutation = useImageUpload({ path: 'diaries' });
+  const { mutate: imageUploadMutate } = useImageUpload({ path: 'diaries' });
 
   useEffect(() => {
     setFocus('content');
@@ -91,7 +91,7 @@ const EditDiary: NextPage = () => {
       const imageFormData = new FormData();
       imageFormData.append('image', files[0]);
 
-      imageUploadMutation(imageFormData, {
+      imageUploadMutate(imageFormData, {
         onSuccess: (imgUrl) => {
           setPreviewImage(imgUrl);
           setValue('imgUrl', imgUrl);

--- a/src/pages/diary/[id]/edit.tsx
+++ b/src/pages/diary/[id]/edit.tsx
@@ -79,13 +79,7 @@ const EditDiary: NextPage = () => {
   });
 
   const editDiaryMutation = useEditDiary(id as string);
-  const imageUploadMutation = useImageUpload({
-    path: 'diaries',
-    onSuccess: (imgUrl: string) => {
-      setPreviewImage(imgUrl);
-      setValue('imgUrl', imgUrl);
-    },
-  });
+  const imageUploadMutation = useImageUpload({ path: 'diaries' });
 
   useEffect(() => {
     setFocus('content');
@@ -94,17 +88,20 @@ const EditDiary: NextPage = () => {
   const handleOnChangeImageFile: ChangeEventHandler<HTMLInputElement> = (e) => {
     const { files } = e.target;
     if (files !== null) {
-      try {
-        const imageFormData = new FormData();
-        imageFormData.append('image', files[0]);
+      const imageFormData = new FormData();
+      imageFormData.append('image', files[0]);
 
-        imageUploadMutation(imageFormData);
-      } catch (error) {
-        if (isAxiosError<ErrorResponse>(error)) {
-          // TODO: 이미지 업로드 시 에러 처리
-          console.log(error);
-        }
-      }
+      imageUploadMutation(imageFormData, {
+        onSuccess: (imgUrl) => {
+          setPreviewImage(imgUrl);
+          setValue('imgUrl', imgUrl);
+        },
+        onError: (error) => {
+          if (isAxiosError<ErrorResponse>(error)) {
+            console.log(error);
+          }
+        },
+      });
     }
   };
 

--- a/src/pages/diary/[id]/edit.tsx
+++ b/src/pages/diary/[id]/edit.tsx
@@ -120,23 +120,28 @@ const EditDiary: NextPage = () => {
     }, 0);
   };
 
-  const onSubmit: SubmitHandler<DiaryForm> = async (data) => {
-    try {
-      const { title, content, imgUrl, isPublic } = data;
-      editDiaryMutation({
+  const onSubmit: SubmitHandler<DiaryForm> = (data) => {
+    const { title, content, imgUrl, isPublic } = data;
+
+    editDiaryMutation(
+      {
         title,
         content,
         imgUrl,
         isPublic,
         id: id as string,
-      });
-
-      await router.replace(PAGE_PATH.diary.detail(id as string));
-    } catch (error) {
-      if (isAxiosError<ErrorResponse>(error)) {
-        alert(errorResponseMessage(error.response?.data.message));
-      }
-    }
+      },
+      {
+        onSuccess: async () => {
+          await router.replace(PAGE_PATH.diary.detail(id as string));
+        },
+        onError: (error) => {
+          if (isAxiosError<ErrorResponse>(error)) {
+            alert(errorResponseMessage(error.response?.data.message));
+          }
+        },
+      },
+    );
   };
 
   if (diaryData === undefined || isLoading) return <FullPageLoading />;

--- a/src/pages/diary/[id]/index.tsx
+++ b/src/pages/diary/[id]/index.tsx
@@ -37,14 +37,14 @@ const DiaryDetailPage: NextPage<DiaryDetailPageProps> = ({ user }) => {
   const { ref, isVisible, setIsVisible } = useClickOutside();
 
   const { diaryData, isLoading } = useDiary(id as string);
-  const deleteDiaryMutation = useDeleteDiary();
+  const { mutate: deleteDiaryMutate } = useDeleteDiary();
 
   const handleGoToEdit = () => {
     void router.push(PAGE_PATH.diary.edit(id as string));
   };
 
   const handleDeleteDiary = () => {
-    deleteDiaryMutation(
+    deleteDiaryMutate(
       { id: id as string },
       {
         onSuccess: () => {

--- a/src/pages/diary/[id]/index.tsx
+++ b/src/pages/diary/[id]/index.tsx
@@ -37,22 +37,26 @@ const DiaryDetailPage: NextPage<DiaryDetailPageProps> = ({ user }) => {
   const { ref, isVisible, setIsVisible } = useClickOutside();
 
   const { diaryData, isLoading } = useDiary(id as string);
-  const deleteDiaryMutation = useDeleteDiary({ id: id as string });
+  const deleteDiaryMutation = useDeleteDiary();
 
   const handleGoToEdit = () => {
     void router.push(PAGE_PATH.diary.edit(id as string));
   };
 
   const handleDeleteDiary = () => {
-    try {
-      deleteDiaryMutation({ id: id as string });
-      // TODO: 일기 삭제 후 라우팅 처리 수정
-      router.back();
-    } catch (error) {
-      if (isAxiosError<ErrorResponse>(error)) {
-        alert(errorResponseMessage(error.response?.data.message));
-      }
-    }
+    deleteDiaryMutation(
+      { id: id as string },
+      {
+        onSuccess: () => {
+          router.back();
+        },
+        onError: (error) => {
+          if (isAxiosError<ErrorResponse>(error)) {
+            alert(errorResponseMessage(error.response?.data.message));
+          }
+        },
+      },
+    );
   };
 
   if (diaryData === undefined || isLoading) return <FullPageLoading />;

--- a/src/pages/diary/index.tsx
+++ b/src/pages/diary/index.tsx
@@ -85,15 +85,21 @@ const WriteDiary: NextPage = () => {
   };
 
   const onSubmit: SubmitHandler<DiaryForm> = (data) => {
-    try {
-      const { title, content, imgUrl, isPublic } = data;
-      writeDiaryMutation({ title, content, imgUrl, isPublic });
-      // TODO: badge 데이터가 있는 경우, 모달로 배지 획득 알람 띄우기
-    } catch (error) {
-      if (isAxiosError<ErrorResponse>(error)) {
-        alert(errorResponseMessage(error.response?.data.message));
-      }
-    }
+    const { title, content, imgUrl, isPublic } = data;
+
+    writeDiaryMutation(
+      { title, content, imgUrl, isPublic },
+      {
+        onSuccess: () => {
+          // TODO: badge 데이터가 있는 경우, 모달로 배지 획득 알람 띄우기
+        },
+        onError: (error) => {
+          if (isAxiosError<ErrorResponse>(error)) {
+            alert(errorResponseMessage(error.response?.data.message));
+          }
+        },
+      },
+    );
   };
 
   return (

--- a/src/pages/diary/index.tsx
+++ b/src/pages/diary/index.tsx
@@ -57,28 +57,25 @@ const WriteDiary: NextPage = () => {
   });
 
   const writeDiaryMutation = useWriteDiary();
-  const imageUploadMutation = useImageUpload({
-    path: 'diaries',
-    onSuccess: (imgUrl: string) => {
-      setPreviewImage(imgUrl);
-      setValue('imgUrl', imgUrl);
-    },
-  });
+  const imageUploadMutation = useImageUpload({ path: 'diaries' });
 
   const handleImageFile: ChangeEventHandler<HTMLInputElement> = (e) => {
     const { files } = e.target;
     if (files !== null) {
-      try {
-        const imageFormData = new FormData();
-        imageFormData.append('image', files[0]);
+      const imageFormData = new FormData();
+      imageFormData.append('image', files[0]);
 
-        imageUploadMutation(imageFormData);
-      } catch (error) {
-        if (isAxiosError<ErrorResponse>(error)) {
-          // TODO: 이미지 업로드 시 에러 처리
-          console.log(error);
-        }
-      }
+      imageUploadMutation(imageFormData, {
+        onSuccess: (imgUrl) => {
+          setPreviewImage(imgUrl);
+          setValue('imgUrl', imgUrl);
+        },
+        onError: (error) => {
+          if (isAxiosError<ErrorResponse>(error)) {
+            console.log(error);
+          }
+        },
+      });
     }
   };
 

--- a/src/pages/diary/index.tsx
+++ b/src/pages/diary/index.tsx
@@ -22,6 +22,7 @@ import {
   HeaderRight,
   HeaderTitle,
 } from 'components/layouts';
+import { PAGE_PATH } from 'constants/common';
 import { MODAL_BUTTON, MODAL_MESSAGE } from 'constants/modal';
 import { useBeforeLeave, useModal } from 'hooks/common';
 import { useImageUpload, useWriteDiary } from 'hooks/services';
@@ -56,7 +57,7 @@ const WriteDiary: NextPage = () => {
     beforeLeaveCallback: handleBeforeLeaveModal.open,
   });
 
-  const writeDiaryMutation = useWriteDiary();
+  const { mutate: writeDiaryMutate } = useWriteDiary();
   const { mutate: imageUploadMutate } = useImageUpload({ path: 'diaries' });
 
   const handleImageFile: ChangeEventHandler<HTMLInputElement> = (e) => {
@@ -87,10 +88,11 @@ const WriteDiary: NextPage = () => {
   const onSubmit: SubmitHandler<DiaryForm> = (data) => {
     const { title, content, imgUrl, isPublic } = data;
 
-    writeDiaryMutation(
+    writeDiaryMutate(
       { title, content, imgUrl, isPublic },
       {
-        onSuccess: () => {
+        onSuccess: async (diary) => {
+          await router.replace(PAGE_PATH.diary.detail(diary.id));
           // TODO: badge 데이터가 있는 경우, 모달로 배지 획득 알람 띄우기
         },
         onError: (error) => {

--- a/src/pages/diary/index.tsx
+++ b/src/pages/diary/index.tsx
@@ -57,7 +57,7 @@ const WriteDiary: NextPage = () => {
   });
 
   const writeDiaryMutation = useWriteDiary();
-  const imageUploadMutation = useImageUpload({ path: 'diaries' });
+  const { mutate: imageUploadMutate } = useImageUpload({ path: 'diaries' });
 
   const handleImageFile: ChangeEventHandler<HTMLInputElement> = (e) => {
     const { files } = e.target;
@@ -65,7 +65,7 @@ const WriteDiary: NextPage = () => {
       const imageFormData = new FormData();
       imageFormData.append('image', files[0]);
 
-      imageUploadMutation(imageFormData, {
+      imageUploadMutate(imageFormData, {
         onSuccess: (imgUrl) => {
           setPreviewImage(imgUrl);
           setValue('imgUrl', imgUrl);

--- a/src/pages/profile/edit.tsx
+++ b/src/pages/profile/edit.tsx
@@ -67,7 +67,7 @@ const ProfileEditPage: NextPage<ProfileEditPageProps> = ({ user }) => {
     useState<SuccessResponse<OnlyMessageResponse> | undefined>(undefined);
   const [previewImage, setPreviewImage] = useState<string>(imgUrl);
 
-  const editProfileMutation = useEditProfile(username);
+  const { mutate: editProfileMutate } = useEditProfile(username);
 
   const handleDuplicateCheckUsername = async () => {
     const { username } = getValues();
@@ -105,7 +105,7 @@ const ProfileEditPage: NextPage<ProfileEditPageProps> = ({ user }) => {
     const { username, imgUrl } = data;
 
     // TODO: 프로필 수정 시 동작 확인 필요, 현재 사용 중인 닉네임일 경우 서버 처리 수정 필요
-    editProfileMutation(
+    editProfileMutate(
       { username, imgUrl },
       {
         onSuccess: async () => {

--- a/src/pages/profile/edit.tsx
+++ b/src/pages/profile/edit.tsx
@@ -102,25 +102,23 @@ const ProfileEditPage: NextPage<ProfileEditPageProps> = ({ user }) => {
   };
 
   const onSubmit: SubmitHandler<EditProfileForm> = (data) => {
-    try {
-      const { username, imgUrl } = data;
+    const { username, imgUrl } = data;
 
-      // TODO: 프로필 수정 시 동작 확인 필요, 현재 사용 중인 닉네임일 경우 서버 처리 수정 필요
-      editProfileMutation(
-        { username, imgUrl },
-        {
-          onSuccess: async () => {
-            await update({ username, imgUrl });
-            await router.replace(PAGE_PATH.profile.index);
-          },
+    // TODO: 프로필 수정 시 동작 확인 필요, 현재 사용 중인 닉네임일 경우 서버 처리 수정 필요
+    editProfileMutation(
+      { username, imgUrl },
+      {
+        onSuccess: async () => {
+          await update({ username, imgUrl });
+          await router.replace(PAGE_PATH.profile.index);
         },
-      );
-    } catch (error) {
-      if (isAxiosError<ErrorResponse>(error)) {
-        // TODO: 에러 처리
-        console.log(error);
-      }
-    }
+        onError: (error) => {
+          if (isAxiosError<ErrorResponse>(error)) {
+            alert(errorResponseMessage(error.response?.data.message));
+          }
+        },
+      },
+    );
   };
 
   return (


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #263
- #261 브랜치 머지 후 해당 브랜치 머지 

<br />

## 🗒 작업 목록

- [x] 각 useMutation의 onSuccess, onError 코드 개선
- [x] 각 useMutation을 이용한 커스텀 훅 useMutation 반환하도록 수정

<br />

## 🧐 PR Point

- useMutation을 이용한 커스텀 훅 코드를 개선하여 호출하는 곳에서 onSuccess, onError 시 어떤 동작을 하는지 명시적으로 코드를 작성할 수 있도록 합니다.
- 각 useMutation을 이용한 커스텀 훅이 useMutation 반환하도록 하여 mutate 이외에 다른 반환 값들을 사용할 수 있도록 합니다.
- 이슈 번호 #263인 커밋만 확인 부탁드립니다.

<br />

## 💥 Trouble Shooting
- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크

- 내용을 입력해주세요.

<br />

## 📚 참고

- 참고한 내용 또는 링크를 입력해주세요.

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다. 
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
