### PR TITLE
매칭 종료 이벤트 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@next/eslint-plugin-next": "^13.1.1",
     "@types/react-calendar-heatmap": "^1.6.3",
     "@types/socket.io-client": "^3.0.0",
+    "@types/webrtc": "^0.0.43",
     "@typescript-eslint/eslint-plugin": "^5.47.1",
     "@typescript-eslint/parser": "^5.47.1",
     "eslint-config-prettier": "^8.5.0",

--- a/src/components/matching/MatchingController.tsx
+++ b/src/components/matching/MatchingController.tsx
@@ -41,6 +41,10 @@ const MatchingController = () => {
   useEffect(() => {
     void signaling();
 
+    matching.addPeerEventHandler({
+      handleDisconnected: handleEndMatching,
+    });
+
     return () => {
       matching.disconnect();
     };

--- a/src/components/matching/MatchingController.tsx
+++ b/src/components/matching/MatchingController.tsx
@@ -3,8 +3,9 @@ import { useRouter } from 'next/router';
 import { useEffect, useRef } from 'react';
 import type { MatchingInformation } from 'types/matching';
 import { MicrophoneOffIcon, EndCallIcon } from 'assets/icons';
-import { AlertModal, IconButton } from 'components/common';
+import { AlertModal, ConfirmModal, IconButton } from 'components/common';
 import { PAGE_PATH } from 'constants/common';
+import { MODAL_BUTTON, MODAL_MESSAGE } from 'constants/modal';
 import { colors } from 'constants/styles';
 import { useMatching } from 'contexts/MatchingProvider';
 import { useModal } from 'hooks/common';
@@ -17,7 +18,11 @@ const MatchingController = () => {
 
   const matching = useMatching();
 
-  const { isVisible, handleModal } = useModal();
+  const { isVisible: isAlertVisible, handleModal: handleAlertModal } =
+    useModal();
+
+  const { isVisible: isConfirmVisible, handleModal: handleConfirmModal } =
+    useModal();
 
   const signaling = async () => {
     const { query } = router;
@@ -34,7 +39,7 @@ const MatchingController = () => {
       });
     } catch (error) {
       console.log(error);
-      handleModal.open();
+      handleAlertModal.open();
     }
   };
 
@@ -57,7 +62,7 @@ const MatchingController = () => {
   };
 
   const handleCloseAlert = () => {
-    handleModal.close();
+    handleAlertModal.close();
     void router.replace(PAGE_PATH.main);
   };
 
@@ -82,18 +87,26 @@ const MatchingController = () => {
             id="end-call"
             backgroundColor={colors.red}
             icon={<EndCallIcon />}
-            onClick={handleEndMatching}
+            onClick={handleConfirmModal.open}
           />
           <label htmlFor="end-call">통화 종료</label>
         </ButtonWrapper>
       </Container>
       {/* FIXME: 디자인이 없어 임시로 디자인한 모달입니다. 추후 변경 예정 */}
-      <AlertModal isVisible={isVisible} onClose={handleCloseAlert}>
+      <AlertModal isVisible={isAlertVisible} onClose={handleCloseAlert}>
         <ModalContent>
           <p>의도하지 않은 에러가 발생했습니다.</p>
           <p>메인 페이지도 이동합니다.</p>
         </ModalContent>
       </AlertModal>
+      {/* FIXME: 디자인이 없어 임시로 디자인한 모달입니다. 추후 변경 예정 */}
+      <ConfirmModal
+        isVisible={isConfirmVisible}
+        message={MODAL_MESSAGE.endMatching}
+        confirmText={MODAL_BUTTON.end}
+        onClose={handleConfirmModal.close}
+        onConfirm={handleEndMatching}
+      />
     </>
   );
 };

--- a/src/constants/modal/message.ts
+++ b/src/constants/modal/message.ts
@@ -3,10 +3,12 @@ export const MODAL_MESSAGE = {
     '등록하지 않고 나갈 시 작성한 일기가 모두 삭제됩니다. 나가시겠습니까?',
   delete: '삭제하시겠습니까?',
   leaveMatching: '페이지 이동 시 매칭이 종료될 수 있습니다. 이동하시겠습니까?',
+  endMatching: '매칭을 종료하시겠습니까?',
 };
 
 export const MODAL_BUTTON = {
   confirm: '확인',
   delete: '삭제',
   leave: '나가기',
+  end: '종료',
 };

--- a/src/types/matching.ts
+++ b/src/types/matching.ts
@@ -16,3 +16,7 @@ export interface MatchingInformation {
   socketId: string;
   userId: string;
 }
+
+export interface PeerEventHandler {
+  handleDisconnected: () => void;
+}

--- a/src/utils/Matching.ts
+++ b/src/utils/Matching.ts
@@ -155,8 +155,6 @@ export class Matching {
   }
 
   public addPeerEventHandler({ handleDisconnected }: PeerEventHandler) {
-    if (this.peer === null) return;
-
     const interval = setInterval(async () => {
       if (this.peer === null) return;
       const statistics = await this.peer.getStats(null);

--- a/src/utils/Matching.ts
+++ b/src/utils/Matching.ts
@@ -1,7 +1,7 @@
 import { io } from 'socket.io-client';
 import type { User } from 'next-auth';
 import type { Socket } from 'socket.io-client';
-import type { MatchingInformation } from 'types/matching';
+import type { MatchingInformation, PeerEventHandler } from 'types/matching';
 import { MATCHING_SOCKET_EVENT, EXCEPTION_MESSAGE } from 'constants/matching';
 
 export class Matching {
@@ -152,6 +152,34 @@ export class Matching {
     this.peer.ontrack = (trackEvent: RTCTrackEvent) => {
       audioElement.srcObject = trackEvent.streams[0];
     };
+  }
+
+  public addPeerEventHandler({ handleDisconnected }: PeerEventHandler) {
+    if (this.peer === null) return;
+
+    const interval = setInterval(async () => {
+      if (this.peer === null) return;
+      const statistics = await this.peer.getStats(null);
+
+      statistics.forEach((report) => {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        switch (report.type) {
+          case 'transport':
+            {
+              const transportReport = report as RTCTransportStats;
+
+              if (
+                transportReport.dtlsState === 'closed' ||
+                transportReport.dtlsState === 'failed'
+              ) {
+                handleDisconnected();
+                clearInterval(interval);
+              }
+            }
+            break;
+        }
+      });
+    }, 1000);
   }
 
   public disconnect() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1536,6 +1536,11 @@
   dependencies:
     socket.io-client "*"
 
+"@types/webrtc@^0.0.43":
+  version "0.0.43"
+  resolved "https://registry.yarnpkg.com/@types/webrtc/-/webrtc-0.0.43.tgz#6a102c82daff5c3560cf8074707ad7055b9fa045"
+  integrity sha512-W5FyScaZ+nLb0CXP/4UaRiNr042RwW/RnLUZYt0uwveZN8w+X1gtt0bYIg9oMzt5ODiU/aQV/kyCFv24wfNrXA==
+
 "@typescript-eslint/eslint-plugin@^5.47.1":
   version "5.51.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.51.0.tgz#da3f2819633061ced84bb82c53bba45a6fe9963a"


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #260 

<br />

## 🗒 작업 목록

- [x] 정의되어 있지 않은 WebRTC 타입 사용을 위한 라이브러리 설치
- [x] 매칭 상대의 Peer 정보 구독
- [x] 매칭 상대의 Peer가 끊긴 경우 이벤트 처리 (매칭 종료)


<br />

## 🧐 PR Point

- addPeerEventHandler는 매칭 상대의 peer 정보를 구독하는 메서드입니다.
     - 해당 interval을 통해 상대방이 보내는 peer 정보를 실시간으로 처리할 수 있습니다.
     - 해당 PR에선 상대방의 연결 끊임을 처리하였지만, 추후 MR에서 상대방이 말하는 이펙트를 처리할 예정입니다.
- webRTC의 Peer 정보를 조회하기 위해 사용되는 RTCStatsReport 객체의 값(report)이 any로 설정되어 있어 공식문서를 참고하여 report.type의 값에 따라 타입을 단언하였습니다.
    - any 타입 사용의 경우 eslint의 제한있습니다. 지금 같이 특수한 경우 때문에 eslint config 파일을 수정하는 것 보다 해당 line에 eslint를 무시하는 것이 낫다고 판단 switch문에서 eslint 무시 문을 작성하였습니다.


<br />

## 💥 Trouble Shooting
- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크

https://github.com/user-attachments/assets/3acd9822-e19c-4b06-a17f-053ee62bb26f


<br />

## 📚 참고

- https://w3c.github.io/webrtc-stats/#dom-rtcstatstype
- https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/getStats

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다. 
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
