### PR TITLE
401 에러 처리

### DIFF
--- a/src/constants/validation/message.ts
+++ b/src/constants/validation/message.ts
@@ -18,6 +18,8 @@ export const ERROR_MESSAGE = {
     length: '6~30자 이내로 입력해주세요.',
     pattern: '영어, 숫자, 특수문자 중 최소 2가지를 조합해주세요.',
     invalidPattern: '사용할 수 없는 문자입니다.',
+    failed:
+      '아이디 또는 비밀번호가 잘못 되었습니다. 아이디와 비밀번호를 정확히 입력해주세요.',
   },
   passwordCheck: {
     required: '비밀번호를 확인해주세요.',

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -1,5 +1,5 @@
-import axios from 'axios';
-import { getSession } from 'next-auth/react';
+import axios, { isAxiosError } from 'axios';
+import { getSession, signOut } from 'next-auth/react';
 import type { AxiosRequestConfig } from 'axios';
 
 const options: AxiosRequestConfig = {
@@ -23,6 +23,21 @@ client.interceptors.request.use(
     return config;
   },
   async (error) => await Promise.reject(error),
+);
+
+client.interceptors.response.use(
+  (response) => {
+    return response;
+  },
+  (error) => {
+    if (isAxiosError(error) && error.response?.status === 401) {
+      alert('세션이 만료되었습니다.\n다시 로그인을 시도해주세요.');
+      void signOut();
+      return;
+    }
+
+    return Promise.reject(error);
+  },
 );
 
 export default client;

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -31,7 +31,7 @@ client.interceptors.response.use(
   },
   (error) => {
     if (isAxiosError(error) && error.response?.status === 401) {
-      alert('세션이 만료되었습니다.\n다시 로그인을 시도해주세요.');
+      alert('접속 시간이 만료되었습니다.\n로그인 후 다시 이용해주세요.');
       void signOut();
       return;
     }

--- a/src/pages/account/login.tsx
+++ b/src/pages/account/login.tsx
@@ -45,7 +45,7 @@ const Login: NextPage = () => {
         });
         setError('password', {
           type: 'exist',
-          message: response?.error,
+          message: ERROR_MESSAGE.password.failed,
         });
       }
       if (response?.ok === true) {


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #275 

<br />

## 🗒 작업 목록

- [x] 401 에러 발생 시 next auth의 SignOut 메소드 호출

<br />

## 🧐 PR Point

- 401 에러 발생 시 Axios의 interceptor를 활용하여 next auth의 signOut 메소드를 호출하였습니다.

<br />

## 💥 Trouble Shooting
- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크

<img width="362" alt="image" src="https://github.com/user-attachments/assets/95f99b4b-7870-4be3-817d-563a98a14345">

<br />

## 📚 참고

- 참고한 내용 또는 링크를 입력해주세요.

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다. 
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
