### PR TITLE
매칭 설문 페이지 API 연동

### DIFF
--- a/src/api/blacklist.ts
+++ b/src/api/blacklist.ts
@@ -3,11 +3,11 @@ import type { OnlyMessageResponse, SuccessResponse } from 'types/response';
 import { API_PATH } from 'constants/services';
 import axios from 'lib/axios';
 
-export const blockUser = async (blockedUserId: string) => {
+export const addToBlackList = async (blockedUserId: string) => {
   const {
     data: { data },
   } = await axios.post<SuccessResponse<OnlyMessageResponse>>(
-    API_PATH.blacklist.blockUser(blockedUserId),
+    API_PATH.blacklist.addToBlackList(blockedUserId),
   );
 
   return data.message;

--- a/src/api/blacklist.ts
+++ b/src/api/blacklist.ts
@@ -1,0 +1,14 @@
+import type { OnlyMessageResponse, SuccessResponse } from 'types/response';
+
+import { API_PATH } from 'constants/services';
+import axios from 'lib/axios';
+
+export const blockUser = async (blockedUserId: string) => {
+  const {
+    data: { data },
+  } = await axios.post<SuccessResponse<OnlyMessageResponse>>(
+    API_PATH.blacklist.blockUser(blockedUserId),
+  );
+
+  return data.message;
+};

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -9,3 +9,4 @@ export * from './profile';
 export * from './activities';
 export * from './badges';
 export * from './matchingHistories';
+export * from './blacklist';

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -8,3 +8,4 @@ export * from './bookmark';
 export * from './profile';
 export * from './activities';
 export * from './badges';
+export * from './matchingHistories';

--- a/src/api/matchingHistories.ts
+++ b/src/api/matchingHistories.ts
@@ -1,4 +1,8 @@
-import type { MatchingHistory } from 'types/matchingHistories';
+import type {
+  CreateMatchingFeedbackRequest,
+  CreateMatchingFeedbackResponse,
+  MatchingHistoryResponse,
+} from 'types/matching';
 import type { SuccessResponse } from 'types/response';
 
 import { API_PATH } from 'constants/services';
@@ -7,9 +11,21 @@ import axios from 'lib/axios';
 export const getRecentMatchingHistory = async () => {
   const {
     data: { data },
-  } = await axios.get<SuccessResponse<MatchingHistory>>(
+  } = await axios.get<SuccessResponse<MatchingHistoryResponse>>(
     API_PATH.matchingHistories.recent,
   );
 
   return data;
+};
+
+export const createMatchingFeedback = async (
+  payload: CreateMatchingFeedbackRequest,
+) => {
+  const { matchingHistoryId, ...feedbackForm } = payload;
+
+  const response = await axios.post<
+    SuccessResponse<CreateMatchingFeedbackResponse>
+  >(API_PATH.matchingHistories.feedback(matchingHistoryId), feedbackForm);
+
+  return response;
 };

--- a/src/api/matchingHistories.ts
+++ b/src/api/matchingHistories.ts
@@ -1,0 +1,15 @@
+import type { MatchingHistory } from 'types/matchingHistories';
+import type { SuccessResponse } from 'types/response';
+
+import { API_PATH } from 'constants/services';
+import axios from 'lib/axios';
+
+export const getRecentMatchingHistory = async () => {
+  const {
+    data: { data },
+  } = await axios.get<SuccessResponse<MatchingHistory>>(
+    API_PATH.matchingHistories.recent,
+  );
+
+  return data;
+};

--- a/src/api/matchingHistories.ts
+++ b/src/api/matchingHistories.ts
@@ -23,9 +23,12 @@ export const createMatchingFeedback = async (
 ) => {
   const { matchingHistoryId, ...feedbackForm } = payload;
 
-  const response = await axios.post<
-    SuccessResponse<CreateMatchingFeedbackResponse>
-  >(API_PATH.matchingHistories.feedback(matchingHistoryId), feedbackForm);
+  const {
+    data: { data },
+  } = await axios.post<SuccessResponse<CreateMatchingFeedbackResponse>>(
+    API_PATH.matchingHistories.feedback(matchingHistoryId),
+    feedbackForm,
+  );
 
-  return response;
+  return data;
 };

--- a/src/components/matching/FeedbackTypeCheckbox.tsx
+++ b/src/components/matching/FeedbackTypeCheckbox.tsx
@@ -16,25 +16,25 @@ const FeedbackTypeCheckbox = ({ register }: FeedbackTypeCheckboxProps) => {
       id: 'isNice',
       icon: <NiceIcon />,
       description: '친절해요',
-      hookFormProps: register('feedbackType.isNice'),
+      hookFormProps: register('isNice'),
     },
     {
       id: 'isFluent',
       icon: <EngIcon />,
       description: '영어를 잘해요',
-      hookFormProps: register('feedbackType.isFluent'),
+      hookFormProps: register('isFluent'),
     },
     {
       id: 'isFun',
       icon: <FunIcon />,
       description: '재밌어요',
-      hookFormProps: register('feedbackType.isFun'),
+      hookFormProps: register('isFun'),
     },
     {
       id: 'isBad',
       icon: <BadIcon />,
       description: '불쾌해요',
-      hookFormProps: register('feedbackType.isBad'),
+      hookFormProps: register('isBad'),
     },
   ]);
 

--- a/src/components/matching/MatchingController.tsx
+++ b/src/components/matching/MatchingController.tsx
@@ -38,7 +38,7 @@ const MatchingController = () => {
       await matching.signaling(audioElement, {
         role: query.r as MatchingInformation['role'],
         socketId: query.ms as MatchingInformation['socketId'],
-        userId: query.mu as MatchingInformation['userId'],
+        userId: query.mu as MatchingInformation['userId'], // FIXME: username으로 변경 필요
       });
     } catch (error) {
       console.log(error);
@@ -59,9 +59,8 @@ const MatchingController = () => {
   }, []);
 
   const handleEndMatching = () => {
-    // FIXME: 매칭 설문 페이지로 이동할 예정입니다.
     matching.disconnect();
-    void router.replace(PAGE_PATH.main);
+    void router.replace(PAGE_PATH.matching.survey);
   };
 
   const handleCloseAlert = () => {

--- a/src/constants/common/page.ts
+++ b/src/constants/common/page.ts
@@ -5,6 +5,7 @@ export const PAGE_PATH = {
     index: '/matching',
     queue: '/matching/queue',
     matchUp: '/matching/match-up',
+    survey: '/matching/survey',
   },
 
   diary: {

--- a/src/constants/services/path.ts
+++ b/src/constants/services/path.ts
@@ -30,4 +30,7 @@ export const API_PATH = {
     recent: '/matching-histories/recent',
     feedback: (id: string) => `/matching-histories/${id}/feedback`,
   },
+  blacklist: {
+    blockUser: (blockedUserId: string) => `/blacklist/${blockedUserId}`,
+  },
 } as const;

--- a/src/constants/services/path.ts
+++ b/src/constants/services/path.ts
@@ -25,4 +25,8 @@ export const API_PATH = {
     index: '/badges',
     users: '/badges/users',
   },
+  matchingHistories: {
+    index: '/matching-histories',
+    recent: '/matching-histories/recent',
+  },
 } as const;

--- a/src/constants/services/path.ts
+++ b/src/constants/services/path.ts
@@ -31,6 +31,6 @@ export const API_PATH = {
     feedback: (id: string) => `/matching-histories/${id}/feedback`,
   },
   blacklist: {
-    blockUser: (blockedUserId: string) => `/blacklist/${blockedUserId}`,
+    addToBlackList: (blockedUserId: string) => `/blacklist/${blockedUserId}`,
   },
 } as const;

--- a/src/constants/services/path.ts
+++ b/src/constants/services/path.ts
@@ -28,5 +28,6 @@ export const API_PATH = {
   matchingHistories: {
     index: '/matching-histories',
     recent: '/matching-histories/recent',
+    feedback: (id: string) => `/matching-histories/${id}/feedback`,
   },
 } as const;

--- a/src/constants/services/queryKeys.ts
+++ b/src/constants/services/queryKeys.ts
@@ -1,4 +1,5 @@
 export const queryKeys = {
+  recentMatchingHistory: 'recentMatchingHistory',
   badges: 'badges',
   bookmark: 'bookmark',
   comments: 'comments',

--- a/src/hooks/services/mutations/useBlockUser.ts
+++ b/src/hooks/services/mutations/useBlockUser.ts
@@ -1,0 +1,8 @@
+import { useMutation } from '@tanstack/react-query';
+import * as api from 'api';
+
+export const useBlockUser = () => {
+  return useMutation(
+    async (blockedUserId: string) => await api.blockUser(blockedUserId),
+  );
+};

--- a/src/hooks/services/mutations/useBlockUser.ts
+++ b/src/hooks/services/mutations/useBlockUser.ts
@@ -1,8 +1,8 @@
 import { useMutation } from '@tanstack/react-query';
 import * as api from 'api';
 
-export const useBlockUser = () => {
+export const useAddToBlackList = () => {
   return useMutation(
-    async (blockedUserId: string) => await api.blockUser(blockedUserId),
+    async (blockedUserId: string) => await api.addToBlackList(blockedUserId),
   );
 };

--- a/src/hooks/services/mutations/useCreateMatchingFeedback.ts
+++ b/src/hooks/services/mutations/useCreateMatchingFeedback.ts
@@ -1,0 +1,11 @@
+import { useMutation } from '@tanstack/react-query';
+
+import type { CreateMatchingFeedbackRequest } from 'types/matching';
+import * as api from 'api';
+
+export const useCreateMatchingFeedback = () => {
+  return useMutation(
+    async (payload: CreateMatchingFeedbackRequest) =>
+      await api.createMatchingFeedback(payload),
+  );
+};

--- a/src/hooks/services/queries/useRecentMatchingHistory.ts
+++ b/src/hooks/services/queries/useRecentMatchingHistory.ts
@@ -1,0 +1,13 @@
+import { useQuery } from '@tanstack/react-query';
+import * as api from 'api';
+
+import { queryKeys } from 'constants/services';
+
+export const useRecentMatchingHistory = () => {
+  const response = useQuery(
+    [queryKeys.recentMatchingHistory],
+    async () => await api.getRecentMatchingHistory(),
+  );
+
+  return response;
+};

--- a/src/pages/matching/survey.tsx
+++ b/src/pages/matching/survey.tsx
@@ -10,6 +10,7 @@ import { CheckedOffIcon, CheckedOnIcon } from 'assets/icons';
 import { Seo } from 'components/common';
 import FeedbackTypeCheckbox from 'components/matching/FeedbackTypeCheckbox';
 import { PAGE_PATH } from 'constants/common';
+import { useCreateMatchingFeedback } from 'hooks/services/mutations/useCreateMatchingFeedback';
 import { useRecentMatchingHistory } from 'hooks/services/queries/useRecentMatchingHistory';
 import { ScreenReaderOnly } from 'styles';
 
@@ -23,19 +24,29 @@ const MatchingSurvey = () => {
 
   const { data: matchingHistory } = useRecentMatchingHistory();
 
-  const onSubmit: SubmitHandler<MatchingFeedbackForm> = async (formData) => {
+  const { mutate } = useCreateMatchingFeedback();
+
+  const onSubmit: SubmitHandler<MatchingFeedbackForm> = (formData) => {
     if (!matchingHistory) return;
 
     const { id, matchedUser } = matchingHistory;
 
-    // TODO: feedback post api 연동 시 사용할 데이터입니다.
-    console.log({
-      matchingHistoryId: id,
-      matchedUserId: matchedUser.id,
-      ...formData,
-    });
-
-    await router.push(PAGE_PATH.main);
+    mutate(
+      {
+        matchingHistoryId: id,
+        matchedUserId: matchedUser.id,
+        ...formData,
+      },
+      {
+        onSuccess: () => {
+          void router.push(PAGE_PATH.main);
+        },
+        onError: () => {
+          alert('의도하지 않은 에러가 발생하였습니다.');
+          void router.push(PAGE_PATH.main);
+        },
+      },
+    );
   };
 
   const handleChangeShouldBlackList = () => {

--- a/src/pages/matching/survey.tsx
+++ b/src/pages/matching/survey.tsx
@@ -10,6 +10,7 @@ import { CheckedOffIcon, CheckedOnIcon } from 'assets/icons';
 import { Seo } from 'components/common';
 import FeedbackTypeCheckbox from 'components/matching/FeedbackTypeCheckbox';
 import { PAGE_PATH } from 'constants/common';
+import { useBlockUser } from 'hooks/services/mutations/useBlockUser';
 import { useCreateMatchingFeedback } from 'hooks/services/mutations/useCreateMatchingFeedback';
 import { useRecentMatchingHistory } from 'hooks/services/queries/useRecentMatchingHistory';
 import { ScreenReaderOnly } from 'styles';
@@ -19,19 +20,29 @@ const MatchingSurvey = () => {
 
   const { register, handleSubmit } = useForm<MatchingFeedbackForm>();
 
-  // TODO: BlackList 기능은 별도의 이슈에서 작업할 예정입니다.
-  const [shouldBlackList, setShouldBackList] = useState<boolean>(false);
+  const [isBlockUser, setIsBlockUser] = useState<boolean>(false);
 
   const { data: matchingHistory } = useRecentMatchingHistory();
 
-  const { mutate } = useCreateMatchingFeedback();
+  const { mutate: createFeedbackMutate } = useCreateMatchingFeedback();
+
+  const { mutate: blockUserMutate } = useBlockUser();
+
+  const onRequestError = () => {
+    alert('의도하지 않은 에러가 발생하였습니다.');
+    void router.push(PAGE_PATH.main);
+  };
 
   const onSubmit: SubmitHandler<MatchingFeedbackForm> = (formData) => {
     if (!matchingHistory) return;
 
     const { id, matchedUser } = matchingHistory;
 
-    mutate(
+    if (isBlockUser) {
+      blockUserMutate(matchedUser.id, { onError: onRequestError });
+    }
+
+    createFeedbackMutate(
       {
         matchingHistoryId: id,
         matchedUserId: matchedUser.id,
@@ -41,16 +52,13 @@ const MatchingSurvey = () => {
         onSuccess: () => {
           void router.push(PAGE_PATH.main);
         },
-        onError: () => {
-          alert('의도하지 않은 에러가 발생하였습니다.');
-          void router.push(PAGE_PATH.main);
-        },
+        onError: onRequestError,
       },
     );
   };
 
-  const handleChangeShouldBlackList = () => {
-    setShouldBackList((previous) => !previous);
+  const handleChangeIsBlockUser = () => {
+    setIsBlockUser((previous) => !previous);
   };
 
   return (
@@ -76,10 +84,10 @@ const MatchingSurvey = () => {
           <CheckBoxLabel>
             <input
               type="checkbox"
-              checked={shouldBlackList}
-              onChange={handleChangeShouldBlackList}
+              checked={isBlockUser}
+              onChange={handleChangeIsBlockUser}
             />
-            {shouldBlackList ? <CheckedOnIcon /> : <CheckedOffIcon />}
+            {isBlockUser ? <CheckedOnIcon /> : <CheckedOffIcon />}
             <p>이 사람이랑 전화하지 않을래요.</p>
           </CheckBoxLabel>
           <Button type="submit">피드백 작성 완료</Button>

--- a/src/pages/matching/survey.tsx
+++ b/src/pages/matching/survey.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 import { useRouter } from 'next/router';
-import { useForm, useWatch } from 'react-hook-form';
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
 
 import type { SubmitHandler } from 'react-hook-form';
 import type { MatchingFeedbackForm } from 'types/matching';
@@ -9,23 +10,37 @@ import { CheckedOffIcon, CheckedOnIcon } from 'assets/icons';
 import { Seo } from 'components/common';
 import FeedbackTypeCheckbox from 'components/matching/FeedbackTypeCheckbox';
 import { PAGE_PATH } from 'constants/common';
+import { useRecentMatchingHistory } from 'hooks/services/queries/useRecentMatchingHistory';
 import { ScreenReaderOnly } from 'styles';
 
 const MatchingSurvey = () => {
   const router = useRouter();
 
-  const { control, register, handleSubmit } = useForm<MatchingFeedbackForm>();
+  const { register, handleSubmit } = useForm<MatchingFeedbackForm>();
 
-  const onSubmit: SubmitHandler<MatchingFeedbackForm> = async (data) => {
-    console.log(data); // FIXME: 실제 API 연동할 때 사용될 데이터 console.log 입니다.
+  // TODO: BlackList 기능은 별도의 이슈에서 작업할 예정입니다.
+  const [shouldBlackList, setShouldBackList] = useState<boolean>(false);
+
+  const { data: matchingHistory } = useRecentMatchingHistory();
+
+  const onSubmit: SubmitHandler<MatchingFeedbackForm> = async (formData) => {
+    if (!matchingHistory) return;
+
+    const { id, matchedUser } = matchingHistory;
+
+    // TODO: feedback post api 연동 시 사용할 데이터입니다.
+    console.log({
+      matchingHistoryId: id,
+      matchedUserId: matchedUser.id,
+      ...formData,
+    });
 
     await router.push(PAGE_PATH.main);
   };
 
-  const isBlockedMatching = useWatch({
-    control,
-    name: 'isBlockedMatching',
-  });
+  const handleChangeShouldBlackList = () => {
+    setShouldBackList((previous) => !previous);
+  };
 
   return (
     <>
@@ -45,11 +60,15 @@ const MatchingSurvey = () => {
           </RegularParagraph07>
           <TextArea
             placeholder="피드백을 남겨주세요."
-            {...register('message')}
+            {...register('content')}
           />
           <CheckBoxLabel>
-            <input type="checkbox" {...register('isBlockedMatching')} />
-            {isBlockedMatching ? <CheckedOnIcon /> : <CheckedOffIcon />}
+            <input
+              type="checkbox"
+              checked={shouldBlackList}
+              onChange={handleChangeShouldBlackList}
+            />
+            {shouldBlackList ? <CheckedOnIcon /> : <CheckedOffIcon />}
             <p>이 사람이랑 전화하지 않을래요.</p>
           </CheckBoxLabel>
           <Button type="submit">피드백 작성 완료</Button>

--- a/src/pages/matching/survey.tsx
+++ b/src/pages/matching/survey.tsx
@@ -50,7 +50,7 @@ const MatchingSurvey = () => {
       },
       {
         onSuccess: () => {
-          void router.push(PAGE_PATH.main);
+          void router.replace(PAGE_PATH.main);
         },
         onError: onRequestError,
       },

--- a/src/pages/matching/survey.tsx
+++ b/src/pages/matching/survey.tsx
@@ -10,7 +10,7 @@ import { CheckedOffIcon, CheckedOnIcon } from 'assets/icons';
 import { Seo } from 'components/common';
 import FeedbackTypeCheckbox from 'components/matching/FeedbackTypeCheckbox';
 import { PAGE_PATH } from 'constants/common';
-import { useBlockUser } from 'hooks/services/mutations/useBlockUser';
+import { useAddToBlackList } from 'hooks/services/mutations/useBlockUser';
 import { useCreateMatchingFeedback } from 'hooks/services/mutations/useCreateMatchingFeedback';
 import { useRecentMatchingHistory } from 'hooks/services/queries/useRecentMatchingHistory';
 import { ScreenReaderOnly } from 'styles';
@@ -26,7 +26,7 @@ const MatchingSurvey = () => {
 
   const { mutate: createFeedbackMutate } = useCreateMatchingFeedback();
 
-  const { mutate: blockUserMutate } = useBlockUser();
+  const { mutate: addToBlackListMutate } = useAddToBlackList();
 
   const onRequestError = () => {
     alert('의도하지 않은 에러가 발생하였습니다.');
@@ -39,7 +39,7 @@ const MatchingSurvey = () => {
     const { id, matchedUser } = matchingHistory;
 
     if (isBlockUser) {
-      blockUserMutate(matchedUser.id, { onError: onRequestError });
+      addToBlackListMutate(matchedUser.id, { onError: onRequestError });
     }
 
     createFeedbackMutate(

--- a/src/pages/matching/survey.tsx
+++ b/src/pages/matching/survey.tsx
@@ -1,6 +1,5 @@
 import styled from '@emotion/styled';
 import { useRouter } from 'next/router';
-import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 
 import type { SubmitHandler } from 'react-hook-form';
@@ -18,9 +17,9 @@ import { ScreenReaderOnly } from 'styles';
 const MatchingSurvey = () => {
   const router = useRouter();
 
-  const { register, handleSubmit } = useForm<MatchingFeedbackForm>();
+  const { register, handleSubmit, watch } = useForm<MatchingFeedbackForm>();
 
-  const [isBlockUser, setIsBlockUser] = useState<boolean>(false);
+  const isBlockUser = watch('isBlockUser');
 
   const { data: matchingHistory } = useRecentMatchingHistory();
 
@@ -37,6 +36,7 @@ const MatchingSurvey = () => {
     if (!matchingHistory) return;
 
     const { id, matchedUser } = matchingHistory;
+    const { isBlockUser, ...feedbackFormData } = formData;
 
     if (isBlockUser) {
       addToBlackListMutate(matchedUser.id, { onError: onRequestError });
@@ -44,7 +44,7 @@ const MatchingSurvey = () => {
 
     createFeedbackMutate(
       {
-        ...formData,
+        ...feedbackFormData,
         matchingHistoryId: id,
         matchedUserId: matchedUser.id,
       },
@@ -55,10 +55,6 @@ const MatchingSurvey = () => {
         onError: onRequestError,
       },
     );
-  };
-
-  const handleChangeIsBlockUser = () => {
-    setIsBlockUser((previous) => !previous);
   };
 
   return (
@@ -82,11 +78,7 @@ const MatchingSurvey = () => {
             {...register('content')}
           />
           <CheckBoxLabel>
-            <input
-              type="checkbox"
-              checked={isBlockUser}
-              onChange={handleChangeIsBlockUser}
-            />
+            <input type="checkbox" {...register('isBlockUser')} />
             {isBlockUser ? <CheckedOnIcon /> : <CheckedOffIcon />}
             <p>이 사람이랑 전화하지 않을래요.</p>
           </CheckBoxLabel>

--- a/src/pages/matching/survey.tsx
+++ b/src/pages/matching/survey.tsx
@@ -44,9 +44,9 @@ const MatchingSurvey = () => {
 
     createFeedbackMutate(
       {
+        ...formData,
         matchingHistoryId: id,
         matchedUserId: matchedUser.id,
-        ...formData,
       },
       {
         onSuccess: () => {

--- a/src/types/matching.ts
+++ b/src/types/matching.ts
@@ -34,8 +34,8 @@ export interface CreateMatchingFeedbackResponse extends MatchingFeedbackForm {
 }
 
 export interface MatchingHistoryResponse {
-  id: 'uuid';
-  matchTime: 'number';
+  id: string;
+  matchTime: number;
   matchedUser: Omit<User, 'accessToken'>;
-  createdAt: 'date';
+  createdAt: string;
 }

--- a/src/types/matching.ts
+++ b/src/types/matching.ts
@@ -5,10 +5,8 @@ interface FeedbackType {
   isBad: boolean;
 }
 
-export interface MatchingFeedbackForm {
-  feedbackType: FeedbackType;
-  message: string;
-  isBlockedMatching: boolean;
+export interface MatchingFeedbackForm extends FeedbackType {
+  content: string;
 }
 
 export interface MatchingInformation {

--- a/src/types/matching.ts
+++ b/src/types/matching.ts
@@ -8,6 +8,7 @@ interface FeedbackType {
 }
 
 export interface MatchingFeedbackForm extends FeedbackType {
+  isBlockUser: boolean;
   content: string;
 }
 
@@ -22,7 +23,8 @@ export interface PeerEventHandler {
 }
 
 /* API */
-export interface CreateMatchingFeedbackRequest extends MatchingFeedbackForm {
+export interface CreateMatchingFeedbackRequest
+  extends Omit<MatchingFeedbackForm, 'isBlockUser'> {
   matchingHistoryId: string;
   matchedUserId: string;
 }

--- a/src/types/matching.ts
+++ b/src/types/matching.ts
@@ -1,3 +1,5 @@
+import type { User } from 'next-auth';
+
 interface FeedbackType {
   isNice: boolean;
   isFluent: boolean;
@@ -17,4 +19,23 @@ export interface MatchingInformation {
 
 export interface PeerEventHandler {
   handleDisconnected: () => void;
+}
+
+/* API */
+export interface CreateMatchingFeedbackRequest extends MatchingFeedbackForm {
+  matchingHistoryId: string;
+  matchedUserId: string;
+}
+
+export interface CreateMatchingFeedbackResponse extends MatchingFeedbackForm {
+  writer: Omit<User, 'accessToken'>;
+  recipient: Omit<User, 'accessToken'>;
+  matchingHistory: Omit<MatchingHistoryResponse, 'matchedUser'>;
+}
+
+export interface MatchingHistoryResponse {
+  id: 'uuid';
+  matchTime: 'number';
+  matchedUser: Omit<User, 'accessToken'>;
+  createdAt: 'date';
 }

--- a/src/types/matchingHistories.ts
+++ b/src/types/matchingHistories.ts
@@ -1,9 +1,0 @@
-import type { User } from 'next-auth';
-
-/* Response */
-export interface MatchingHistory {
-  id: 'uuid';
-  matchTime: 'number';
-  matchedUser: Omit<User, 'accessToken'>;
-  createdAt: 'date';
-}

--- a/src/types/matchingHistories.ts
+++ b/src/types/matchingHistories.ts
@@ -1,0 +1,9 @@
+import type { User } from 'next-auth';
+
+/* Response */
+export interface MatchingHistory {
+  id: 'uuid';
+  matchTime: 'number';
+  matchedUser: Omit<User, 'accessToken'>;
+  createdAt: 'date';
+}

--- a/src/utils/Matching.ts
+++ b/src/utils/Matching.ts
@@ -178,7 +178,13 @@ export class Matching {
 
       statistics.forEach((report) => {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        switch (report.type) {
+        switch (report.type as RTCStatsType) {
+          case 'inbound-rtp': {
+            // TODO: 상대방 audioLevel에 따른 UI 이벤트 적용 예정
+            // const InboundRTPReport = report as RTCInboundRtpStreamStats;
+            // console.log(InboundRTPReport.audioLevel); //  매칭 상대가 보내는 audio level
+            break;
+          }
           case 'transport':
             {
               const transportReport = report as RTCTransportStats;
@@ -195,6 +201,22 @@ export class Matching {
         }
       });
     }, 1000);
+
+    // 상대방이 의도하지 않는 방법으로 페이지를 이탈한 경우 처리(새로고침, 브라우저 닫기 등)
+    this.peer?.addEventListener('iceconnectionstatechange', () => {
+      if (this.peer === null) return;
+
+      const { iceConnectionState } = this.peer;
+
+      if (
+        iceConnectionState === 'disconnected' ||
+        iceConnectionState === 'failed' ||
+        iceConnectionState === 'closed'
+      ) {
+        handleDisconnected();
+        clearInterval(interval);
+      }
+    });
   }
 
   public disconnect() {


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #271 

<br />

## 🗒 작업 목록

- [x] 매칭 이력 API 연동
- [x] 피드백 생성 API 연동
- [x] API 연동에 따른 코드 구조 및 UI 수정

<br />

## 🧐 PR Point

- Feedback API와 BlackList API를 분리하여 작업하였습니다.
    - 위와 같은 이유로 기존의 Feedback form에서 BlockUser 값을 제외하고 Blacklist는 별도의 state로 관리합니다.
    - 추후 블랙리스트 취소에 대한 논의가 필요할 것 같습니다.
- Feedback Form의 경우 생성 API의 형식을 맞추기 위해 feedback type으로 묶어두었던 객체를 풀어 넣었습니다.

**추가 작업**
- 랜덤 매칭 시 상대방이 의도하지 않은 방법(브라우저 닫기)으로 매칭이 종료되는 경우 매칭을 끊을 수 있는 이벤트를 추가하였습니다.
- 상대방의 마이크 음량 정도를 시각화 할 수 있는 데이터를 주석해두었습니다. -> 해당 기능에 대해 논의 후 방영할 예정입니다.

<br />

## 💥 Trouble Shooting
- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크

- 내용을 입력해주세요.

<br />

## 📚 참고

- 참고한 내용 또는 링크를 입력해주세요.

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다. 
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
