### PR TITLE
약관 동의, 개인 정보 처리 방침 상세 페이지 개발

### DIFF
--- a/src/assets/icons/arrow-right.svg
+++ b/src/assets/icons/arrow-right.svg
@@ -1,0 +1,3 @@
+<svg width="8" height="14" viewBox="0 0 8 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1 1L7 7L1 13" stroke="#DDDDDD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/assets/icons/index.ts
+++ b/src/assets/icons/index.ts
@@ -1,5 +1,6 @@
 import ArrowDownIcon from './arrow-down.svg';
-import ArrowRightIcon from './arrow-right-circle.svg';
+import ArrowCircleRightIcon from './arrow-right-circle.svg';
+import ArrowRightIcon from './arrow-right.svg';
 import BackIcon from './back.svg';
 import BadIcon from './bad.svg';
 import BlockIcon from './block.svg';
@@ -50,8 +51,9 @@ import WriteCommentIcon from './write_comment.svg';
 import WriteDiaryIcon from './write_diary.svg';
 
 export {
-  ArrowRightIcon,
+  ArrowCircleRightIcon,
   ArrowDownIcon,
+  ArrowRightIcon,
   BackIcon,
   BookmarkOffIcon,
   BookmarkOnIcon,

--- a/src/components/account/RegisterTerms.tsx
+++ b/src/components/account/RegisterTerms.tsx
@@ -11,31 +11,22 @@ interface TermsAgreementState {
   all: boolean;
   service: boolean;
   privacy: boolean;
-  marketing: boolean;
 }
 
-type TermsAgreementField =
-  | 'termsAgreement.service'
-  | 'termsAgreement.privacy'
-  | 'termsAgreement.marketing';
+type TermsAgreementField = 'termsAgreement.service' | 'termsAgreement.privacy';
 
 export const RegisterTerms = () => {
   const { termsAgreementsData } = useTermsAgreements();
   const { register, setValue } = useFormContext<RegisterForm>();
 
   const [agreedToTerms, setAgreedToTerms] = useState<TermsAgreementState>({
-    all: true,
-    service: true,
-    privacy: true,
-    marketing: true,
+    all: false,
+    service: false,
+    privacy: false,
   });
 
   useEffect(() => {
-    if (
-      agreedToTerms.service &&
-      agreedToTerms.privacy &&
-      agreedToTerms.marketing
-    ) {
+    if (agreedToTerms.service && agreedToTerms.privacy) {
       setAgreedToTerms((state) => {
         return { ...state, all: true };
       });
@@ -44,7 +35,7 @@ export const RegisterTerms = () => {
         return { ...state, all: false };
       });
     }
-  }, [agreedToTerms.service, agreedToTerms.privacy, agreedToTerms.marketing]);
+  }, [agreedToTerms.service, agreedToTerms.privacy]);
 
   const handleOnToggleCheckbox: ChangeEventHandler = (e) => {
     const { id } = e.target as HTMLInputElement;
@@ -54,14 +45,12 @@ export const RegisterTerms = () => {
           all: false,
           service: false,
           privacy: false,
-          marketing: false,
         });
         setValue(
           'termsAgreement',
           {
             service: false,
             privacy: false,
-            marketing: false,
           },
           { shouldValidate: true },
         );
@@ -70,14 +59,12 @@ export const RegisterTerms = () => {
           all: true,
           service: true,
           privacy: true,
-          marketing: true,
         });
         setValue(
           'termsAgreement',
           {
             service: true,
             privacy: true,
-            marketing: true,
           },
           { shouldValidate: true },
         );
@@ -91,11 +78,6 @@ export const RegisterTerms = () => {
     if (id === 'privacy') {
       setAgreedToTerms((state) => {
         return { ...state, privacy: !state.privacy };
-      });
-    }
-    if (id === 'marketing') {
-      setAgreedToTerms((state) => {
-        return { ...state, marketing: !state.marketing };
       });
     }
   };

--- a/src/components/account/RegisterTerms.tsx
+++ b/src/components/account/RegisterTerms.tsx
@@ -1,9 +1,11 @@
 import styled from '@emotion/styled';
 import { useEffect, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
+import { TermsDetail } from './TermsDetail';
 import type { ChangeEventHandler } from 'react';
 import type { RegisterForm } from 'types/register';
-import { CheckedOffIcon, CheckedOnIcon } from 'assets/icons';
+import type { TermsAgreementId } from 'types/termsAgreement';
+import { ArrowRightIcon, CheckedOffIcon, CheckedOnIcon } from 'assets/icons';
 import { useTermsAgreements } from 'hooks/services';
 import { FadeInAnimationStyle } from 'styles';
 
@@ -18,6 +20,8 @@ type TermsAgreementField = 'termsAgreement.service' | 'termsAgreement.privacy';
 export const RegisterTerms = () => {
   const { termsAgreementsData } = useTermsAgreements();
   const { register, setValue } = useFormContext<RegisterForm>();
+
+  const [targetTerms, setTargetTerms] = useState<TermsAgreementId | null>(null);
 
   const [agreedToTerms, setAgreedToTerms] = useState<TermsAgreementState>({
     all: false,
@@ -82,6 +86,10 @@ export const RegisterTerms = () => {
     }
   };
 
+  const onCloseTermsDetail = () => {
+    setTargetTerms(null);
+  };
+
   return (
     <Section>
       <Title>약관에 동의해주세요.</Title>
@@ -97,10 +105,10 @@ export const RegisterTerms = () => {
       </CheckboxLabel>
       <CheckboxList>
         {termsAgreementsData?.map((term) => {
-          const { id, title, isRequired } = term;
+          const { id, title, contents, isRequired } = term;
           const fieldName = `termsAgreement.${id}` as TermsAgreementField;
           return (
-            <li key={`terms-and-conditions-${id}`}>
+            <ListItem key={`terms-and-conditions-${id}`}>
               <CheckboxInput
                 id={id}
                 type="checkbox"
@@ -112,10 +120,24 @@ export const RegisterTerms = () => {
               />
               <CheckboxLabel htmlFor={id}>
                 {agreedToTerms[id] ? <CheckedOnIcon /> : <CheckedOffIcon />}
-                {title}
+                {title} {isRequired && '(필수)'}
               </CheckboxLabel>
-              {/* TODO: 각 이용 약관 모달 형식으로 보여주기 */}
-            </li>
+              <IconButton
+                type="button"
+                onClick={() => {
+                  setTargetTerms(id);
+                }}
+              >
+                <ArrowRightIcon />
+              </IconButton>
+              {targetTerms === id && (
+                <TermsDetail
+                  title={title}
+                  contents={contents}
+                  onClose={onCloseTermsDetail}
+                />
+              )}
+            </ListItem>
           );
         })}
       </CheckboxList>
@@ -130,6 +152,19 @@ const Section = styled.section`
 const Title = styled.h1`
   margin-bottom: 36px;
   ${({ theme }) => theme.fonts.headline_01}
+`;
+
+const ListItem = styled.li`
+  display: flex;
+  justify-content: space-between;
+`;
+
+const IconButton = styled.button`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 20px;
+  height: 20px;
 `;
 
 const CheckboxList = styled.ul`

--- a/src/components/account/TermsDetail.tsx
+++ b/src/components/account/TermsDetail.tsx
@@ -1,0 +1,50 @@
+import styled from '@emotion/styled';
+
+import type { TermsContent } from 'types/termsAgreement';
+import { FullScreenModal } from 'components/common';
+
+interface TermsDetailProps {
+  title: string;
+  contents: TermsContent[];
+  onClose: () => void;
+}
+
+export const TermsDetail = ({ title, contents, onClose }: TermsDetailProps) => {
+  return (
+    <FullScreenModal onClose={onClose}>
+      <Title>{title}</Title>
+      <Article>
+        <ul>
+          {contents.map(({ subTitle, content }) => {
+            return (
+              <li key={subTitle}>
+                <SubTitle>{subTitle}</SubTitle>
+                <Content>{content}</Content>
+              </li>
+            );
+          })}
+        </ul>
+      </Article>
+    </FullScreenModal>
+  );
+};
+
+const Title = styled.h1`
+  ${({ theme }) => theme.fonts.headline_01}
+  margin-bottom: 24px;
+`;
+
+const Article = styled.article`
+  overflow: auto;
+`;
+
+const SubTitle = styled.strong`
+  ${({ theme }) => theme.fonts.headline_04};
+  display: inline-block;
+  margin-bottom: 8px;
+`;
+
+const Content = styled.p`
+  ${({ theme }) => theme.fonts.body_06};
+  margin-bottom: 16px;
+`;

--- a/src/components/common/FullScreenModal.tsx
+++ b/src/components/common/FullScreenModal.tsx
@@ -1,0 +1,47 @@
+import styled from '@emotion/styled';
+import { useEffect, useState, type ReactNode } from 'react';
+import { createPortal } from 'react-dom';
+import { Header, HeaderLeft } from 'components/layouts';
+import { FadeInAnimationStyle } from 'styles';
+
+interface FullScreenModalProps {
+  children: ReactNode;
+  onClose: () => void;
+}
+
+export const FullScreenModal = ({
+  children,
+  onClose,
+}: FullScreenModalProps) => {
+  const [modalElement, setModalElement] = useState<HTMLElement | null>(null);
+
+  useEffect(() => {
+    const modalRoot = document.getElementById('modal-root');
+
+    setModalElement(modalRoot);
+  }, []);
+
+  if (modalElement === null) return null;
+
+  return createPortal(
+    <ModalLayout>
+      <Header left={<HeaderLeft type="이전" onClick={onClose} />} />
+      <Container>{children}</Container>
+    </ModalLayout>,
+    modalElement,
+  );
+};
+
+const ModalLayout = styled.div`
+  ${FadeInAnimationStyle}
+  background-color: ${({ theme }) => theme.colors.white};
+  position: fixed;
+  inset: 0;
+  z-index: 110;
+  overflow: auto;
+`;
+
+const Container = styled.div`
+  margin-top: 54px;
+  padding: 28px 20px;
+`;

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -11,3 +11,4 @@ export * from './Seo';
 export * from './Loading';
 export * from './ObserverTarget';
 export * from './Popover';
+export * from './FullScreenModal';

--- a/src/components/layouts/header/HeaderLeft.tsx
+++ b/src/components/layouts/header/HeaderLeft.tsx
@@ -34,7 +34,7 @@ export const HeaderLeft = ({ type, onClick }: HeaderLeftProps) => {
         <Button
           type="button"
           onClick={() => {
-            router.back();
+            onClick ? onClick() : router.back();
           }}
         >
           <BackIcon />

--- a/src/components/profile/ProfileContainer.tsx
+++ b/src/components/profile/ProfileContainer.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 import Image from 'next/image';
 import Link from 'next/link';
 import { NoLinkProfileImage } from './ProfileImage';
-import { ArrowRightIcon, SettingIcon } from 'assets/icons';
+import { ArrowCircleRightIcon, SettingIcon } from 'assets/icons';
 import { FullPageLoading } from 'components/common';
 import { PAGE_PATH } from 'constants/common';
 import { useBadges, useProfile } from 'hooks/services';
@@ -51,7 +51,7 @@ export const ProfileContainer = ({
           );
         })}
         <BadgeLink href={PAGE_PATH.profile.badges(username)}>
-          <ArrowRightIcon />
+          <ArrowCircleRightIcon />
         </BadgeLink>
       </BadgesContainer>
       {isMyProfile && (

--- a/src/types/termsAgreement.ts
+++ b/src/types/termsAgreement.ts
@@ -1,4 +1,4 @@
-export type TermsAgreementId = 'service' | 'privacy' | 'marketing';
+export type TermsAgreementId = 'service' | 'privacy';
 
 export interface TermsAgreement {
   id: TermsAgreementId;

--- a/src/types/termsAgreement.ts
+++ b/src/types/termsAgreement.ts
@@ -1,8 +1,13 @@
 export type TermsAgreementId = 'service' | 'privacy';
 
+export interface TermsContent {
+  subTitle: string;
+  content: string;
+}
+
 export interface TermsAgreement {
   id: TermsAgreementId;
   title: string;
-  content: string;
+  contents: TermsContent[];
   isRequired: boolean;
 }


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #289

<br />

## 🗒 작업 목록

- [x] 약관 동의 기본값 변경 (true -> false)
- [x] 약관 동의 상세 페이지 개발
- [x] 개인 정보 처리 방침 상세 페이지 개발
- [x] 회원가입의 각 약관 버튼 이벤트 설정

<br />

## 🧐 PR Point

1. 기존 각 약관 동의의 기본값은 true였습니다.
    - 약관 동의의 경우 사용자가 해당 내용을 인지하고 동의한다는 의미로 체크한다고 생각합니다. 기본값이 true인 경우 앞에서 설명한 의미가 어색하게 느껴진다고 생각하여 기본값을 변경하였습니다.
2. 약관 동의 상세 페이지을 모달로 구현한 이유는 다음과 같습니다. (FullScreenModal 개발)
    - 회원가입 약관 동의 상세로 페이지가 변경하는 경우 입력한 값들이 휘발되기 때문에, 모달 방식으로 구현하였습니다.
    - 입력값을 보존하기 위해 새로운 브라우저를 띄우는 방법도 있지만 사용성이 떨어진다고 판단하여 해당 방법은 채택하지 않았습니다.
3. 공용 HeaderLeft 컴포넌트의 이전 버튼의 이벤트를 커스텀 할 수 있도록 변경하였습니다.
    - 기존 이전 버튼의 이벤트는 router.back() 함수로 고정되어 있습니다.
    - FullScreenModal의 경우 페이지 이동은 아니지만 Header의 경우 동일한 UI를 가져갑니다.
    - 새롭게 Header 컴포넌트를 개발하는 방식도 있지만, 기존 컴포넌트의 onClick 함수의 Optional인 설정을 활용하여 이전이면서 onClick 이벤트가 있는 경우는 router.back() 함수를 오버로드하도록 변경하였습니다.
4. 약관 동의 조회 API 응답값의 구조가 변경되어 응답 타입을 수정하였습니다.
    - ADD 프로젝트에선 마케팅 관련한 작업을 수행하지 않을 것이므로 marketing 약관동의는 제거하였습니다.

<br />

## 💥 Trouble Shooting
- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸  스크린샷 / 피그마 링크

영상 업로드가 안되어 해당 영역 첨부 못드린 점 양해 부탁드립니다.

<br />

## 📚 참고

- 참고한 내용 또는 링크를 입력해주세요.

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다. 
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
