### PR TITLE
프로필 > 설정 페이지 UI 구현

### DIFF
--- a/src/assets/icons/arrow_right_thin.svg
+++ b/src/assets/icons/arrow_right_thin.svg
@@ -1,0 +1,3 @@
+<svg width="8" height="14" viewBox="0 0 8 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1 1L7 7L1 13" stroke="#222222" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/assets/icons/index.ts
+++ b/src/assets/icons/index.ts
@@ -1,6 +1,7 @@
 import ArrowDownIcon from './arrow-down.svg';
 import ArrowCircleRightIcon from './arrow-right-circle.svg';
 import ArrowRightIcon from './arrow-right.svg';
+import ArrowRightThinIcon from './arrow_right_thin.svg';
 import BackIcon from './back.svg';
 import BadIcon from './bad.svg';
 import BlockIcon from './block.svg';
@@ -54,6 +55,7 @@ export {
   ArrowCircleRightIcon,
   ArrowDownIcon,
   ArrowRightIcon,
+  ArrowRightThinIcon,
   BackIcon,
   BookmarkOffIcon,
   BookmarkOnIcon,

--- a/src/components/common/Toggle.tsx
+++ b/src/components/common/Toggle.tsx
@@ -67,7 +67,7 @@ const ToggleInput = styled.input`
 
   &:disabled {
     pointer-events: none;
-    cursor: default;
+    cursor: not-allowed;
     background-color: ${({ theme }) => theme.colors.gray_05};
   }
 `;

--- a/src/components/common/Toggle.tsx
+++ b/src/components/common/Toggle.tsx
@@ -1,0 +1,73 @@
+import styled from '@emotion/styled';
+import type { ChangeEvent } from 'react';
+
+interface ToggleProps {
+  defaultChecked?: boolean;
+  onChange?: (checked: boolean) => void;
+  disabled?: boolean;
+}
+
+export const Toggle = ({
+  defaultChecked = false,
+  onChange,
+  disabled = false,
+}: ToggleProps) => {
+  const handleToggleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const newCheckedState = event.target.checked;
+    onChange?.(newCheckedState);
+  };
+
+  return (
+    <ToggleWrapper>
+      <ToggleInput
+        type="checkbox"
+        defaultChecked={defaultChecked}
+        onChange={handleToggleChange}
+        disabled={disabled}
+      />
+    </ToggleWrapper>
+  );
+};
+
+const ToggleWrapper = styled.label`
+  display: inline-flex;
+  align-items: center;
+`;
+
+const ToggleInput = styled.input`
+  appearance: none;
+  position: relative;
+  border-radius: 100px;
+  width: 44px;
+  height: 24px;
+  margin: 0;
+  background-color: ${({ theme }) => theme.colors.gray_05};
+  cursor: pointer;
+
+  /* Slider */
+  &::before {
+    content: '';
+    position: absolute;
+    left: 2px;
+    top: 2px;
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    background-color: ${({ theme }) => theme.colors.white};
+    transition: left 250ms linear;
+  }
+
+  &:checked {
+    background-color: ${({ theme }) => theme.colors.primary_00};
+
+    &::before {
+      left: 22px;
+    }
+  }
+
+  &:disabled {
+    pointer-events: none;
+    cursor: default;
+    background-color: ${({ theme }) => theme.colors.gray_05};
+  }
+`;

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -12,3 +12,4 @@ export * from './Loading';
 export * from './ObserverTarget';
 export * from './Popover';
 export * from './FullScreenModal';
+export * from './Toggle';

--- a/src/components/layouts/footer/Footer.tsx
+++ b/src/components/layouts/footer/Footer.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import Link from 'next/link';
+import { FOOTER_HEIGHT } from 'constants/styles';
 
 export const Footer = () => {
   return (
@@ -18,6 +19,7 @@ export const Footer = () => {
 
 const FooterLayout = styled.footer`
   width: 100%;
+  height: ${FOOTER_HEIGHT};
   padding: 16px 20px;
   background-color: ${({ theme }) => theme.colors.bg_02};
   position: fixed;

--- a/src/components/layouts/footer/Footer.tsx
+++ b/src/components/layouts/footer/Footer.tsx
@@ -1,0 +1,48 @@
+import styled from '@emotion/styled';
+import Link from 'next/link';
+
+export const Footer = () => {
+  return (
+    <FooterLayout>
+      <div>
+        {/* @TODO: 링크 연결하기 */}
+        <LegalLink href={'/'}>개인정보처리방침</LegalLink>
+        <LegalLink href={'/'}>이용약관</LegalLink>
+      </div>
+      <p>Copy right 2023. ADD. All rights reserved.</p>
+      {/* @TODO: 이메일주소 변경하기 */}
+      <a href="mailto:addofficial@gmail.com">addofficial@gmail.com</a>
+    </FooterLayout>
+  );
+};
+
+const FooterLayout = styled.footer`
+  width: 100%;
+  padding: 16px 20px;
+  background-color: ${({ theme }) => theme.colors.bg_02};
+  position: fixed;
+  bottom: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+
+  ${({ theme }) => theme.fonts.caption_02};
+  color: ${({ theme }) => theme.colors.gray_03};
+`;
+
+const LegalLink = styled(Link)`
+  ${({ theme }) => theme.fonts.caption_01}
+  color: ${({ theme }) => theme.colors.gray_02};
+
+  /* 새로 구분선 */
+  &:not(:last-of-type) {
+    &::after {
+      content: '';
+      display: inline-block;
+      margin: 0 6px;
+      width: 1px;
+      height: 8px;
+      background-color: ${({ theme }) => theme.colors.gray_05};
+    }
+  }
+`;

--- a/src/components/layouts/footer/index.ts
+++ b/src/components/layouts/footer/index.ts
@@ -1,0 +1,1 @@
+export * from './Footer';

--- a/src/components/layouts/header/Header.tsx
+++ b/src/components/layouts/header/Header.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import type { ReactNode } from 'react';
-import { Z_INDEX } from 'constants/styles';
+import { HEADER_HEIGHT, Z_INDEX } from 'constants/styles';
 
 interface HeaderProps {
   left: ReactNode;
@@ -27,7 +27,7 @@ const HeaderLayout = styled.header`
   right: 0;
   left: 0;
   z-index: ${Z_INDEX.header};
-  height: 54px;
+  height: ${HEADER_HEIGHT};
   padding: 0 20px;
   border-bottom: 1px solid ${({ theme }) => theme.colors.gray_06};
   background: ${({ theme }) => theme.colors.white};

--- a/src/components/setting/SettingMenus.tsx
+++ b/src/components/setting/SettingMenus.tsx
@@ -1,15 +1,13 @@
 import styled from '@emotion/styled';
 import Link from 'next/link';
+import { SettingThemeToggle } from './SettingThemeToggle';
 import { ArrowRightThinIcon } from 'assets/icons';
 import { PAGE_PATH } from 'constants/common';
 
 const SETTING_MENUS = [
   {
     title: '다크모드',
-    /**
-     * @TODO 토글 컴포넌트로 변경
-     */
-    action: <></>,
+    action: <SettingThemeToggle />,
   },
   {
     title: '비밀번호 재설정',

--- a/src/components/setting/SettingMenus.tsx
+++ b/src/components/setting/SettingMenus.tsx
@@ -54,7 +54,7 @@ export const SettingMenus = () => {
 };
 
 const List = styled.ul`
-  margin-top: 54px;
+  margin-top: 12px;
 `;
 
 const ListItem = styled.li`

--- a/src/components/setting/SettingMenus.tsx
+++ b/src/components/setting/SettingMenus.tsx
@@ -1,0 +1,72 @@
+import styled from '@emotion/styled';
+import Link from 'next/link';
+import { ArrowRightThinIcon } from 'assets/icons';
+import { PAGE_PATH } from 'constants/common';
+
+const SETTING_MENUS = [
+  {
+    title: '다크모드',
+    /**
+     * @TODO 토글 컴포넌트로 변경
+     */
+    action: <></>,
+  },
+  {
+    title: '비밀번호 재설정',
+    action: (
+      <Link href={PAGE_PATH.account.resetPassword}>
+        <ArrowRightThinIcon />
+      </Link>
+    ),
+  },
+  /**
+   * @TODO 문의게시판, 로그아웃 링크 연결
+   */
+  {
+    title: '문의게시판',
+    action: (
+      <Link href="/">
+        <ArrowRightThinIcon />
+      </Link>
+    ),
+  },
+  {
+    title: '로그아웃',
+    action: (
+      <Link href="/">
+        <ArrowRightThinIcon />
+      </Link>
+    ),
+  },
+];
+
+export const SettingMenus = () => {
+  return (
+    <List>
+      {SETTING_MENUS.map((menu) => (
+        <ListItem key={menu.title}>
+          <Title>{menu.title}</Title>
+          {menu.action}
+        </ListItem>
+      ))}
+    </List>
+  );
+};
+
+const List = styled.ul`
+  margin-top: 54px;
+`;
+
+const ListItem = styled.li`
+  width: 100%;
+  min-height: 56px;
+  padding: 0 20px;
+
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+const Title = styled.span`
+  ${({ theme }) => theme.fonts.body_05};
+`;

--- a/src/components/setting/SettingThemeToggle.tsx
+++ b/src/components/setting/SettingThemeToggle.tsx
@@ -1,0 +1,11 @@
+import { Toggle } from 'components/common';
+
+export const SettingThemeToggle = () => {
+  const toggleMode = (isDarkMode: boolean) => {
+    /**
+     * @TODO 다크/라이트 모드 테마 적용 로직 추가
+     */
+    console.log(isDarkMode ? '다크모드로 전환' : '라이트모드로 전환');
+  };
+  return <Toggle onChange={toggleMode} />;
+};

--- a/src/components/setting/index.ts
+++ b/src/components/setting/index.ts
@@ -1,1 +1,2 @@
 export * from './SettingMenus';
+export * from './SettingThemeToggle';

--- a/src/components/setting/index.ts
+++ b/src/components/setting/index.ts
@@ -1,0 +1,1 @@
+export * from './SettingMenus';

--- a/src/constants/styles/index.ts
+++ b/src/constants/styles/index.ts
@@ -1,3 +1,4 @@
 export * from './colors';
 export * from './zIndex';
 export * from './heatmap';
+export * from './layout';

--- a/src/constants/styles/layout.ts
+++ b/src/constants/styles/layout.ts
@@ -1,0 +1,2 @@
+export const HEADER_HEIGHT = '54px';
+export const FOOTER_HEIGHT = '84px';

--- a/src/pages/setting/index.tsx
+++ b/src/pages/setting/index.tsx
@@ -1,0 +1,17 @@
+import type { NextPage } from 'next/types';
+import { Seo } from 'components/common';
+import { Header, HeaderLeft, HeaderTitle } from 'components/layouts';
+
+const SettingPage: NextPage = () => {
+  return (
+    <>
+      <Seo title={'설정 | a daily diary'} />
+      <Header
+        left={<HeaderLeft type="이전" />}
+        title={<HeaderTitle title="설정" position="center" />}
+      />
+    </>
+  );
+};
+
+export default SettingPage;

--- a/src/pages/setting/index.tsx
+++ b/src/pages/setting/index.tsx
@@ -4,6 +4,7 @@ import { Seo } from 'components/common';
 import { Header, HeaderLeft, HeaderTitle } from 'components/layouts';
 import { Footer } from 'components/layouts/footer';
 import { SettingMenus } from 'components/setting';
+import { HEADER_HEIGHT, FOOTER_HEIGHT } from 'constants/styles';
 
 const SettingPage: NextPage = () => {
   return (
@@ -15,6 +16,7 @@ const SettingPage: NextPage = () => {
       />
       <Section>
         <SettingMenus />
+        <WithdrawButton>회원탈퇴</WithdrawButton>
       </Section>
       <Footer />
     </>
@@ -24,5 +26,18 @@ const SettingPage: NextPage = () => {
 export default SettingPage;
 
 const Section = styled.section`
-  margin-top: 54px;
+  padding-top: ${HEADER_HEIGHT};
+  padding-bottom: ${FOOTER_HEIGHT};
+  height: 100vh;
+
+  position: relative;
+`;
+
+const WithdrawButton = styled.button`
+  ${({ theme }) => theme.fonts.body_05};
+  color: ${({ theme }) => theme.colors.gray_02};
+  padding: 20px;
+
+  position: absolute;
+  bottom: ${FOOTER_HEIGHT};
 `;

--- a/src/pages/setting/index.tsx
+++ b/src/pages/setting/index.tsx
@@ -1,6 +1,8 @@
+import styled from '@emotion/styled';
 import type { NextPage } from 'next/types';
 import { Seo } from 'components/common';
 import { Header, HeaderLeft, HeaderTitle } from 'components/layouts';
+import { SettingMenus } from 'components/setting';
 
 const SettingPage: NextPage = () => {
   return (
@@ -10,8 +12,15 @@ const SettingPage: NextPage = () => {
         left={<HeaderLeft type="이전" />}
         title={<HeaderTitle title="설정" position="center" />}
       />
+      <Section>
+        <SettingMenus />
+      </Section>
     </>
   );
 };
 
 export default SettingPage;
+
+const Section = styled.section`
+  margin-top: 54px;
+`;

--- a/src/pages/setting/index.tsx
+++ b/src/pages/setting/index.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled';
 import type { NextPage } from 'next/types';
 import { Seo } from 'components/common';
 import { Header, HeaderLeft, HeaderTitle } from 'components/layouts';
+import { Footer } from 'components/layouts/footer';
 import { SettingMenus } from 'components/setting';
 
 const SettingPage: NextPage = () => {
@@ -15,6 +16,7 @@ const SettingPage: NextPage = () => {
       <Section>
         <SettingMenus />
       </Section>
+      <Footer />
     </>
   );
 };


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #269 

<br />

## 🗒 작업 목록

- [x] 설정 목록 UI
- [x] 토글 컴포넌트 구현
- [x] Footer UI (copyright, 개인정보처리방침 등)
- [x] 회원탈퇴 버튼 UI 

<br />

## 🧐 PR Point
setting 페이지를 추가하고 UI 를 완성했습니다. 버튼/링크 클릭 시 기능은 구현되지 않았으며 `@TODO` 로 표시해 두었습니다.
- setting 페이지 하단의 footer 는 components/layouts/footer 에 공통 컴포넌트로 추가하였습니다.
- 스타일 코드에서 매직 넘버를 제거하기 위해 header, footer 의 높이(height) 값을 상수화 하였습니다. 
(ex. `margin-top: 54px` -> `margin-top: {HEADER_HEIGHT}`

### 이어질 작업
- 다크/라이트 모드 토글 시 테마 적용
- 회원탈퇴 기능 구현
- 로그아웃 기능 구현
- 개인정보처리방침, 이용약관 페이지 연결

<br />

## 💥 Trouble Shooting
- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크
세팅 페이지 | 
-- | 
![스크린샷 2025-02-26 오후 11 47 56](https://github.com/user-attachments/assets/bb6d4e82-036f-46b9-9339-a800b5e5ab24)


<br />

## 📚 참고

- 참고한 내용 또는 링크를 입력해주세요.

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다. 
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
