### PR TITLE
프로필 수정 페이지 이미지 설정되지 않는 이슈

### DIFF
--- a/src/api/profile.ts
+++ b/src/api/profile.ts
@@ -23,9 +23,9 @@ export const getProfileByUsername = async ({
 export const editProfile = async ({ username, imgUrl }: EditProfileRequest) => {
   const {
     data: { data },
-  } = await axios.put<SuccessResponse<Partial<User>>>(
-    `${API_PATH.users.index}`,
-    { username, imgUrl },
-  );
+  } = await axios.put<SuccessResponse<User>>(`${API_PATH.users.index}`, {
+    username,
+    imgUrl,
+  });
   return data;
 };

--- a/src/components/account/RegisterProfileImage.tsx
+++ b/src/components/account/RegisterProfileImage.tsx
@@ -1,8 +1,7 @@
 import styled from '@emotion/styled';
 import Image from 'next/image';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
-import type { MouseEventHandler } from 'react';
 import type { RegisterForm } from 'types/register';
 import { ProfileUpload } from 'components/common';
 import { DEFAULT_PROFILE_IMAGES } from 'constants/profile';
@@ -15,7 +14,6 @@ export const RegisterProfileImage = () => {
   const [previewImage, setPreviewImage] = useState<string>(
     DEFAULT_PROFILE_IMAGES[0].url,
   );
-  const imageRef = useRef<Array<HTMLImageElement | null>>([]);
 
   const { action: alertAction, Alert } = useAlert();
 
@@ -27,16 +25,6 @@ export const RegisterProfileImage = () => {
 
     setValue('imgUrl', previewImage);
   }, [previewImage]);
-
-  const handleDefaultProfileImage: MouseEventHandler<HTMLButtonElement> = (
-    e,
-  ) => {
-    imageRef.current.forEach((element, index) => {
-      if (element === e.target) {
-        setPreviewImage(DEFAULT_PROFILE_IMAGES[index].url);
-      }
-    });
-  };
 
   return (
     <>
@@ -58,17 +46,18 @@ export const RegisterProfileImage = () => {
         </PreviewImageContainer>
         <ImageFileContainer>
           <ProfileUpload onChange={setPreviewImage} />
-          {DEFAULT_PROFILE_IMAGES.map((image, index) => {
+          {DEFAULT_PROFILE_IMAGES.map((image) => {
             const { id, url } = image;
             return (
               <ImageButton
                 key={`default-images-${id}`}
                 type="button"
-                onClick={handleDefaultProfileImage}
+                onClick={() => {
+                  setPreviewImage(image.url);
+                }}
                 isActive={url === previewImage}
               >
                 <Image
-                  ref={(element) => (imageRef.current[index] = element)}
                   src={url}
                   alt={`기본 프로필 이미지 ${id}`}
                   width={60}

--- a/src/components/account/RegisterProfileImage.tsx
+++ b/src/components/account/RegisterProfileImage.tsx
@@ -1,30 +1,19 @@
 import styled from '@emotion/styled';
 import Image from 'next/image';
-import { useEffect, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 import type { RegisterForm } from 'types/register';
 import { ProfileUpload } from 'components/common';
 import { DEFAULT_PROFILE_IMAGES } from 'constants/profile';
-import { useAlert } from 'hooks/common/useAlert';
 import { FadeInAnimationStyle, SVGVerticalAlignStyle } from 'styles';
 
 export const RegisterProfileImage = () => {
-  const { setValue } = useFormContext<RegisterForm>();
+  const { setValue, watch } = useFormContext<RegisterForm>();
 
-  const [previewImage, setPreviewImage] = useState<string>(
-    DEFAULT_PROFILE_IMAGES[0].url,
-  );
+  const previewImage = watch('imgUrl');
 
-  const { action: alertAction, Alert } = useAlert();
-
-  useEffect(() => {
-    if (previewImage.length === 0) {
-      alertAction('선택된 이미지가 없습니다. 다시 시도해주세요.');
-      return;
-    }
-
-    setValue('imgUrl', previewImage);
-  }, [previewImage]);
+  const onChangePreviewImage = (imageUrl: string) => {
+    setValue('imgUrl', imageUrl);
+  };
 
   return (
     <>
@@ -45,7 +34,7 @@ export const RegisterProfileImage = () => {
           />
         </PreviewImageContainer>
         <ImageFileContainer>
-          <ProfileUpload onChange={setPreviewImage} />
+          <ProfileUpload onChange={onChangePreviewImage} />
           {DEFAULT_PROFILE_IMAGES.map((image) => {
             const { id, url } = image;
             return (
@@ -53,7 +42,7 @@ export const RegisterProfileImage = () => {
                 key={`default-images-${id}`}
                 type="button"
                 onClick={() => {
-                  setPreviewImage(image.url);
+                  onChangePreviewImage(image.url);
                 }}
                 isActive={url === previewImage}
               >
@@ -68,7 +57,6 @@ export const RegisterProfileImage = () => {
           })}
         </ImageFileContainer>
       </Section>
-      {Alert}
     </>
   );
 };

--- a/src/components/account/RegisterProfileImage.tsx
+++ b/src/components/account/RegisterProfileImage.tsx
@@ -1,20 +1,13 @@
 import styled from '@emotion/styled';
-import { isAxiosError } from 'axios';
 import Image from 'next/image';
 import { useEffect, useRef, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
-import type { MouseEventHandler, ChangeEventHandler } from 'react';
+import type { MouseEventHandler } from 'react';
 import type { RegisterForm } from 'types/register';
-import type { ErrorResponse } from 'types/response';
-import { ImagePickerIcon } from 'assets/icons';
-import { ALLOW_IMAGE_TYPES, DEFAULT_PROFILE_IMAGES } from 'constants/profile';
+import { ProfileUpload } from 'components/common';
+import { DEFAULT_PROFILE_IMAGES } from 'constants/profile';
 import { useAlert } from 'hooks/common/useAlert';
-import { useImageUpload } from 'hooks/services';
-import {
-  FadeInAnimationStyle,
-  SVGVerticalAlignStyle,
-  ScreenReaderOnly,
-} from 'styles';
+import { FadeInAnimationStyle, SVGVerticalAlignStyle } from 'styles';
 
 export const RegisterProfileImage = () => {
   const { setValue } = useFormContext<RegisterForm>();
@@ -26,8 +19,6 @@ export const RegisterProfileImage = () => {
 
   const { action: alertAction, Alert } = useAlert();
 
-  const { mutate: imageUploadMutate } = useImageUpload({ path: 'users' });
-
   useEffect(() => {
     if (previewImage.length === 0) {
       alertAction('선택된 이미지가 없습니다. 다시 시도해주세요.');
@@ -36,32 +27,6 @@ export const RegisterProfileImage = () => {
 
     setValue('imgUrl', previewImage);
   }, [previewImage]);
-
-  const handleImageFile: ChangeEventHandler<HTMLInputElement> = (e) => {
-    // NOTE: input의 multiple 속성이 false이므로 files length는 최대 1임을 보장합니다.
-    const file = e.target.files?.[0];
-    if (!file) return;
-
-    // NOTE: input의 accept 속성은 개발자 도구에서 제거할 수 있기 때문에, 이중으로 체크합니다.
-    if (!ALLOW_IMAGE_TYPES.includes(file.type)) {
-      alertAction('SVG 파일은 업로드할 수 없습니다.');
-      return;
-    }
-
-    const imageFormData = new FormData();
-    imageFormData.append('image', file);
-
-    imageUploadMutate(imageFormData, {
-      onSuccess: (imgUrl) => {
-        setPreviewImage(imgUrl);
-      },
-      onError: (error) => {
-        if (isAxiosError<ErrorResponse>(error)) {
-          console.log(error);
-        }
-      },
-    });
-  };
 
   const handleDefaultProfileImage: MouseEventHandler<HTMLButtonElement> = (
     e,
@@ -92,36 +57,26 @@ export const RegisterProfileImage = () => {
           />
         </PreviewImageContainer>
         <ImageFileContainer>
-          <ImageFileLabel htmlFor="selectImageFile">
-            <ImagePickerIcon />
-          </ImageFileLabel>
-          <ImageFileInput
-            type="file"
-            id="selectImageFile"
-            accept={ALLOW_IMAGE_TYPES.join(', ')}
-            onChange={handleImageFile}
-          />
-          <>
-            {DEFAULT_PROFILE_IMAGES.map((image, index) => {
-              const { id, url } = image;
-              return (
-                <ImageButton
-                  key={`default-images-${id}`}
-                  type="button"
-                  onClick={handleDefaultProfileImage}
-                  isActive={url === previewImage}
-                >
-                  <Image
-                    ref={(element) => (imageRef.current[index] = element)}
-                    src={url}
-                    alt={`기본 프로필 이미지 ${id}`}
-                    width={60}
-                    height={60}
-                  />
-                </ImageButton>
-              );
-            })}
-          </>
+          <ProfileUpload onChange={setPreviewImage} />
+          {DEFAULT_PROFILE_IMAGES.map((image, index) => {
+            const { id, url } = image;
+            return (
+              <ImageButton
+                key={`default-images-${id}`}
+                type="button"
+                onClick={handleDefaultProfileImage}
+                isActive={url === previewImage}
+              >
+                <Image
+                  ref={(element) => (imageRef.current[index] = element)}
+                  src={url}
+                  alt={`기본 프로필 이미지 ${id}`}
+                  width={60}
+                  height={60}
+                />
+              </ImageButton>
+            );
+          })}
         </ImageFileContainer>
       </Section>
       {Alert}
@@ -165,21 +120,6 @@ const ImageFileContainer = styled.div`
   align-items: center;
   width: fit-content;
   margin: 32px auto;
-`;
-
-const ImageFileLabel = styled.label`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 60px;
-  border-radius: 50%;
-  background-color: ${({ theme }) => theme.colors.bg_02};
-  aspect-ratio: 1;
-  cursor: pointer;
-`;
-
-const ImageFileInput = styled.input`
-  ${ScreenReaderOnly}
 `;
 
 const ImageButton = styled.button<{ isActive: boolean }>`

--- a/src/components/common/ProfileUpload.tsx
+++ b/src/components/common/ProfileUpload.tsx
@@ -18,7 +18,7 @@ export const ProfileUpload = ({ onChange }: ProfileUploadProps) => {
   const { mutate: imageUploadMutate } = useImageUpload({ path: 'users' });
 
   const handleImageFile: ChangeEventHandler<HTMLInputElement> = (e) => {
-    // NOTE: input의 multiple 속성이 없으로 files length는 최대 1임을 보장합니다.
+    // NOTE: input의 multiple 속성이 없으므로 files length는 최대 1임을 보장합니다.
     const file = e.target.files?.[0];
     if (!file) return;
 

--- a/src/components/common/ProfileUpload.tsx
+++ b/src/components/common/ProfileUpload.tsx
@@ -1,0 +1,75 @@
+import styled from '@emotion/styled';
+import { isAxiosError } from 'axios';
+import type { ChangeEventHandler } from 'react';
+import type { ErrorResponse } from 'types/response';
+import { ImagePickerIcon } from 'assets/icons';
+import { ALLOW_IMAGE_TYPES } from 'constants/profile';
+import { useAlert } from 'hooks/common/useAlert';
+import { useImageUpload } from 'hooks/services';
+import { ScreenReaderOnly } from 'styles';
+
+interface ProfileUploadProps {
+  onChange: (value: string) => void;
+}
+
+export const ProfileUpload = ({ onChange }: ProfileUploadProps) => {
+  const { action: alertAction, Alert } = useAlert();
+
+  const { mutate: imageUploadMutate } = useImageUpload({ path: 'users' });
+
+  const handleImageFile: ChangeEventHandler<HTMLInputElement> = (e) => {
+    // NOTE: input의 multiple 속성이 없으로 files length는 최대 1임을 보장합니다.
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    // NOTE: input의 accept 속성은 개발자 도구에서 제거할 수 있기 때문에, 이중으로 체크합니다.
+    if (!ALLOW_IMAGE_TYPES.includes(file.type)) {
+      alertAction('SVG 파일은 업로드할 수 없습니다.');
+      return;
+    }
+
+    const imageFormData = new FormData();
+    imageFormData.append('image', file);
+
+    imageUploadMutate(imageFormData, {
+      onSuccess: (imgUrl) => {
+        onChange(imgUrl);
+      },
+      onError: (error) => {
+        if (isAxiosError<ErrorResponse>(error)) {
+          console.log(error);
+        }
+      },
+    });
+  };
+
+  return (
+    <>
+      <ImageFileLabel htmlFor="selectImageFile">
+        <ImagePickerIcon />
+      </ImageFileLabel>
+      <ImageFileInput
+        type="file"
+        id="selectImageFile"
+        accept={ALLOW_IMAGE_TYPES.join(', ')}
+        onChange={handleImageFile}
+      />
+      {Alert}
+    </>
+  );
+};
+
+const ImageFileLabel = styled.label`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 60px;
+  border-radius: 50%;
+  background-color: ${({ theme }) => theme.colors.bg_02};
+  aspect-ratio: 1;
+  cursor: pointer;
+`;
+
+const ImageFileInput = styled.input`
+  ${ScreenReaderOnly}
+`;

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -1,3 +1,4 @@
+export * from './ProfileUpload';
 export * from './AlertModal';
 export * from './Button';
 export * from './ColorChip';

--- a/src/components/profile/SelectProfileImage.tsx
+++ b/src/components/profile/SelectProfileImage.tsx
@@ -1,11 +1,6 @@
 import styled from '@emotion/styled';
 import Image from 'next/image';
-import {
-  useRef,
-  type Dispatch,
-  type MouseEventHandler,
-  type SetStateAction,
-} from 'react';
+import { type Dispatch, type SetStateAction } from 'react';
 import { ProfileUpload } from 'components/common';
 import { DEFAULT_PROFILE_IMAGES } from 'constants/profile';
 import { SVGVerticalAlignStyle } from 'styles';
@@ -19,32 +14,21 @@ export const SelectProfileImage = ({
   previewImage,
   setPreviewImage,
 }: SelectProfileImageProps) => {
-  const imageRef = useRef<Array<HTMLImageElement | null>>([]);
-
-  const handleDefaultProfileImage: MouseEventHandler<HTMLButtonElement> = (
-    e,
-  ) => {
-    imageRef.current.forEach((element, index) => {
-      if (element === e.target) {
-        setPreviewImage(DEFAULT_PROFILE_IMAGES[index].url);
-      }
-    });
-  };
-
   return (
     <ImageFileContainer>
       <ProfileUpload onChange={setPreviewImage} />
-      {DEFAULT_PROFILE_IMAGES.map((image, index) => {
+      {DEFAULT_PROFILE_IMAGES.map((image) => {
         const { id, url } = image;
         return (
           <ImageButton
             key={`default-images-${id}`}
             type="button"
-            onClick={handleDefaultProfileImage}
+            onClick={() => {
+              setPreviewImage(image.url);
+            }}
             isActive={url === previewImage}
           >
             <Image
-              ref={(element) => (imageRef.current[index] = element)}
               src={url}
               alt={`기본 프로필 이미지 ${id}`}
               width={60}

--- a/src/components/profile/SelectProfileImage.tsx
+++ b/src/components/profile/SelectProfileImage.tsx
@@ -1,18 +1,14 @@
 import styled from '@emotion/styled';
-import { isAxiosError } from 'axios';
 import Image from 'next/image';
 import {
   useRef,
-  type ChangeEventHandler,
   type Dispatch,
   type MouseEventHandler,
   type SetStateAction,
 } from 'react';
-import type { ErrorResponse } from 'types/response';
-import { ImagePickerIcon } from 'assets/icons';
+import { ProfileUpload } from 'components/common';
 import { DEFAULT_PROFILE_IMAGES } from 'constants/profile';
-import { useImageUpload } from 'hooks/services';
-import { ScreenReaderOnly, SVGVerticalAlignStyle } from 'styles';
+import { SVGVerticalAlignStyle } from 'styles';
 
 interface SelectProfileImageProps {
   previewImage: string;
@@ -24,26 +20,6 @@ export const SelectProfileImage = ({
   setPreviewImage,
 }: SelectProfileImageProps) => {
   const imageRef = useRef<Array<HTMLImageElement | null>>([]);
-  const { mutate: imageUploadMutate } = useImageUpload({ path: 'users' });
-
-  const handleImageFile: ChangeEventHandler<HTMLInputElement> = (e) => {
-    const { files } = e.target;
-    if (files !== null) {
-      const imageFormData = new FormData();
-      imageFormData.append('image', files[0]);
-
-      imageUploadMutate(imageFormData, {
-        onSuccess: (imgUrl) => {
-          setPreviewImage(imgUrl);
-        },
-        onError: (error) => {
-          if (isAxiosError<ErrorResponse>(error)) {
-            console.log(error);
-          }
-        },
-      });
-    }
-  };
 
   const handleDefaultProfileImage: MouseEventHandler<HTMLButtonElement> = (
     e,
@@ -57,36 +33,26 @@ export const SelectProfileImage = ({
 
   return (
     <ImageFileContainer>
-      <ImageFileLabel htmlFor="selectImageFile">
-        <ImagePickerIcon />
-      </ImageFileLabel>
-      <ImageFileInput
-        type="file"
-        id="selectImageFile"
-        accept="image/*"
-        onChange={handleImageFile}
-      />
-      <>
-        {DEFAULT_PROFILE_IMAGES.map((image, index) => {
-          const { id, url } = image;
-          return (
-            <ImageButton
-              key={`default-images-${id}`}
-              type="button"
-              onClick={handleDefaultProfileImage}
-              isActive={url === previewImage}
-            >
-              <Image
-                ref={(element) => (imageRef.current[index] = element)}
-                src={url}
-                alt={`기본 프로필 이미지 ${id}`}
-                width={60}
-                height={60}
-              />
-            </ImageButton>
-          );
-        })}
-      </>
+      <ProfileUpload onChange={setPreviewImage} />
+      {DEFAULT_PROFILE_IMAGES.map((image, index) => {
+        const { id, url } = image;
+        return (
+          <ImageButton
+            key={`default-images-${id}`}
+            type="button"
+            onClick={handleDefaultProfileImage}
+            isActive={url === previewImage}
+          >
+            <Image
+              ref={(element) => (imageRef.current[index] = element)}
+              src={url}
+              alt={`기본 프로필 이미지 ${id}`}
+              width={60}
+              height={60}
+            />
+          </ImageButton>
+        );
+      })}
     </ImageFileContainer>
   );
 };
@@ -97,21 +63,6 @@ const ImageFileContainer = styled.div`
   align-items: center;
   width: fit-content;
   margin: 12px auto 36px;
-`;
-
-const ImageFileLabel = styled.label`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 60px;
-  border-radius: 50%;
-  background-color: ${({ theme }) => theme.colors.bg_02};
-  aspect-ratio: 1;
-  cursor: pointer;
-`;
-
-const ImageFileInput = styled.input`
-  ${ScreenReaderOnly}
 `;
 
 const ImageButton = styled.button<{ isActive: boolean }>`

--- a/src/components/profile/SelectProfileImage.tsx
+++ b/src/components/profile/SelectProfileImage.tsx
@@ -1,22 +1,21 @@
 import styled from '@emotion/styled';
 import Image from 'next/image';
-import { type Dispatch, type SetStateAction } from 'react';
 import { ProfileUpload } from 'components/common';
 import { DEFAULT_PROFILE_IMAGES } from 'constants/profile';
 import { SVGVerticalAlignStyle } from 'styles';
 
 interface SelectProfileImageProps {
   previewImage: string;
-  setPreviewImage: Dispatch<SetStateAction<string>>;
+  onChangePreviewImage: (imageUrl: string) => void;
 }
 
 export const SelectProfileImage = ({
   previewImage,
-  setPreviewImage,
+  onChangePreviewImage,
 }: SelectProfileImageProps) => {
   return (
     <ImageFileContainer>
-      <ProfileUpload onChange={setPreviewImage} />
+      <ProfileUpload onChange={onChangePreviewImage} />
       {DEFAULT_PROFILE_IMAGES.map((image) => {
         const { id, url } = image;
         return (
@@ -24,7 +23,7 @@ export const SelectProfileImage = ({
             key={`default-images-${id}`}
             type="button"
             onClick={() => {
-              setPreviewImage(image.url);
+              onChangePreviewImage(image.url);
             }}
             isActive={url === previewImage}
           >

--- a/src/hooks/services/mutations/useEditProfile.ts
+++ b/src/hooks/services/mutations/useEditProfile.ts
@@ -3,7 +3,7 @@ import type { EditProfileRequest } from 'types/profile';
 import * as api from 'api';
 import { queryKeys } from 'constants/services';
 
-export const useEditProfile = (username: string) => {
+export const useEditProfile = () => {
   const queryClient = useQueryClient();
 
   return useMutation(
@@ -13,7 +13,7 @@ export const useEditProfile = (username: string) => {
         imgUrl,
       }),
     {
-      onSuccess: async () => {
+      onSuccess: async ({ username }) => {
         await queryClient.invalidateQueries([queryKeys.users, username]);
       },
     },

--- a/src/pages/profile/edit.tsx
+++ b/src/pages/profile/edit.tsx
@@ -4,7 +4,7 @@ import { isAxiosError } from 'axios';
 
 import { useRouter } from 'next/router';
 import { useSession } from 'next-auth/react';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import type { GetServerSidePropsContext, NextPage } from 'next';
 import type { User } from 'next-auth';
@@ -34,7 +34,6 @@ import {
   INVALID_VALUE,
   VALID_VALUE,
 } from 'constants/validation';
-import { useAlert } from 'hooks/common/useAlert';
 import { useEditProfile } from 'hooks/services';
 import { getServerSidePropsWithAuth } from 'lib/auth';
 import { ScreenReaderOnly } from 'styles';
@@ -56,6 +55,7 @@ const ProfileEditPage: NextPage<ProfileEditPageProps> = ({ user }) => {
     formState: { errors, isValid },
     setError,
     handleSubmit,
+    watch,
   } = useForm<EditProfileForm>({
     mode: 'onChange',
     defaultValues: {
@@ -65,22 +65,12 @@ const ProfileEditPage: NextPage<ProfileEditPageProps> = ({ user }) => {
     },
   });
 
-  const { action: alertAction, Alert } = useAlert();
+  const previewImage = watch('imgUrl');
 
   const [successDuplicateCheckUsername, setSuccessDuplicateCheckUsername] =
     useState<SuccessResponse<OnlyMessageResponse> | undefined>(undefined);
-  const [previewImage, setPreviewImage] = useState<string>(imgUrl);
 
   const { mutate: editProfileMutate } = useEditProfile();
-
-  useEffect(() => {
-    if (previewImage.length === 0) {
-      alertAction('선택된 이미지가 없습니다. 다시 시도해주세요.');
-      return;
-    }
-
-    setValue('imgUrl', previewImage);
-  }, [previewImage]);
 
   const handleDuplicateCheckUsername = async () => {
     const { username } = getValues();
@@ -112,6 +102,10 @@ const ProfileEditPage: NextPage<ProfileEditPageProps> = ({ user }) => {
         setSuccessDuplicateCheckUsername(undefined);
       }
     }
+  };
+
+  const onChangePreviewImage = (imagePath: string) => {
+    setValue('imgUrl', imagePath);
   };
 
   const onSubmit: SubmitHandler<EditProfileForm> = (data) => {
@@ -159,7 +153,7 @@ const ProfileEditPage: NextPage<ProfileEditPageProps> = ({ user }) => {
           />
           <SelectProfileImage
             previewImage={previewImage}
-            setPreviewImage={setPreviewImage}
+            onChangePreviewImage={onChangePreviewImage}
           />
           <FormInputContainer>
             <FormInput
@@ -212,7 +206,6 @@ const ProfileEditPage: NextPage<ProfileEditPageProps> = ({ user }) => {
 
         <BadgesContainer />
       </Section>
-      {Alert}
     </>
   );
 };

--- a/src/pages/profile/edit.tsx
+++ b/src/pages/profile/edit.tsx
@@ -4,7 +4,7 @@ import { isAxiosError } from 'axios';
 
 import { useRouter } from 'next/router';
 import { useSession } from 'next-auth/react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import type { GetServerSidePropsContext, NextPage } from 'next';
 import type { User } from 'next-auth';
@@ -34,6 +34,7 @@ import {
   INVALID_VALUE,
   VALID_VALUE,
 } from 'constants/validation';
+import { useAlert } from 'hooks/common/useAlert';
 import { useEditProfile } from 'hooks/services';
 import { getServerSidePropsWithAuth } from 'lib/auth';
 import { ScreenReaderOnly } from 'styles';
@@ -51,6 +52,7 @@ const ProfileEditPage: NextPage<ProfileEditPageProps> = ({ user }) => {
   const {
     register,
     getValues,
+    setValue,
     formState: { errors, isValid },
     setError,
     handleSubmit,
@@ -63,11 +65,22 @@ const ProfileEditPage: NextPage<ProfileEditPageProps> = ({ user }) => {
     },
   });
 
+  const { action: alertAction, Alert } = useAlert();
+
   const [successDuplicateCheckUsername, setSuccessDuplicateCheckUsername] =
     useState<SuccessResponse<OnlyMessageResponse> | undefined>(undefined);
   const [previewImage, setPreviewImage] = useState<string>(imgUrl);
 
-  const { mutate: editProfileMutate } = useEditProfile(username);
+  const { mutate: editProfileMutate } = useEditProfile();
+
+  useEffect(() => {
+    if (previewImage.length === 0) {
+      alertAction('선택된 이미지가 없습니다. 다시 시도해주세요.');
+      return;
+    }
+
+    setValue('imgUrl', previewImage);
+  }, [previewImage]);
 
   const handleDuplicateCheckUsername = async () => {
     const { username } = getValues();
@@ -199,6 +212,7 @@ const ProfileEditPage: NextPage<ProfileEditPageProps> = ({ user }) => {
 
         <BadgesContainer />
       </Section>
+      {Alert}
     </>
   );
 };


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #294

<br />

## 🗒 작업 목록

- [x] 프로필 사진 업로드 공용 컴포넌트 개발 및 적용

<br />

## 🧐 PR Point

- 회원가입과 프로필 수정 페이지에서 사용되는 프로필 사진 업로드 로직을 하나의 공용 컴포넌트(ProfileUpload)로 분리하였습니다.
- 변경한 이미지 경로를 hook form에 추가하는 로직을 추가하였습니다.
- 기본 프로필 이미지를 선택하여 이미지 경로를 저장하는 로직에서 Ref를 제거하였습니다.
    - 기본 프로필 이미지 선택 시 해당 이미지의 경로가 state에 저장되도록 개선하였습니다.
- 프로필 수정 커스텀 훅에서 요청 성공 시 반환되는 데이터의 username을 활용하도록 개선하였습니다.
    - 프로필 수정 API(PUT /users)의 경우 응답값으로 요청한 유저의 최신 값을 반환하고 있는데, 코드 상에 Partial 제네릭 타입으로 묶여 각 값이 undefined 처리가 되고 있었습니다. 이와 같은 이유로 Partial 제네릭 타입 제거해주었습니다.

<br />

## 💥 Trouble Shooting
- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크

https://github.com/user-attachments/assets/a3e8f31a-7726-4e3c-8899-1b18db36d8b6


<br />

## 📚 참고

- 참고한 내용 또는 링크를 입력해주세요.

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다. 
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
