### PR TITLE
회원가입 페이지 기능 개선

### DIFF
--- a/src/components/account/RegisterInformation.tsx
+++ b/src/components/account/RegisterInformation.tsx
@@ -1,8 +1,19 @@
 import styled from '@emotion/styled';
 import { isAxiosError } from 'axios';
 import { useFormContext } from 'react-hook-form';
-import type { RegisterStep, RegisterForm } from 'types/register';
-import type { ErrorResponse } from 'types/response';
+
+import type { AxiosResponse } from 'axios';
+import type { ChangeEvent } from 'react';
+import type {
+  RegisterStep,
+  RegisterForm,
+  DuplicateCheckField,
+} from 'types/register';
+import type {
+  ErrorResponse,
+  OnlyMessageResponse,
+  SuccessResponse,
+} from 'types/response';
 import * as api from 'api';
 import { FormInput } from 'components/form';
 import {
@@ -10,7 +21,19 @@ import {
   INVALID_VALUE,
   VALID_VALUE,
 } from 'constants/validation';
+import { useDebounce } from 'hooks/common';
 import { errorResponseMessage } from 'utils';
+
+const duplicateCheckMap: Record<
+  DuplicateCheckField,
+  (
+    value: string,
+  ) => Promise<AxiosResponse<SuccessResponse<OnlyMessageResponse>>>
+> = {
+  email: async (value: string) => await api.emailExists({ email: value }),
+  username: async (value: string) =>
+    await api.usernameExists({ username: value }),
+};
 
 interface RegisterProps {
   registerStep: RegisterStep;
@@ -24,39 +47,33 @@ export const RegisterInformation = ({ registerStep }: RegisterProps) => {
     setError,
   } = useFormContext<RegisterForm>();
 
+  const debouncedDuplicateCheck = useDebounce(
+    ({ type, value }: { type: DuplicateCheckField; value: string }) => {
+      const duplicatorChecker = duplicateCheckMap[type]; // email or username exists check function
+
+      duplicatorChecker(value).catch((error) => {
+        if (isAxiosError<ErrorResponse>(error)) {
+          setError(type, {
+            type: 'exist',
+            message: errorResponseMessage(error.response?.data.message),
+          });
+        }
+      });
+    },
+    200,
+  );
+
+  const onChangeEmail = (event: ChangeEvent<HTMLInputElement>) => {
+    debouncedDuplicateCheck({ type: 'email', value: event.target.value });
+  };
+
+  const onChangeUsername = (event: ChangeEvent<HTMLInputElement>) => {
+    debouncedDuplicateCheck({ type: 'username', value: event.target.value });
+  };
+
   const registerStepValues = Object.values(registerStep).filter(
     (value) => value,
   ).length;
-
-  // TODO : lodash 설치 후 username input이 변경될 때 중복확인하는 코드로 수정
-  const handleOnBlurUsername = async () => {
-    try {
-      const { username } = getValues();
-      await api.usernameExists({ username });
-    } catch (error) {
-      if (isAxiosError<ErrorResponse>(error)) {
-        setError('username', {
-          type: 'exist',
-          message: errorResponseMessage(error.response?.data.message),
-        });
-      }
-    }
-  };
-
-  // TODO : lodash 설치 후 email input이 변경될 때 중복확인하는 코드로 수정
-  const handleOnBlurEmail = async () => {
-    try {
-      const { email } = getValues();
-      await api.emailExists({ email });
-    } catch (error) {
-      if (isAxiosError<ErrorResponse>(error)) {
-        setError('email', {
-          type: 'exist',
-          message: errorResponseMessage(error.response?.data.message),
-        });
-      }
-    }
-  };
 
   return (
     <section>
@@ -97,7 +114,7 @@ export const RegisterInformation = ({ registerStep }: RegisterProps) => {
               value: VALID_VALUE.email,
               message: ERROR_MESSAGE.email.pattern,
             },
-            onBlur: handleOnBlurEmail,
+            onChange: onChangeEmail,
           })}
           type="text"
           placeholder="이메일"
@@ -121,10 +138,10 @@ export const RegisterInformation = ({ registerStep }: RegisterProps) => {
                 value: VALID_VALUE.username.pattern,
                 message: ERROR_MESSAGE.username.pattern,
               },
+              onChange: onChangeUsername,
               validate: (value) =>
                 !INVALID_VALUE.username.test(value) ||
                 ERROR_MESSAGE.username.invalidPattern,
-              onBlur: handleOnBlurUsername,
             })}
             type="text"
             placeholder="닉네임"

--- a/src/components/account/RegisterInformation.tsx
+++ b/src/components/account/RegisterInformation.tsx
@@ -1,9 +1,8 @@
 import styled from '@emotion/styled';
-import { isAxiosError } from 'axios';
+import { isAxiosError, type AxiosResponse } from 'axios';
+import { useEffect, type ChangeEvent } from 'react';
 import { useFormContext } from 'react-hook-form';
 
-import type { AxiosResponse } from 'axios';
-import type { ChangeEvent } from 'react';
 import type {
   RegisterStep,
   RegisterForm,
@@ -45,7 +44,21 @@ export const RegisterInformation = ({ registerStep }: RegisterProps) => {
     getValues,
     formState: { errors },
     setError,
+    setFocus,
   } = useFormContext<RegisterForm>();
+
+  useEffect(() => {
+    // NOTE: Step이 낮은 값을 뒤로 배치하여 이미 지난 step에 대해선 find 무시
+    const fields: Array<keyof RegisterForm> = [
+      'passwordCheck',
+      'password',
+      'username',
+      'email',
+    ];
+
+    const focusField = fields.find((field) => registerStep[field]);
+    if (focusField) setFocus(focusField);
+  }, [registerStep]);
 
   const debouncedDuplicateCheck = useDebounce(
     ({ type, value }: { type: DuplicateCheckField; value: string }) => {

--- a/src/components/account/RegisterInformation.tsx
+++ b/src/components/account/RegisterInformation.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
-import { isAxiosError, type AxiosResponse } from 'axios';
-import { useEffect, type ChangeEvent } from 'react';
+import { isAxiosError } from 'axios';
+import { useEffect } from 'react';
 import { useFormContext } from 'react-hook-form';
 
 import type {
@@ -8,11 +8,7 @@ import type {
   RegisterForm,
   DuplicateCheckField,
 } from 'types/register';
-import type {
-  ErrorResponse,
-  OnlyMessageResponse,
-  SuccessResponse,
-} from 'types/response';
+import type { ErrorResponse } from 'types/response';
 import * as api from 'api';
 import { FormInput } from 'components/form';
 import {
@@ -23,22 +19,15 @@ import {
 import { useDebounce } from 'hooks/common';
 import { errorResponseMessage } from 'utils';
 
-const duplicateCheckMap: Record<
-  DuplicateCheckField,
-  (
-    value: string,
-  ) => Promise<AxiosResponse<SuccessResponse<OnlyMessageResponse>>>
-> = {
-  email: async (value: string) => await api.emailExists({ email: value }),
-  username: async (value: string) =>
-    await api.usernameExists({ username: value }),
-};
-
 interface RegisterProps {
   registerStep: RegisterStep;
+  changeIsEmailOrUsernameDuplicated: (value: boolean) => void;
 }
 
-export const RegisterInformation = ({ registerStep }: RegisterProps) => {
+export const RegisterInformation = ({
+  registerStep,
+  changeIsEmailOrUsernameDuplicated,
+}: RegisterProps) => {
   const {
     register,
     getValues,
@@ -60,29 +49,36 @@ export const RegisterInformation = ({ registerStep }: RegisterProps) => {
     if (focusField) setFocus(focusField);
   }, [registerStep]);
 
-  const debouncedDuplicateCheck = useDebounce(
-    ({ type, value }: { type: DuplicateCheckField; value: string }) => {
-      const duplicatorChecker = duplicateCheckMap[type]; // email or username exists check function
-
-      duplicatorChecker(value).catch((error) => {
-        if (isAxiosError<ErrorResponse>(error)) {
-          setError(type, {
-            type: 'exist',
-            message: errorResponseMessage(error.response?.data.message),
-          });
-        }
+  const handleAxiosError = (type: DuplicateCheckField, error: unknown) => {
+    if (isAxiosError<ErrorResponse>(error)) {
+      setError(type, {
+        type: 'exist',
+        message: errorResponseMessage(error.response?.data.message),
       });
-    },
-    200,
-  );
-
-  const onChangeEmail = (event: ChangeEvent<HTMLInputElement>) => {
-    debouncedDuplicateCheck({ type: 'email', value: event.target.value });
+    }
   };
 
-  const onChangeUsername = (event: ChangeEvent<HTMLInputElement>) => {
-    debouncedDuplicateCheck({ type: 'username', value: event.target.value });
-  };
+  const onChangeEmail = useDebounce(async () => {
+    changeIsEmailOrUsernameDuplicated(true);
+
+    try {
+      await api.emailExists({ email: getValues('email') });
+      changeIsEmailOrUsernameDuplicated(false);
+    } catch (error) {
+      handleAxiosError('email', error);
+    }
+  }, 200);
+
+  const onChangeUsername = useDebounce(async () => {
+    changeIsEmailOrUsernameDuplicated(true);
+
+    try {
+      await api.usernameExists({ username: getValues('username') });
+      changeIsEmailOrUsernameDuplicated(false);
+    } catch (error) {
+      handleAxiosError('username', error);
+    }
+  }, 200);
 
   const registerStepValues = Object.values(registerStep).filter(
     (value) => value,

--- a/src/pages/account/register.tsx
+++ b/src/pages/account/register.tsx
@@ -25,6 +25,9 @@ import { useRegisterUser } from 'hooks/services';
 import { errorResponseMessage } from 'utils';
 
 const Register: NextPage = () => {
+  const [isEmailOrUsernameDuplicated, setIsEmailOrUsernameDuplicated] =
+    useState(true);
+
   const methods = useForm<RegisterForm>({
     mode: 'onChange',
     defaultValues: {
@@ -47,6 +50,10 @@ const Register: NextPage = () => {
   });
 
   const { mutate: registerMutate } = useRegisterUser();
+
+  const changeIsEmailOrUsernameDuplicated = (value: boolean) => {
+    setIsEmailOrUsernameDuplicated(value);
+  };
 
   const onSubmit: SubmitHandler<RegisterForm> = (data) => {
     if (registerStep.email)
@@ -113,14 +120,24 @@ const Register: NextPage = () => {
         <FormProvider {...methods}>
           <From onSubmit={handleSubmit(onSubmit)}>
             {!registerStep.imgUrl && !registerStep.termsAgreement && (
-              <RegisterInformation registerStep={registerStep} />
+              <RegisterInformation
+                registerStep={registerStep}
+                changeIsEmailOrUsernameDuplicated={
+                  changeIsEmailOrUsernameDuplicated
+                }
+              />
             )}
             {!registerStep.termsAgreement && registerStep.imgUrl && (
               <RegisterProfileImage />
             )}
             {registerStep.termsAgreement && <RegisterTerms />}
             <ButtonContainer>
-              <Button type="submit" disabled={!isValid} fullWidth text="다음" />
+              <Button
+                type="submit"
+                disabled={isEmailOrUsernameDuplicated || !isValid}
+                fullWidth
+                text="다음"
+              />
             </ButtonContainer>
           </From>
         </FormProvider>

--- a/src/types/register.ts
+++ b/src/types/register.ts
@@ -7,6 +7,8 @@ export type RegisterForm = Omit<RegisterRequest, 'termsAgreementIdList'> & {
   };
 };
 
+export type DuplicateCheckField = 'email' | 'username';
+
 /* Request */
 
 export type ExistsRequest = Record<string, string>;


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #285

<br />

## 🗒 작업 목록

- [x] 이메일, 닉네임 중복 확인 로직 개선
- [x] 새로운 입력칸으로 포커스 처리

<br />

## 🧐 PR Point

- 기존 이메일과 닉네임의 중복 체크는 input의 blur 이벤트 시에만 실행되었습니다.
    - 위와 같이 구현된 경우 blur 이벤트 없이 다음 스텝으로 넘어가는 문제가 발생했습니다.
    - 이를 해결하기 위해 debounce를 적용하고 입력값이 채워지면 중복 체크를 하도록 개선하였습니다.
- 중복 체크 API 요청에 대한 응답을 받기 전 버튼의 disabled가 풀리지 않도록 register 페이지 컴포넌트에서 isEmailOrUsernameDuplicated 상태를 변경하는 함수를 RegisterInformation 컴포넌트로 내려주어 중복 확인이 처리된 경우에만 disabled가 풀리도록 구현하였습니다.
- 스텝 변경 시 해당 입력칸으로 포커스 되도록 처리하였습니다.

<br />

## 💥 Trouble Shooting
- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크

영상이 업로드 되지 않아 추후에 첨부드리겠습니다.

<br />

## 📚 참고

- 참고한 내용 또는 링크를 입력해주세요.

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다. 
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
