### PR TITLE
비밀번호 재설정 페이지 진입 시 이미 로그인한 유저는 QueryParam 없어도 진입 가능하도록 처리

### DIFF
--- a/src/api/users.ts
+++ b/src/api/users.ts
@@ -66,14 +66,14 @@ export const passwordResetLink = async ({
 
 export const resetPassword = async ({
   email,
-  tempToken,
+  token,
   password,
 }: PasswordResetRequest) => {
   return await axios.put<SuccessResponse<OnlyMessageResponse>>(
     API_PATH.users.password,
     {
       email,
-      tempToken,
+      token,
       password,
     },
   );

--- a/src/components/account/ResetPasswordForm.tsx
+++ b/src/components/account/ResetPasswordForm.tsx
@@ -31,7 +31,7 @@ export const ResetPasswordForm = ({ email, token }: ResetPasswordFormProps) => {
   const onSubmit: SubmitHandler<PasswordResetForm> = async (data) => {
     try {
       const { password } = data;
-      await api.resetPassword({ email, tempToken: token, password });
+      await api.resetPassword({ email, token, password });
       await router.replace(PAGE_PATH.account.login);
     } catch (error) {
       if (isAxiosError<ErrorResponse>(error)) {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -12,6 +12,9 @@ export async function middleware(request: NextRequest) {
   const isLoggedIn = session != null;
 
   if (isLoggedIn) {
+    // NOTE: 로그인 상태에서 비밀번호 재설정 페이지 접근 가능
+    if (pathname.startsWith(PAGE_PATH.account.resetPassword)) return;
+
     // NOTE: 로그인 상태에서 로그인, 회원가입 페이지 접근 불가
     if (pathname.startsWith(PAGE_PATH.account.index)) {
       return NextResponse.redirect(new URL(PAGE_PATH.main, request.url));

--- a/src/pages/account/reset-password.tsx
+++ b/src/pages/account/reset-password.tsx
@@ -1,13 +1,14 @@
 import styled from '@emotion/styled';
 import type {
-  GetServerSideProps,
   InferGetServerSidePropsType,
+  GetServerSidePropsContext,
   NextPage,
-} from 'next/types';
+} from 'next';
 import * as api from 'api';
 import { ResetPasswordForm } from 'components/account';
 import { Seo } from 'components/common';
 import { SERVER_SIDE_PROPS } from 'constants/server';
+import { getServerSidePropsWithAuth } from 'lib/auth';
 import { getQueryParams } from 'utils';
 
 const ResetPassword: NextPage<
@@ -23,26 +24,34 @@ const ResetPassword: NextPage<
   );
 };
 
-export const getServerSideProps = (async (context) => {
-  const { query } = context;
-  const [email] = getQueryParams(query.email);
-  const [token] = getQueryParams(query.token);
+export const getServerSideProps = getServerSidePropsWithAuth(
+  async (context: GetServerSidePropsContext) => {
+    const { user, query } = context;
 
-  if (!email || !token) {
-    return SERVER_SIDE_PROPS.REDIRECT_LOGIN;
-  }
+    if (user) {
+      const { email, accessToken } = user;
+      return { props: { email, token: accessToken } };
+    }
 
-  try {
-    await api.tempTokenValidation({
-      email,
-      tempToken: token,
-    });
+    const [email] = getQueryParams(query.email);
+    const [token] = getQueryParams(query.token);
 
-    return { props: { email, token } };
-  } catch (error) {
-    return SERVER_SIDE_PROPS.REDIRECT_LOGIN;
-  }
-}) satisfies GetServerSideProps;
+    if (!email || !token) {
+      return SERVER_SIDE_PROPS.REDIRECT_LOGIN;
+    }
+
+    try {
+      await api.tempTokenValidation({
+        email,
+        tempToken: token,
+      });
+
+      return { props: { email, token } };
+    } catch (error) {
+      return SERVER_SIDE_PROPS.REDIRECT_LOGIN;
+    }
+  },
+);
 
 export default ResetPassword;
 

--- a/src/types/password.ts
+++ b/src/types/password.ts
@@ -8,7 +8,7 @@ export interface PasswordResetLinkRequest {
 
 export interface PasswordResetRequest {
   email: string;
-  tempToken: string;
+  token: string;
   password: string;
 }
 


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #270 

<br />

## 🗒 작업 목록

- [x] session 존재 여부에 따른 페이지 진입 분기 처리
- [x] `/user/password` API param 변경에 따른 대응 ([스웨거](http://3.35.186.27:5000/docs/#/USER/UsersController_passwordReset))

<br />

## 🧐 PR Point
비밀번호 재설정 페이지 진입 시 이미 로그인한 유저는 QueryParam 없어도 진입 가능하도록 합니다.

로그인 여부는 서버 사이드에서 `getServerSession()`을 통해 `session`을 확인하고 `user` 항목이 존재하면 로그인한 유저로 판단합니다. 해당 기능을 위해 `getServerSideProps`를 `getServerSidePropsWithAuth()` 함수를 사용하는 방식으로 변경 하였습니다.

로그인한 사용자는 `/account` 경로가 포함된 페이지에 접근할 수 없도록 미들웨어에서 처리하고 있지만, 비밀번호 재설정 페이지(`/account/reset-password`)는 예외적으로 접근할 수 있도록 허용했습니다.

---
(++)
`/user/password` API param 이 변경되어 함께 param을 변경하였습니다. API param 변경에 대한 히스토리는 [디스코드 대화](https://discord.com/channels/1033653057877180426/1054007900042965032/1280179714228621312)를 확인해주세요!
<br />

## 💥 Trouble Shooting
- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크
<img src="https://github.com/user-attachments/assets/bcbe9e16-1ca4-411d-b450-1cce9af4eda7" width="350" />

<br />

## 📚 참고

- 참고한 내용 또는 링크를 입력해주세요.

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다. 
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
