### PR TITLE
프로필 상세 북마크 취소 시 데이터 반영 안되는 이슈

### DIFF
--- a/src/hooks/services/mutations/useBookmarkDiary.ts
+++ b/src/hooks/services/mutations/useBookmarkDiary.ts
@@ -13,7 +13,7 @@ export const useBookmarkDiary = ({ diaryId }: UseBookmarkDiaryProps) => {
     onSuccess: async () => {
       await queryClient.invalidateQueries([queryKeys.diaries]);
       await queryClient.invalidateQueries([queryKeys.diaries, diaryId]);
-      await queryClient.invalidateQueries([queryKeys.bookmark, diaryId]);
+      await queryClient.invalidateQueries([queryKeys.bookmark]);
     },
   });
 };

--- a/src/hooks/services/mutations/useCancelBookmarkDiary.ts
+++ b/src/hooks/services/mutations/useCancelBookmarkDiary.ts
@@ -15,7 +15,7 @@ export const useCancelBookmarkDiary = ({
     onSuccess: async () => {
       await queryClient.invalidateQueries([queryKeys.diaries]);
       await queryClient.invalidateQueries([queryKeys.diaries, diaryId]);
-      await queryClient.invalidateQueries([queryKeys.bookmark, diaryId]);
+      await queryClient.invalidateQueries([queryKeys.bookmark]);
     },
   });
 };

--- a/src/hooks/services/queries/useBookmarkedDiaries.ts
+++ b/src/hooks/services/queries/useBookmarkedDiaries.ts
@@ -12,6 +12,7 @@ export const useBookmarkedDiaries = (username: string) => {
           currentPage: pageParam as number,
         }),
       getNextPageParam: (lastPage) => lastPage.nextPage,
+      cacheTime: 0, // FIXME: 더 좋은 방식에 대한 고민 필요
     });
 
   const isLoading = isFetching && !isFetchingNextPage;


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #298

<br />

## 🗒 작업 목록

- [x] 북마크 등록 및 취소 mutation 함수의 onSuccess 이벤트에 invalid query key 수정

<br />

## 🧐 PR Point

- 북마크 취소 시 프로필 상세에서 데이터가 갱신되는 것은 실시간으로 반영되었지만, 일기 목록에서 새롭게 북마크한 데이터는 바로 적용되지 않는 이슈가 발생하였습니다.
    - 해당 이슈에 대해 임시로 useQuery의 cacheTime을 0으로 지정하여 해결했지만, 더 좋은 방법에 대해 고민이 필요합니다.

<br />

## 💥 Trouble Shooting
- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크

https://github.com/user-attachments/assets/e0885f1d-6139-4940-aa2e-36549d8d7268

<br />

## 📚 참고

- 참고한 내용 또는 링크를 입력해주세요.

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다. 
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
