### PR TITLE
회원가입 시 프로필 설정 안되는 이슈

### DIFF
--- a/src/components/account/RegisterProfileImage.tsx
+++ b/src/components/account/RegisterProfileImage.tsx
@@ -5,7 +5,9 @@ import { useRef, useState } from 'react';
 import type { MouseEventHandler, ChangeEventHandler } from 'react';
 import type { ErrorResponse } from 'types/response';
 import { ImagePickerIcon } from 'assets/icons';
-import { DEFAULT_PROFILE_IMAGES } from 'constants/profile';
+import { AlertModal } from 'components/common';
+import { ALLOW_IMAGE_TYPES, DEFAULT_PROFILE_IMAGES } from 'constants/profile';
+import { useModal } from 'hooks/common';
 import { useImageUpload } from 'hooks/services';
 import {
   FadeInAnimationStyle,
@@ -21,23 +23,33 @@ export const RegisterProfileImage = () => {
 
   const { mutate: imageUploadMutate } = useImageUpload({ path: 'users' });
 
-  const handleImageFile: ChangeEventHandler<HTMLInputElement> = (e) => {
-    const { files } = e.target;
-    if (files !== null) {
-      const imageFormData = new FormData();
-      imageFormData.append('image', files[0]);
+  const { isVisible, handleModal } = useModal();
 
-      imageUploadMutate(imageFormData, {
-        onSuccess: (imgUrl) => {
-          setPreviewImage(imgUrl);
-        },
-        onError: (error) => {
-          if (isAxiosError<ErrorResponse>(error)) {
-            console.log(error);
-          }
-        },
-      });
+  const handleImageFile: ChangeEventHandler<HTMLInputElement> = (e) => {
+    // NOTE: input의 multiple 속성이 false이므로 files length는 최대 1임을 보장합니다.
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    // NOTE: input의 accept 속성은 개발자 도구에서 제거할 수 있기 때문에, 이중으로 체크합니다.
+    if (!ALLOW_IMAGE_TYPES.includes(file.type)) {
+      handleModal.open();
+      return;
     }
+
+    const imageFormData = new FormData();
+    imageFormData.append('image', file);
+
+    imageUploadMutate(imageFormData, {
+      onSuccess: (imgUrl) => {
+        setPreviewImage(imgUrl);
+        // TODO: react hook form에 등록 -> useEffect로 통합할지 고민
+      },
+      onError: (error) => {
+        if (isAxiosError<ErrorResponse>(error)) {
+          console.log(error);
+        }
+      },
+    });
   };
 
   const handleDefaultProfileImage: MouseEventHandler<HTMLButtonElement> = (
@@ -46,60 +58,69 @@ export const RegisterProfileImage = () => {
     imageRef.current.forEach((element, index) => {
       if (element === e.target) {
         setPreviewImage(DEFAULT_PROFILE_IMAGES[index].url);
+        // TODO: react hook form에 등록 -> useEffect로 통합할지 고민
       }
     });
   };
 
   return (
-    <Section>
-      <TitleContainer>
-        <Title>프로필 사진을 등록해주세요.</Title>
-        <DescriptionText>
-          프로필로 등록할 사진을 앨범에서 가져오시거나, <br /> 기본 프로필
-          이미지에서 선택해주세요.
-        </DescriptionText>
-      </TitleContainer>
-      <PreviewImageContainer>
-        <PreviewImage
-          src={previewImage}
-          alt="프로필"
-          width={160}
-          height={160}
-        />
-      </PreviewImageContainer>
-      <ImageFileContainer>
-        <ImageFileLabel htmlFor="selectImageFile">
-          <ImagePickerIcon />
-        </ImageFileLabel>
-        <ImageFileInput
-          type="file"
-          id="selectImageFile"
-          accept="image/*"
-          onChange={handleImageFile}
-        />
-        <>
-          {DEFAULT_PROFILE_IMAGES.map((image, index) => {
-            const { id, url } = image;
-            return (
-              <ImageButton
-                key={`default-images-${id}`}
-                type="button"
-                onClick={handleDefaultProfileImage}
-                isActive={url === previewImage}
-              >
-                <Image
-                  ref={(element) => (imageRef.current[index] = element)}
-                  src={url}
-                  alt={`기본 프로필 이미지 ${id}`}
-                  width={60}
-                  height={60}
-                />
-              </ImageButton>
-            );
-          })}
-        </>
-      </ImageFileContainer>
-    </Section>
+    <>
+      <Section>
+        <TitleContainer>
+          <Title>프로필 사진을 등록해주세요.</Title>
+          <DescriptionText>
+            프로필로 등록할 사진을 앨범에서 가져오시거나, <br /> 기본 프로필
+            이미지에서 선택해주세요.
+          </DescriptionText>
+        </TitleContainer>
+        <PreviewImageContainer>
+          <PreviewImage
+            src={previewImage}
+            alt="프로필"
+            width={160}
+            height={160}
+          />
+        </PreviewImageContainer>
+        <ImageFileContainer>
+          <ImageFileLabel htmlFor="selectImageFile">
+            <ImagePickerIcon />
+          </ImageFileLabel>
+          <ImageFileInput
+            type="file"
+            id="selectImageFile"
+            accept={ALLOW_IMAGE_TYPES.join(', ')}
+            onChange={handleImageFile}
+          />
+          <>
+            {DEFAULT_PROFILE_IMAGES.map((image, index) => {
+              const { id, url } = image;
+              return (
+                <ImageButton
+                  key={`default-images-${id}`}
+                  type="button"
+                  onClick={handleDefaultProfileImage}
+                  isActive={url === previewImage}
+                >
+                  <Image
+                    ref={(element) => (imageRef.current[index] = element)}
+                    src={url}
+                    alt={`기본 프로필 이미지 ${id}`}
+                    width={60}
+                    height={60}
+                  />
+                </ImageButton>
+              );
+            })}
+          </>
+        </ImageFileContainer>
+      </Section>
+      {/* FIXME: 디자인이 없어 임시로 디자인한 모달입니다. 추후 변경 예정 */}
+      <AlertModal isVisible={isVisible} onClose={handleModal.close}>
+        <ModalContent>
+          <p>SVG 파일은 업로드할 수 없습니다.</p>
+        </ModalContent>
+      </AlertModal>
+    </>
   );
 };
 
@@ -166,4 +187,12 @@ const ImageButton = styled.button<{ isActive: boolean }>`
   border-radius: 50%;
   transition: border 0.2s;
   aspect-ratio: 1;
+`;
+
+const ModalContent = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  padding: 40px 32px 30px;
 `;

--- a/src/components/account/RegisterProfileImage.tsx
+++ b/src/components/account/RegisterProfileImage.tsx
@@ -5,9 +5,8 @@ import { useRef, useState } from 'react';
 import type { MouseEventHandler, ChangeEventHandler } from 'react';
 import type { ErrorResponse } from 'types/response';
 import { ImagePickerIcon } from 'assets/icons';
-import { AlertModal } from 'components/common';
 import { ALLOW_IMAGE_TYPES, DEFAULT_PROFILE_IMAGES } from 'constants/profile';
-import { useModal } from 'hooks/common';
+import { useAlert } from 'hooks/common/useAlert';
 import { useImageUpload } from 'hooks/services';
 import {
   FadeInAnimationStyle,
@@ -21,9 +20,9 @@ export const RegisterProfileImage = () => {
   );
   const imageRef = useRef<Array<HTMLImageElement | null>>([]);
 
-  const { mutate: imageUploadMutate } = useImageUpload({ path: 'users' });
+  const { action: alertAction, Alert } = useAlert();
 
-  const { isVisible, handleModal } = useModal();
+  const { mutate: imageUploadMutate } = useImageUpload({ path: 'users' });
 
   const handleImageFile: ChangeEventHandler<HTMLInputElement> = (e) => {
     // NOTE: input의 multiple 속성이 false이므로 files length는 최대 1임을 보장합니다.
@@ -32,7 +31,7 @@ export const RegisterProfileImage = () => {
 
     // NOTE: input의 accept 속성은 개발자 도구에서 제거할 수 있기 때문에, 이중으로 체크합니다.
     if (!ALLOW_IMAGE_TYPES.includes(file.type)) {
-      handleModal.open();
+      alertAction('SVG 파일은 업로드할 수 없습니다.');
       return;
     }
 
@@ -114,12 +113,7 @@ export const RegisterProfileImage = () => {
           </>
         </ImageFileContainer>
       </Section>
-      {/* FIXME: 디자인이 없어 임시로 디자인한 모달입니다. 추후 변경 예정 */}
-      <AlertModal isVisible={isVisible} onClose={handleModal.close}>
-        <ModalContent>
-          <p>SVG 파일은 업로드할 수 없습니다.</p>
-        </ModalContent>
-      </AlertModal>
+      {Alert}
     </>
   );
 };
@@ -187,12 +181,4 @@ const ImageButton = styled.button<{ isActive: boolean }>`
   border-radius: 50%;
   transition: border 0.2s;
   aspect-ratio: 1;
-`;
-
-const ModalContent = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 6px;
-  padding: 40px 32px 30px;
 `;

--- a/src/components/account/RegisterProfileImage.tsx
+++ b/src/components/account/RegisterProfileImage.tsx
@@ -1,8 +1,10 @@
 import styled from '@emotion/styled';
 import { isAxiosError } from 'axios';
 import Image from 'next/image';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { useFormContext } from 'react-hook-form';
 import type { MouseEventHandler, ChangeEventHandler } from 'react';
+import type { RegisterForm } from 'types/register';
 import type { ErrorResponse } from 'types/response';
 import { ImagePickerIcon } from 'assets/icons';
 import { ALLOW_IMAGE_TYPES, DEFAULT_PROFILE_IMAGES } from 'constants/profile';
@@ -15,6 +17,8 @@ import {
 } from 'styles';
 
 export const RegisterProfileImage = () => {
+  const { setValue } = useFormContext<RegisterForm>();
+
   const [previewImage, setPreviewImage] = useState<string>(
     DEFAULT_PROFILE_IMAGES[0].url,
   );
@@ -23,6 +27,15 @@ export const RegisterProfileImage = () => {
   const { action: alertAction, Alert } = useAlert();
 
   const { mutate: imageUploadMutate } = useImageUpload({ path: 'users' });
+
+  useEffect(() => {
+    if (previewImage.length === 0) {
+      alertAction('선택된 이미지가 없습니다. 다시 시도해주세요.');
+      return;
+    }
+
+    setValue('imgUrl', previewImage);
+  }, [previewImage]);
 
   const handleImageFile: ChangeEventHandler<HTMLInputElement> = (e) => {
     // NOTE: input의 multiple 속성이 false이므로 files length는 최대 1임을 보장합니다.
@@ -41,7 +54,6 @@ export const RegisterProfileImage = () => {
     imageUploadMutate(imageFormData, {
       onSuccess: (imgUrl) => {
         setPreviewImage(imgUrl);
-        // TODO: react hook form에 등록 -> useEffect로 통합할지 고민
       },
       onError: (error) => {
         if (isAxiosError<ErrorResponse>(error)) {
@@ -57,7 +69,6 @@ export const RegisterProfileImage = () => {
     imageRef.current.forEach((element, index) => {
       if (element === e.target) {
         setPreviewImage(DEFAULT_PROFILE_IMAGES[index].url);
-        // TODO: react hook form에 등록 -> useEffect로 통합할지 고민
       }
     });
   };

--- a/src/components/matching/MatchingController.tsx
+++ b/src/components/matching/MatchingController.tsx
@@ -3,12 +3,13 @@ import { useRouter } from 'next/router';
 import { useEffect, useRef, useState } from 'react';
 import type { MatchingInformation } from 'types/matching';
 import { MicrophoneOnIcon, MicrophoneOffIcon, EndCallIcon } from 'assets/icons';
-import { AlertModal, ConfirmModal, IconButton } from 'components/common';
+import { ConfirmModal, IconButton } from 'components/common';
 import { PAGE_PATH } from 'constants/common';
 import { MODAL_BUTTON, MODAL_MESSAGE } from 'constants/modal';
 import { colors } from 'constants/styles';
 import { useMatching } from 'contexts/MatchingProvider';
 import { useModal } from 'hooks/common';
+import { useAlert } from 'hooks/common/useAlert';
 import { ScreenReaderOnly } from 'styles';
 
 const MatchingController = () => {
@@ -21,8 +22,9 @@ const MatchingController = () => {
 
   const matching = useMatching();
 
-  const { isVisible: isAlertVisible, handleModal: handleAlertModal } =
-    useModal();
+  const { action: alertAction, Alert } = useAlert(() => {
+    void router.replace(PAGE_PATH.main);
+  });
 
   const { isVisible: isConfirmVisible, handleModal: handleConfirmModal } =
     useModal();
@@ -42,7 +44,9 @@ const MatchingController = () => {
       });
     } catch (error) {
       console.log(error);
-      handleAlertModal.open();
+      alertAction(
+        '의도하지 않은 에러가 발생했습니다.\n메인 페이지도 이동합니다.',
+      );
     }
   };
 
@@ -61,11 +65,6 @@ const MatchingController = () => {
   const handleEndMatching = () => {
     matching.disconnect();
     void router.replace(PAGE_PATH.matching.survey);
-  };
-
-  const handleCloseAlert = () => {
-    handleAlertModal.close();
-    void router.replace(PAGE_PATH.main);
   };
 
   const handleToggleMicrophone = () => {
@@ -104,14 +103,7 @@ const MatchingController = () => {
           <label htmlFor="end-call">통화 종료</label>
         </ButtonWrapper>
       </Container>
-      {/* FIXME: 디자인이 없어 임시로 디자인한 모달입니다. 추후 변경 예정 */}
-      <AlertModal isVisible={isAlertVisible} onClose={handleCloseAlert}>
-        <ModalContent>
-          <p>의도하지 않은 에러가 발생했습니다.</p>
-          <p>메인 페이지도 이동합니다.</p>
-        </ModalContent>
-      </AlertModal>
-      {/* FIXME: 디자인이 없어 임시로 디자인한 모달입니다. 추후 변경 예정 */}
+      {Alert}
       <ConfirmModal
         isVisible={isConfirmVisible}
         message={MODAL_MESSAGE.endMatching}
@@ -162,12 +154,4 @@ const Tooltip = styled.div`
     border: 8px solid transparent;
     border-top-color: ${({ theme }) => theme.colors.primary_00};
   }
-`;
-
-const ModalContent = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 6px;
-  padding: 40px 32px 30px;
 `;

--- a/src/constants/profile/images.ts
+++ b/src/constants/profile/images.ts
@@ -12,3 +12,10 @@ export const DEFAULT_PROFILE_IMAGES = [
     url: 'http://add.bucket.s3.amazonaws.com/default/dd_blue.PNG',
   },
 ];
+
+export const ALLOW_IMAGE_TYPES = [
+  'image/png',
+  'image/jpeg',
+  'image/webp',
+  'image/gif',
+];

--- a/src/hooks/common/useAlert.tsx
+++ b/src/hooks/common/useAlert.tsx
@@ -1,0 +1,59 @@
+import styled from '@emotion/styled';
+import { Fragment, useState } from 'react';
+import { useModal } from './useModal';
+import { AlertModal } from 'components/common';
+
+/**
+ * 1. closeCallback 함수로 해당 alert이 닫힐 때 이벤트를 등록할 수 있습니다.
+ * 2. 커스텀훅 실행 후 반환되는 Alert 컴포넌트를 tsx에 넣어줍니다.
+ * 3. action 함수를 실행하여 alert 컴포넌트를 화면에 렌더링합니다.
+ *     - action 함수의 message 인수에 \n 문자열을 기준으로 줄바꿈을 합니다.
+ */
+export const useAlert = (closeCallback?: () => void) => {
+  const { isVisible, handleModal } = useModal();
+  const [messageLines, setMessageLines] = useState<string[]>([]);
+
+  const action = (message: string) => {
+    // NOTE: message에 줄바꿈을 위해 이스케이프 문자를 기준으로 배열로 변경합니다.
+    setMessageLines(message.split('\n'));
+
+    handleModal.open();
+  };
+
+  const handleCloseAlert = () => {
+    handleModal.close();
+    if (closeCallback) closeCallback();
+  };
+
+  const Alert = (
+    <AlertModal isVisible={isVisible} onClose={handleCloseAlert}>
+      <ModalContent>
+        <p>
+          {messageLines.map((message, index) => {
+            const key = `message-${index}`;
+            const isLast = messageLines.length - 1 === index;
+            return (
+              <Fragment key={key}>
+                {message}
+                {!isLast && <br />}
+              </Fragment>
+            );
+          })}
+        </p>
+      </ModalContent>
+    </AlertModal>
+  );
+
+  return {
+    action,
+    Alert,
+  };
+};
+
+const ModalContent = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  padding: 40px 32px 30px;
+`;


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #291

<br />

## 🗒 작업 목록

- [x] 회원가입 프로필 설정 안되는 이슈 해결
- [x] next image 400, 500 에러 처리
- [x] 공용 alert 커스텀훅 개발

<br />

## 🧐 PR Point

- next js의 image에서 svg를 사용하고 싶은 경우 dangerouslyallowsvg 속성 설정을 해야합니다. (아래 [참고 링크](https://nextjs.org/docs/pages/api-reference/components/image#dangerouslyallowsvg) 및 이미지 참고)
<img width="995" alt="스크린샷 2025-02-16 오후 4 12 44" src="https://github.com/user-attachments/assets/24ddff55-c505-4995-9028-087129b560de" />

- dangerouslyallowsvg 속성을 허용하도록 설정을 할 수 있지만, **svg의 경우 script 태그를 삽입할 수 있어 XSS 공격의 위험성**이 있다고 생각하여, i**nput의 accept 속성**에서 **svg를 제외한 이미지 포맷**만 추가할 수 있도록 하였습니다.
    - input의 속성은 html에서 삭제가 가능하기 때문에, **이미지를 설정하는 로직에서도 유효성 처리 로직**을 추가하였습니다.
- 회원가입 시 사용자 설정 프로필 이미지가 적용되지 않는 이슈는 **form에 변경된 프로필 경로를 저장하고 있지 않아 발생했던 이슈**였습니다.
- 텍스트만 다른 alert 컴포넌트를 각 컴포넌트에서 스타일 설정하는 것을 개선하기 위해 **useAlert 컴포넌트를 개발**하였습니다.
    - 커스텀훅의 반환값 중 Alert를 tsx에 추가하고 alert이 화면에 노출 시키고 싶은 경우 action 메소드의 메시지를 넣어 실행합니다.

<br />

## 💥 Trouble Shooting
- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크

- <img width="374" alt="스크린샷 2025-02-16 오후 5 22 38" src="https://github.com/user-attachments/assets/c1fa4cbe-15c0-428c-9695-2098ea88f17a" />


<br />

## 📚 참고

- https://nextjs.org/docs/pages/api-reference/components/image#dangerouslyallowsvg
- https://reactnext-central.xyz/blog/nextjs/image-component#svg-%EC%9D%B4%EB%AF%B8%EC%A7%80-%EC%B2%98%EB%A6%AC%EC%99%80-dangerouslyallowsvg


<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다. 
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
